### PR TITLE
Add option to read speed from imported GPX files

### DIFF
--- a/src/Charts/PythonChart.cpp
+++ b/src/Charts/PythonChart.cpp
@@ -438,6 +438,7 @@ PythonChart::setWeb(bool x)
 
         // setup the canvas
         canvas = new QWebEngineView(this);
+        canvas->setUrl(QUrl());
         canvas->setContentsMargins(0,0,0,0);
         canvas->setZoomFactor(dpiXFactor);
         canvas->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));

--- a/src/FileIO/GpxParser.h
+++ b/src/FileIO/GpxParser.h
@@ -29,6 +29,8 @@
 #include <QXmlDefaultHandler>
 #include "Settings.h"
 
+#define GPX_SAMPLE_INTERVAL (1.0)
+
 class GpxParser : public QXmlDefaultHandler
 {
 public:
@@ -53,6 +55,7 @@ private:
     QDateTime   time;
     double      distance;
     double      lastLat, lastLon;
+    double      lastSpeed;
 
     double      alt;
     double      lat;
@@ -61,6 +64,7 @@ private:
     double      temp;
     double      cad;
     double      watts;
+    double      speed;
 
     // set to false after the first time element is seen (not in metadata)
     bool firstTime;

--- a/src/FileIO/GpxRideFile.cpp
+++ b/src/FileIO/GpxRideFile.cpp
@@ -32,7 +32,7 @@ RideFile *GpxFileReader::openRideFile(QFile &file, QStringList &errors, QList<Ri
 {
     (void) errors;
     RideFile *rideFile = new RideFile();
-    rideFile->setRecIntSecs(1.0);
+    rideFile->setRecIntSecs(GPX_SAMPLE_INTERVAL);
     //rideFile->setDeviceType("GPS Exchange Format");
     rideFile->setFileFormat("GPS Exchange Format (gpx)");
 

--- a/src/Resources/translations/gc_cs.ts
+++ b/src/Resources/translations/gc_cs.ts
@@ -107,38 +107,38 @@ Může být nezbytné ji vypnout ručně.</translation>
         <translation type="vanished">LTS průměr (days)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="504"/>
+        <location filename="../../Gui/AthletePages.cpp" line="489"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="517"/>
-        <location filename="../../Gui/AthletePages.cpp" line="522"/>
+        <location filename="../../Gui/AthletePages.cpp" line="502"/>
+        <location filename="../../Gui/AthletePages.cpp" line="507"/>
         <source>days</source>
         <translation type="unfinished">dny</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="525"/>
+        <location filename="../../Gui/AthletePages.cpp" line="510"/>
         <source>PMC Stress Balance Today</source>
         <translation>PMC poměr zátěže počítat dnes</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="528"/>
+        <location filename="../../Gui/AthletePages.cpp" line="513"/>
         <source>Restore Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="517"/>
         <source>W&apos;bal tau</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="518"/>
         <source>Short Term Stress (STS) average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="534"/>
+        <location filename="../../Gui/AthletePages.cpp" line="519"/>
         <source>Long Term Stress (LTS) average</source>
         <translation type="unfinished"></translation>
     </message>
@@ -154,96 +154,96 @@ Může být nezbytné ji vypnout ručně.</translation>
 <context>
     <name>AboutRiderPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="372"/>
+        <location filename="../../Gui/AthletePages.cpp" line="357"/>
         <source>Nickname</source>
         <translation>Přezdívka</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="373"/>
+        <location filename="../../Gui/AthletePages.cpp" line="358"/>
         <source>Date of Birth</source>
         <translation>Datum narození</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="374"/>
+        <location filename="../../Gui/AthletePages.cpp" line="359"/>
         <source>Sex</source>
         <translation>Pohlaví</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="376"/>
+        <location filename="../../Gui/AthletePages.cpp" line="361"/>
         <source>Weight</source>
         <translation type="unfinished">Hmotnost</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="375"/>
+        <location filename="../../Gui/AthletePages.cpp" line="360"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="279"/>
+        <location filename="../../Gui/AthletePages.cpp" line="264"/>
         <source>Male</source>
         <translation>Muž</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="280"/>
+        <location filename="../../Gui/AthletePages.cpp" line="265"/>
         <source>Female</source>
         <translation>Žena</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> kg</source>
         <translation type="unfinished"> kg</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> lb</source>
         <translation type="unfinished"> lb</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> cm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="359"/>
+        <location filename="../../Gui/AthletePages.cpp" line="344"/>
         <source>Calculate...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="378"/>
+        <location filename="../../Gui/AthletePages.cpp" line="363"/>
         <source>Bike</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="379"/>
+        <location filename="../../Gui/AthletePages.cpp" line="364"/>
         <source>Crank Length</source>
         <translation>Délka klik</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="380"/>
+        <location filename="../../Gui/AthletePages.cpp" line="365"/>
         <source>Wheelsize</source>
         <translation>Rozměr kol</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="438"/>
+        <location filename="../../Gui/AthletePages.cpp" line="423"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="356"/>
+        <location filename="../../Gui/AthletePages.cpp" line="341"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="437"/>
+        <location filename="../../Gui/AthletePages.cpp" line="422"/>
         <source>Choose Picture</source>
         <translation>Vyber si fotku</translation>
     </message>
@@ -2275,397 +2275,394 @@ Pokračujte kliknutím na tlačítko Další
 <context>
     <name>AllPlotWindow</name>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="190"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="444"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="165"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
         <source>Smooth</source>
         <translation>Vyhlazení</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="198"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="173"/>
         <source>Stacked</source>
         <translation>Nad sebou</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="199"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="174"/>
         <source>by series</source>
         <translation>po sériích</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="200"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="175"/>
         <source>Fullplot</source>
         <translation>Celý plán</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="201"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="176"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="239"/>
         <source>Overlay</source>
         <translation>Překrytí</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="229"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="204"/>
         <source>View</source>
         <translation>Pohled</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="206"/>
         <source>Stack</source>
         <translation>Nad sebou</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="210"/>
         <source>By Series</source>
         <translation>Po sériích</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="246"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="221"/>
         <source>Stack Zoom</source>
         <translation>Přiblížení rozdělení</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="248"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="223"/>
         <source>Full plot</source>
         <translation>Celý graf</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="227"/>
         <source>Show Interval Markers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="256"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
         <source>Interval Navigator</source>
         <translation>Navigátor v intervalech</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="260"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
         <source>Hover intervals</source>
         <translation>Intervaly při najetí kurzorem</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="268"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="243"/>
         <source>Fill Curves</source>
         <translation>Vyplnit křivky</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="247"/>
         <source>Grid</source>
         <translation>Mřížka</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="277"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
         <source>Acceleration</source>
         <translation>Akcelerace</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="279"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="254"/>
         <source>Delta Series</source>
         <translation>Delta série</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="280"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="255"/>
         <source>Power %1</source>
         <translation>Výkon %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="283"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="258"/>
         <source>Cadence %1</source>
         <translation>Kadence %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="261"/>
         <source>Torque %1</source>
         <translation>Točivý moment %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="289"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
         <source>Heartrate %1</source>
         <translation>Tepová frekvence %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="295"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="270"/>
         <source>Balance</source>
         <translation>Poměr</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
         <source>Left/Right</source>
         <translation>Levá/Pravá</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="274"/>
         <source>Torque Effectiveness</source>
         <translation>Efektivita šlapání</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="303"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="278"/>
         <source>Smoothness</source>
         <translation>Plynulost</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="282"/>
         <source>Pedal Center Offset</source>
         <translation>Ofset středu pedálu</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="311"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
         <source>Power Phase</source>
         <translation>Fáze výkonu</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="290"/>
         <source>Peak Power Phase</source>
         <translation>Fáze špičkového výkonu</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="322"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
         <source>Vertical Oscillation</source>
         <translation>Vertikální oscilace</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="324"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
         <source>Running</source>
         <translation>Běh</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="326"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="301"/>
         <source>Ground Contact Time</source>
         <translation>Doba kontaktu se zemí</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
         <source>Cadence </source>
         <translation>Kadence </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="313"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="340"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
         <source>Moxy</source>
         <translation>Moxy</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="317"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="321"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="325"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="355"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="330"/>
         <source>Heart Rate</source>
         <translation>Srdeční tep</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="357"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
         <source>Data series</source>
         <translation>Datová série</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="359"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="334"/>
         <source>Core Temperature</source>
         <translation>Tělesná teplota</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="363"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
         <source>Speed</source>
         <translation>Rychlost</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="367"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
         <source>Cadence</source>
         <translation>Kadence</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="94"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="95"/>
         <source>Basic</source>
         <translation>Obecné</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="109"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="110"/>
         <source>Curves</source>
         <translation>Křivky</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="116"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="117"/>
         <source>User Data</source>
         <translation>Uživatelská data</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="132"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Name</source>
         <translation>Jméno</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="134"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Formula</source>
         <translation>Formule</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="144"/>
         <source>Edit</source>
-        <translation>Upravit</translation>
+        <translation type="vanished">Upravit</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="163"/>
         <source>Up</source>
-        <translation>Nahoru</translation>
+        <translation type="vanished">Nahoru</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="164"/>
         <source>Down</source>
-        <translation>Dolů</translation>
+        <translation type="vanished">Dolů</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="371"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
         <source>Altitude</source>
         <translation>Nadm. výška</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
         <source>Temperature</source>
         <translation>Teplota</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="379"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="354"/>
         <source>Headwind</source>
         <translation>Protivítr</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="383"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="358"/>
         <source>Torque</source>
         <translation>Točivý moment</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="387"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="362"/>
         <source>Gear Ratio</source>
         <translation>Převodový poměr</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="391"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="366"/>
         <source>Slope</source>
         <translation>Sklon</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="373"/>
         <source>No Alt/Slope</source>
         <translation>Žádná n. výška/sklon</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="399"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="374"/>
         <source>0.1km|mi -  1min</source>
         <translation>0.1km|mi -  1min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="400"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
         <source>0.5km|mi -  5min</source>
         <translation>0.5km|mi -  5min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="401"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="376"/>
         <source>1.0km|mi - 10min</source>
         <translation>1.0km|mi - 10min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1528"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="377"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="1503"/>
         <source>Alt/Slope</source>
         <translation>N. Výška/sklon</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="382"/>
         <source>Anaerobic TISS</source>
         <translation>Anaerobní TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="384"/>
         <source>Metrics</source>
         <translation>Metriky</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="411"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="386"/>
         <source>Aerobic TISS</source>
         <translation>Aerobní TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="390"/>
         <source>Iso Power</source>
         <translation>IsoVýkon</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="394"/>
         <source>Skiba xPower</source>
         <translation>Skiba xVýkon</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="423"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
         <source>Altitude Power</source>
         <translation>Výškový výkon</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="427"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
         <source>W&apos; balance</source>
         <translation>W&apos; poměr</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="441"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="416"/>
         <source>Time of day</source>
         <translation>Čas dne</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="742"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="717"/>
         <source>Intervals</source>
         <translation>Intervaly</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="2253"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="2228"/>
         <source>Selection #%1 </source>
         <translation>Selekce č. %1 </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="432"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
         <source>Power + shade</source>
         <translation>Výkon a zóny</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="433"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="408"/>
         <source>Power - shade</source>
         <translation>Výkon</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="434"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
         <source>No Power</source>
         <translation>Bez výkonu</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="435"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="410"/>
         <source>Shading</source>
         <translation>Stínování</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="439"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="414"/>
         <source>Time</source>
         <translation>Čas</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="440"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
         <source>Distance</source>
         <translation>Vzdálenost</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="442"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="417"/>
         <source>X Axis</source>
         <translation>Osa X</translation>
     </message>
@@ -3472,51 +3469,45 @@ Pokračujte kliknutím na tlačítko Další
 <context>
     <name>AutoImportPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4028"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4029"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
         <source>Browse</source>
         <translation type="vanished">Procházet</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4040"/>
         <source>Add</source>
-        <translation>Přidat</translation>
+        <translation type="vanished">Přidat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4041"/>
         <source>Delete</source>
-        <translation>Smazat</translation>
+        <translation type="vanished">Smazat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4042"/>
         <source>Up</source>
-        <translation>Nahoru</translation>
+        <translation type="vanished">Nahoru</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4043"/>
         <source>Down</source>
-        <translation>Dolů</translation>
+        <translation type="vanished">Dolů</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4054"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3779"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4059"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3784"/>
         <source>Directory</source>
         <translation>Adresář</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4060"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3785"/>
         <source>Import Rule</source>
         <translation>Importní pravidlo</translation>
     </message>
@@ -4334,37 +4325,37 @@ Pokračujte kliknutím na tlačítko Další
 <context>
     <name>BackupPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="608"/>
+        <location filename="../../Gui/AthletePages.cpp" line="593"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="601"/>
         <source>every</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="617"/>
+        <location filename="../../Gui/AthletePages.cpp" line="602"/>
         <source>times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="603"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="605"/>
         <source>Backup now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="623"/>
+        <location filename="../../Gui/AthletePages.cpp" line="608"/>
         <source>Auto Backup Folder</source>
         <translation>Složka automatického zálohování</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="624"/>
+        <location filename="../../Gui/AthletePages.cpp" line="609"/>
         <source>Auto Backup after closing the athlete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5190,41 +5181,33 @@ Pojďme to nastavit.</translation>
         <translation type="vanished">Aktualizovat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1202"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1203"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1204"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1150"/>
         <source>Review...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1206"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1152"/>
         <source>Changed power estimates are available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1213"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1225"/>
         <source>Add</source>
-        <translation>Přidat</translation>
+        <translation type="vanished">Přidat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1214"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1226"/>
         <source>Delete</source>
-        <translation>Smazat</translation>
+        <translation type="vanished">Smazat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1216"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1158"/>
         <source>Def</source>
         <translation>Výchozí</translation>
     </message>
@@ -5233,27 +5216,27 @@ Pojďme to nastavit.</translation>
         <translation type="vanished">Od</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1218"/>
         <source>Critical Power</source>
         <translation>Kritický výkon</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1305"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>AeTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1306"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>FTP</source>
         <translation>FTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1307"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1221"/>
         <source>W&apos;</source>
         <translation>W&apos;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1308"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1222"/>
         <source>Pmax</source>
         <translation>Pmax</translation>
     </message>
@@ -5262,207 +5245,207 @@ Pojďme to nastavit.</translation>
         <translation type="vanished">d MMM, yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1347"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1261"/>
         <source>Short</source>
         <translation>Zkratka</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1247"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1169"/>
         <source>Use CP for all metrics</source>
         <translation>Použít CP pro všechny metriky</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1240"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1162"/>
         <source>Manual</source>
         <translation type="unfinished">Ruční</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1241"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1163"/>
         <source>Semi-Automatic (CP2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1164"/>
         <source>Semi-Automatic (CP3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1243"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1165"/>
         <source>Semi-Automatic (Extended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1170"/>
         <source>Use FTP for Coggan metrics</source>
         <translation>Použít FTP rpo Cogganovy metriky</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1273"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1279"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1285"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1342"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1618"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1631"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2283"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2289"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2310"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1187"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1193"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1199"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1211"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1537"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1545"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2180"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2186"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2194"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2207"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1205"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1547"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2201"/>
         <source>J</source>
         <translation type="unfinished">J</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1303"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1217"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2145"/>
         <source>Start Date</source>
         <translation type="unfinished">Datum začátkku</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1309"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1223"/>
         <source>Model Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1262"/>
         <source>Long</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1349"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1263"/>
         <source>From Watts</source>
         <translation>Od wattů</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1598"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1512"/>
         <source>Review range starting on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1614"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1528"/>
         <source>Current</source>
         <translation type="unfinished">Aktuální</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1615"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1529"/>
         <source>Estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1530"/>
         <source>Accept</source>
         <translation type="unfinished">Přijmout</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1788"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1691"/>
         <source>🗹</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1692"/>
         <source>Estimate and settings &lt;b&gt;match&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1695"/>
         <source>☐</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1696"/>
         <source>Estimate and settings &lt;b&gt;differ&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1797"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1700"/>
         <source>⏲</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1800"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1703"/>
         <source>Range is %1 days older than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1802"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1705"/>
         <source>Range is %1 days younger than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1808"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1711"/>
         <source>∅</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1712"/>
         <source>No estimate available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1902"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1805"/>
         <source>New range from estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2237"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2134"/>
         <source>The proposed value for AeTP is a very rough estimate, assuming %1 % of CP. Usually it is determined by a&lt;ul&gt;&lt;li&gt;Metabolic test&lt;/li&gt;&lt;li&gt;Lactate ramp test&lt;/li&gt;&lt;li&gt;Run / Cycling ‘conversational’ test&lt;/li&gt;&lt;li&gt;Run Decoupling test&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2239"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2136"/>
         <source>Updating FTP internally to match CP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2139"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2244"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2141"/>
         <source>Your selected model does not deliver values for PMax, using default value of %1 W instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2246"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2143"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;li&gt;PMax, assuming a default of %1 W&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2250"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2147"/>
         <source>Critical Power (CP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2252"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2149"/>
         <source>Aerobic Threshold Power (AeTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2254"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2151"/>
         <source>Functional Threshold Power (FTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2153"/>
         <source>Anaerobic Work Capacity (W&apos;)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2258"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2155"/>
         <source>Maximum Power (PMax)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2270"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2167"/>
         <source>Manual range</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5471,14 +5454,14 @@ Pojďme to nastavit.</translation>
         <translation type="vanished">Maximum 10 zón dosaženo.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2018"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2025"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1917"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1924"/>
         <source>New</source>
         <translation>Nový</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2020"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1919"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1926"/>
         <source>New (%1)</source>
         <translation>Nový (%1)</translation>
     </message>
@@ -5931,52 +5914,44 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">Aktualizovat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3307"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3319"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3308"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3320"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3313"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3325"/>
         <source>Add</source>
-        <translation>Přidat</translation>
+        <translation type="vanished">Přidat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3314"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3326"/>
         <source>Delete</source>
-        <translation>Smazat</translation>
+        <translation type="vanished">Smazat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3316"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3109"/>
         <source>Def</source>
         <translation>Výchozí</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3359"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3506"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3272"/>
         <source>Start Date</source>
         <translation type="unfinished">Datum začátkku</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3249"/>
         <source>New range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3507"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3273"/>
         <source>Critical Velocity (CV)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3508"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3274"/>
         <source>Aerobic Threshold (AeT)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5985,12 +5960,12 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">Od</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3360"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3128"/>
         <source>Critical Velocity</source>
         <translation>Kritická rychlost</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3361"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3129"/>
         <source>Aerobic Threshold</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5999,17 +5974,17 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">d MMM, yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3403"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
         <source>Short</source>
         <translation>Zkratka</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3404"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3172"/>
         <source>Long</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3405"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3173"/>
         <source>From</source>
         <translation>Od</translation>
     </message>
@@ -6018,14 +5993,14 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">Maximum 10 zón dosaženo.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3679"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3686"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3441"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3448"/>
         <source>New</source>
         <translation>Nový</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3681"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3688"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3443"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3450"/>
         <source>New (%1)</source>
         <translation>Nový (%1)</translation>
     </message>
@@ -7559,37 +7534,32 @@ Chcete změnu aplikovat a restartovat GoldenCheetah?</translation>
 <context>
     <name>CredentialsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="67"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
+    </message>
+    <message>
+        <source>-</source>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="vanished">Upravit</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">Přidat</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">Smazat</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="68"/>
-        <source>-</source>
-        <translation>-</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="69"/>
-        <source>Edit</source>
-        <translation>Upravit</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="74"/>
-        <source>Add</source>
-        <translation>Přidat</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="75"/>
-        <source>Delete</source>
-        <translation>Smazat</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="86"/>
         <source>Service</source>
         <translation>Služba</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="87"/>
+        <location filename="../../Gui/AthletePages.cpp" line="69"/>
         <source>Description</source>
         <translation>Popis</translation>
     </message>
@@ -8276,7 +8246,7 @@ Chcete změnu aplikovat a restartovat GoldenCheetah?</translation>
 <context>
     <name>DataFilterEdit</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2743"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2712"/>
         <source>Warning: sample() is slow -- update code to use samples()</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8635,7 +8605,7 @@ Chcete změnu aplikovat a restartovat GoldenCheetah?</translation>
 <context>
     <name>DirectoryPathWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="277"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="308"/>
         <source>Browse</source>
         <translation type="unfinished">Procházet</translation>
     </message>
@@ -8872,28 +8842,28 @@ Možná budete muset (re) instalovat ovladač FTDI nebo PL2303 než zahájíte s
 <context>
     <name>Dropbox</name>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="68"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="77"/>
         <source>Problem accessing Dropbox data</source>
         <translation>Problém s přístupem k datům Dropboxu</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="130"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="139"/>
         <source>You must authorise with Dropbox first</source>
         <translation>Nejdříve musíte autorizovat Dropbox</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="205"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="214"/>
         <source>Parsing Error: %1</source>
         <translation>Chyba zpracování: %1</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="293"/>
-        <location filename="../../Cloud/Dropbox.cpp" line="312"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="302"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="321"/>
         <source>Completed.</source>
         <translation>Hotovo.</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="297"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="306"/>
         <source>Network Error - Upload failed.</source>
         <translation>Chyba sítě - nahrávání selhalo.</translation>
     </message>
@@ -9038,136 +9008,136 @@ Možná budete muset (re) instalovat ovladač FTDI nebo PL2303 než zahájíte s
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2064"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2033"/>
         <source>Name</source>
         <translation>Jméno</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2034"/>
         <source>Axis Label / Units</source>
         <translation>Označení osy / jednotky</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1597"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1566"/>
         <source>Curve Settings</source>
         <translation>Nastavení křivky</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1558"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1527"/>
         <source>Estimate %1 %2 Power</source>
         <translation>Odhadnout %1 %2 výkon</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1562"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1531"/>
         <source>Endurance Index</source>
         <translation>Index vytrvalosti</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1532"/>
         <source>Vo2Max Estimate</source>
         <translation>Odhad VO2Max</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1605"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1574"/>
         <source>Metric</source>
         <translation>Metrika</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1606"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1575"/>
         <source>Best</source>
         <translation>Nejlepší výkon</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1607"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1576"/>
         <source>Estimate</source>
         <translation>Odhad</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1577"/>
         <source>PMC</source>
         <translation>PMC</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1609"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1578"/>
         <source>Formula</source>
         <translation>Vzorec</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1610"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1579"/>
         <source>Measure</source>
         <translation>Míra</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1611"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1580"/>
         <source>Performance</source>
         <translation>Výkon</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1612"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1581"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1684"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1767"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1653"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1736"/>
         <source>seconds</source>
         <translation>sekundy</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1685"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1768"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1737"/>
         <source>minutes</source>
         <translation>minuty</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1769"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1655"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1738"/>
         <source>hours</source>
         <translation>hodiny</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1723"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1816"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1692"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1785"/>
         <source>Peak</source>
         <translation>Špička</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1781"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1750"/>
         <source>Absolute</source>
         <translation>Absolutní</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1751"/>
         <source>Per Kilogram</source>
         <translation>Na kilogram</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1813"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
         <source>Total</source>
         <translation>Celkem</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1814"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1783"/>
         <source>Running Total</source>
         <translation>Celkově pro běh</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1815"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1784"/>
         <source>Average</source>
         <translation>Průměr</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1817"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1786"/>
         <source>Low</source>
         <translation>Nízký</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1820"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1789"/>
         <source>Aggregate:</source>
         <translation>Součet:</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1828"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1797"/>
         <source># type in a formula to use
 # for e.g. BikeStress / Duration
 # as you type the available metrics
@@ -9180,292 +9150,292 @@ Možná budete muset (re) instalovat ovladač FTDI nebo PL2303 než zahájíte s
 </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1839"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1808"/>
         <source>Weekly Best Performances</source>
         <translation>Týdenní nejlepší výkony</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1840"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1809"/>
         <source>Submaximal Weekly Best</source>
         <translation>Submaximální týdenní nejlepší výkon</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1841"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1810"/>
         <source>Performance Tests</source>
         <translation>Výkonnostní testy</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1933"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1902"/>
         <source>Short Term Stress (STS/ATL)</source>
         <translation>Krátkodobá zátěž (STS/ATL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1934"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1903"/>
         <source>Long Term Stress  (LTS/CTL)</source>
         <translation>Dlouhodobá zátěž (LTS/CTL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1935"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1904"/>
         <source>Stress Balance    (SB/TSB)</source>
         <translation>Bilance zátěže (SB/TSB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1936"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1905"/>
         <source>Stress Ramp Rate  (RR)</source>
         <translation>Tempo navyšování zátěže (RR)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1944"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1913"/>
         <source>Stress Type</source>
         <translation>Typ zátěže</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1949"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1918"/>
         <source>Negative Training Effect (NTE)</source>
         <translation>Negativní tréninkový efekt (NTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1950"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1919"/>
         <source>Positive Training Effect (PTE)</source>
         <translation>Pozitivní tréninkový efekt (PTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1951"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1920"/>
         <source>Performance (Power Index)</source>
         <translation>Výkon (index výkonu)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1952"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1921"/>
         <source>Predicted CP (Watts)</source>
         <translation>Predikovaný CP (Watty)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1969"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1938"/>
         <source>Curve Type</source>
         <translation>Typ křivky</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1945"/>
         <source>Perf. Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2006"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1975"/>
         <source>Metadata Field</source>
         <translation>Pole metadat</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2007"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
         <source>PMC metric</source>
         <translation>PMC metrika</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2032"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2001"/>
         <source>Measure Group</source>
         <translation>Změřit skupinu</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2009"/>
         <source>Measure Field</source>
         <translation>Změřit pole</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2029"/>
         <source>Filter</source>
         <translation>Filtr</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2071"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
         <source>Style</source>
         <translation>Styl</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2042"/>
         <source>Bar</source>
         <translation>Sloupcový graf</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2074"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2043"/>
         <source>Line</source>
         <translation>Spojitý graf</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2075"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2044"/>
         <source>Sticks</source>
         <translation>Přichytit</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2076"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2045"/>
         <source>Dots</source>
         <translation>Body</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2048"/>
         <source>Stack</source>
         <translation>Nad sebou</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2053"/>
         <source>Symbol</source>
         <translation>Symbol</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2086"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2055"/>
         <source>None</source>
         <translation>Žádný</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2087"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2056"/>
         <source>Circle</source>
         <translation>Kruh</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2057"/>
         <source>Square</source>
         <translation>Čtverec</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2089"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2058"/>
         <source>Diamond</source>
         <translation>Diamant</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2090"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2059"/>
         <source>Triangle</source>
         <translation>Trojúhelník</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2091"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
         <source>Cross</source>
         <translation>Křížek</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2092"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2061"/>
         <source>Hexagon</source>
         <translation>Šestihran</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2062"/>
         <source>Star</source>
         <translation>Hvězda</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
         <source>Color</source>
         <translation>Barva</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2100"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2069"/>
         <source>Fill curve</source>
         <translation>Vyplnit křivku</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
         <source>Data labels</source>
         <translation>Označení dat</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2080"/>
         <source>Highlight Highest</source>
         <translation>Zvýraznit nejvyšší</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
         <source>Highlight Lowest</source>
         <translation>Zvýraznit nejnižší</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2127"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
         <source>Highlight Outliers</source>
         <translation>Zvýraznit odlehlé hodnoty</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2135"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
         <source>Baseline</source>
         <translation>Základní hodnota</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2143"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2112"/>
         <source>Smooth Curve</source>
         <translation>Vyhlazená křivka</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2147"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2116"/>
         <source>No trend Line</source>
         <translation>Bez linie trendu</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2148"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2117"/>
         <source>Linear Trend</source>
         <translation>Lineární trend</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2149"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2118"/>
         <source>Quadratic Trend</source>
         <translation>Kvadratický trend</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2150"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
         <source>Moving Average</source>
         <translation>Klouzavý průměr</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2151"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2120"/>
         <source>Simple Average</source>
         <translation>Jednoduchý průměr</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2123"/>
         <source>Ignore Zeros</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2168"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2201"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2170"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Zrušit</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2431"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2400"/>
         <source>Peak %1</source>
         <translation>Špička %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2402"/>
         <source> second </source>
         <translation> sekunda </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2434"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2403"/>
         <source> minute </source>
         <translation> minuta </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2436"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2405"/>
         <source> hour </source>
         <translation> hodina </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2456"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2425"/>
         <source>%1 - %2</source>
         <translation>%1 - %2</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2470"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2439"/>
         <source>Performances</source>
         <translation>Výkony</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2471"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2440"/>
         <source>Power Index</source>
         <translation>Index výkonu</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2588"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2557"/>
         <source>Performances_%1_%2_%3</source>
         <translation>Výkony_%1_%2_%3</translation>
     </message>
@@ -9795,93 +9765,93 @@ Možná budete muset (re) instalovat ovladač FTDI nebo PL2303 než zahájíte s
 <context>
     <name>EditUserAxisDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1731"/>
+        <location filename="../../Charts/UserChart.cpp" line="1689"/>
         <source>Edit Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1741"/>
+        <location filename="../../Charts/UserChart.cpp" line="1699"/>
         <source>&amp;OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1742"/>
+        <location filename="../../Charts/UserChart.cpp" line="1700"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1750"/>
+        <location filename="../../Charts/UserChart.cpp" line="1708"/>
         <source>Units</source>
         <translation type="unfinished">Jednotky</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1760"/>
+        <location filename="../../Charts/UserChart.cpp" line="1718"/>
         <source>Logarithmic Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1757"/>
+        <location filename="../../Charts/UserChart.cpp" line="1715"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1761"/>
-        <location filename="../../Charts/UserChart.cpp" line="1780"/>
+        <location filename="../../Charts/UserChart.cpp" line="1719"/>
+        <location filename="../../Charts/UserChart.cpp" line="1738"/>
         <source> </source>
         <translation type="unfinished"> </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1763"/>
+        <location filename="../../Charts/UserChart.cpp" line="1721"/>
         <source>Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1774"/>
+        <location filename="../../Charts/UserChart.cpp" line="1732"/>
         <source> from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1776"/>
+        <location filename="../../Charts/UserChart.cpp" line="1734"/>
         <source> to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1779"/>
+        <location filename="../../Charts/UserChart.cpp" line="1737"/>
         <source>Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1787"/>
+        <location filename="../../Charts/UserChart.cpp" line="1745"/>
         <source>Smoothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1792"/>
+        <location filename="../../Charts/UserChart.cpp" line="1750"/>
         <source>None</source>
         <translation type="unfinished">Žádný</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1793"/>
+        <location filename="../../Charts/UserChart.cpp" line="1751"/>
         <source>Day</source>
         <translation type="unfinished">Den</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1794"/>
+        <location filename="../../Charts/UserChart.cpp" line="1752"/>
         <source>Week</source>
         <translation type="unfinished">Týden</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1795"/>
+        <location filename="../../Charts/UserChart.cpp" line="1753"/>
         <source>Month</source>
         <translation type="unfinished">Měsíc</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1796"/>
+        <location filename="../../Charts/UserChart.cpp" line="1754"/>
         <source>Year</source>
         <translation type="unfinished">Rok</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1798"/>
+        <location filename="../../Charts/UserChart.cpp" line="1756"/>
         <source>Group By</source>
         <translation type="unfinished">Seskupit podle</translation>
     </message>
@@ -10078,158 +10048,158 @@ Možná budete muset (re) instalovat ovladač FTDI nebo PL2303 než zahájíte s
 <context>
     <name>EditUserSeriesDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1398"/>
+        <location filename="../../Charts/UserChart.cpp" line="1356"/>
         <source>Edit Data Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1414"/>
+        <location filename="../../Charts/UserChart.cpp" line="1372"/>
         <source>&amp;OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1415"/>
+        <location filename="../../Charts/UserChart.cpp" line="1373"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1422"/>
+        <location filename="../../Charts/UserChart.cpp" line="1380"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1430"/>
+        <location filename="../../Charts/UserChart.cpp" line="1388"/>
         <source>Series Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1519"/>
+        <location filename="../../Charts/UserChart.cpp" line="1477"/>
         <source>Y units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1524"/>
+        <location filename="../../Charts/UserChart.cpp" line="1482"/>
         <source>X units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1528"/>
+        <location filename="../../Charts/UserChart.cpp" line="1486"/>
         <source>Sum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1529"/>
+        <location filename="../../Charts/UserChart.cpp" line="1487"/>
         <source>Average</source>
         <translation type="unfinished">Průměr</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1530"/>
+        <location filename="../../Charts/UserChart.cpp" line="1488"/>
         <source>Peak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1531"/>
+        <location filename="../../Charts/UserChart.cpp" line="1489"/>
         <source>Low</source>
         <translation type="unfinished">Nízký</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1532"/>
+        <location filename="../../Charts/UserChart.cpp" line="1490"/>
         <source>Running Total</source>
         <translation type="unfinished">Celkově pro běh</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1533"/>
+        <location filename="../../Charts/UserChart.cpp" line="1491"/>
         <source>Mean Square Root</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1534"/>
+        <location filename="../../Charts/UserChart.cpp" line="1492"/>
         <source>Std Deviation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1537"/>
+        <location filename="../../Charts/UserChart.cpp" line="1495"/>
         <source>Aggregate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1541"/>
-        <location filename="../../Charts/UserChart.cpp" line="1557"/>
+        <location filename="../../Charts/UserChart.cpp" line="1499"/>
+        <location filename="../../Charts/UserChart.cpp" line="1515"/>
         <source>None</source>
         <translation type="unfinished">Žádný</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1542"/>
+        <location filename="../../Charts/UserChart.cpp" line="1500"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1543"/>
+        <location filename="../../Charts/UserChart.cpp" line="1501"/>
         <source>Dashed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1544"/>
+        <location filename="../../Charts/UserChart.cpp" line="1502"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1545"/>
+        <location filename="../../Charts/UserChart.cpp" line="1503"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1546"/>
+        <location filename="../../Charts/UserChart.cpp" line="1504"/>
         <source>Fast Graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1547"/>
+        <location filename="../../Charts/UserChart.cpp" line="1505"/>
         <source>Show on Legend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1548"/>
+        <location filename="../../Charts/UserChart.cpp" line="1506"/>
         <source>Show Data Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1554"/>
+        <location filename="../../Charts/UserChart.cpp" line="1512"/>
         <source>Line Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1558"/>
+        <location filename="../../Charts/UserChart.cpp" line="1516"/>
         <source>Circle</source>
         <translation type="unfinished">Kruh</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1559"/>
+        <location filename="../../Charts/UserChart.cpp" line="1517"/>
         <source>Rectangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1564"/>
+        <location filename="../../Charts/UserChart.cpp" line="1522"/>
         <source>Symbol</source>
         <translation type="unfinished">Symbol</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1572"/>
+        <location filename="../../Charts/UserChart.cpp" line="1530"/>
         <source>Color</source>
         <translation type="unfinished">Barva</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1575"/>
+        <location filename="../../Charts/UserChart.cpp" line="1533"/>
         <source>Fill curve</source>
         <translation type="unfinished">Vyplnit křivku</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1583"/>
+        <location filename="../../Charts/UserChart.cpp" line="1541"/>
         <source>Opacity (%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1589"/>
+        <location filename="../../Charts/UserChart.cpp" line="1547"/>
         <source>Size/Width</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10276,6 +10246,24 @@ Možná budete muset (re) instalovat ovladač FTDI nebo PL2303 než zahájíte s
         <location filename="../../Metrics/BasicRideMetrics.cpp" line="144"/>
         <source>Only useful for intervals, time the interval started</source>
         <translation>Užitečné pouze u intervalů, čas kdy interval začal</translation>
+    </message>
+</context>
+<context>
+    <name>ElevationChartWindow</name>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="221"/>
+        <source>Profile Distance (m)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="229"/>
+        <source>Seconds for delta slope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="237"/>
+        <source>Elevation window size (%) relative to current altitude</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10714,7 +10702,7 @@ Možná budete muset (re) instalovat ovladač FTDI nebo PL2303 než zahájíte s
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ExhaustionDialog.cpp" line="160"/>
+        <location filename="../../Charts/ExhaustionDialog.cpp" line="162"/>
         <source>Time</source>
         <translation>Čas</translation>
     </message>
@@ -13103,42 +13091,42 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
 <context>
     <name>GcCrashDialog</name>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="78"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="74"/>
         <source>%1 Crash Recovery</source>
         <translation>%1 Obnovení po pádu</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="116"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="112"/>
         <source>&lt;b&gt;GoldenCheetah appears to have PREVIOUSLY crashed for this athlete. &lt;/b&gt;&lt;br&gt;&lt;br&gt;The report below gives some diagnostic information that will be useful to the developers. Feel free to post this with a short description of what was occurring when the crash happened to the &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah forums&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;We respect privacy - this log does NOT contain ids, passwords or personal information.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;When this dialog is closed the athlete will be opened.&lt;/b&gt;</source>
         <translation>&lt;b&gt;Vypadá to, že GoldenCheetah dříve spadnul pro tohoto sportovce. &lt;/b&gt;&lt;br&gt;&lt;br&gt;Zpráva níže obsahuje diagnostické informace důležité pro vývojáře. Můžete tuto zprávu společně s krátkým popisem, co jste dělali, když k pádu došlo, nahrát na &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah fórum&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;Respektujeme soukromí - tento log neobsahuje žádné identifikační údaje, hesla nebo osobní informace.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;Po uzavření tohoto dialogu bude nahrán sportovec.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="141"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="137"/>
         <source>Save Crash Report...</source>
         <translation>Uložit zprávu o pádu aplikace...</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="143"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="139"/>
         <source>Close</source>
         <translation>Zavřít</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="225"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="221"/>
         <source>&lt;p&gt;Build date: %1 %2&lt;br&gt;Build id: %3&lt;br&gt;Version: %4&lt;br&gt;DB Schema: %5&lt;br&gt;Metrics: %7&lt;br&gt;OS: %6&lt;br&gt;OpenGL: %10&lt;br&gt;UI: dpi scale (%8) font size (%9)&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="255"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="251"/>
         <source>&lt;table&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QT&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QWT&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;%3&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SRMIO&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;D2XX&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;ICAL&lt;/td&gt;&lt;td&gt;%9&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;USBXPRESS&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LIBUSB&lt;/td&gt;&lt;td&gt;%11&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VLC&lt;/td&gt;&lt;td&gt;%12&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VIDEO&lt;/td&gt;&lt;td&gt;%13&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SAMPLERATE&lt;/td&gt;&lt;td&gt;%14&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SSL&lt;/td&gt;&lt;td&gt;%15&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;R&lt;/td&gt;&lt;td&gt;%16&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;Python&lt;/td&gt;&lt;td&gt;%18&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LMFIT&lt;/td&gt;&lt;td&gt;7.0&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;GSL&lt;/td&gt;&lt;td&gt;%19&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Save Diagnostics</source>
         <translation>Uložit diagnostiku</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Text File (*.txt)</source>
         <translation>Textový soubor (*.txt)</translation>
     </message>
@@ -13473,167 +13461,172 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
 <context>
     <name>GcWindowRegistry</name>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
         <source>Performance</source>
         <translation>Výkon</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="89"/>
         <source>Histogram</source>
         <translation>Histogram</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
         <source>Distribution</source>
         <translation>Rozložení</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
         <source>Pedal Force vs Velocity</source>
         <translation>Síla šlapání vs rychlost</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
         <source>Heartrate vs Power</source>
         <translation>Tepová frekvence vs Výkon</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
         <source>Python Chart</source>
         <translation>Python diagram</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
         <source>Python Chart </source>
         <translation>Python diagram </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="101"/>
         <source>Calendar</source>
         <translation>Kalendář</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
         <source>Navigator</source>
         <translation>Navigátor</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="71"/>
         <source>Season Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="72"/>
         <source>Blank Overview </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="76"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="73"/>
         <source>User Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
         <source>Trends</source>
         <translation type="unfinished">Trendy</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="78"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
         <source>TreeMap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
         <source>Power Duration </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="83"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
         <source>Activity Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="81"/>
         <source>Blank Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="85"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="82"/>
         <source>User Chart </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
         <source>Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="88"/>
         <source>Power Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
         <source>Scatter</source>
         <translation type="unfinished">Rozptyl</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="103"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
         <source>Aerolab</source>
         <translation type="unfinished">Aerolab</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
         <source>Telemetry</source>
         <translation>Telemetrie</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
         <source>Workout</source>
         <translation>Cvičení</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="106"/>
         <source>Realtime</source>
         <translation>Diagram v reálném čase</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
         <source>Pedal Stroke</source>
         <translation>Šlapání</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="113"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
         <source>Live Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="114"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <source>Elevation Chart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
         <source>Web page</source>
         <translation>Webová stránka</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
         <source>Map</source>
         <translation>Mapa</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
         <source>R Chart</source>
         <translation>R diagram</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="98"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
         <source>R Chart </source>
         <translation>R diagram </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
         <source>Video Player</source>
         <translation>Přehrávač</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
         <source>Workout Editor</source>
         <translation>Editor cvičení</translation>
     </message>
@@ -14735,142 +14728,147 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="296"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="294"/>
+        <source>Show elevation profile of instant position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
         <source>Predefined and configurable set of data ranges for selection of activities to be analysed</source>
         <translation>Předdefinovaná a konfigurovatelná sada rozsahu dat pro výběr aktivit k analýze</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
         <source>Powerful filter and search engine to determine the activities which are considered in diagram</source>
         <translation>Filtr a vyhledávač sloužící k určení, které aktivity budou zahrnuty v diagramu</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
         <source>Configurable list of activities</source>
         <translation>Konfigurovatelný seznam aktivit</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="317"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
         <source>Configurable list of training devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
         <source>Configurable list of workout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
         <source>Configurable list of video files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="325"/>
         <source>Configurable list of video sync files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="327"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
         <source>Entry field for sophisticated Searching and Filtering of activities</source>
         <translation>Vstupní pole pro hledání a filtrování aktivit</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
         <source>Adding intervals to an activity using simple query methods</source>
         <translation>Přidávání intervalů k aktivitě pomocí jednoduchých dotazovacích metod</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
         <source>To compare Activities/Intervals in Activity View and Date Ranges in Trends View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="335"/>
         <source>Workout Control, Intensity Adjustments and Notifications Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
         <source>Athlete Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
         <source>Athlete Measures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
         <source>Auto Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
         <source>Backup</source>
         <translation type="unfinished">Záloha</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="355"/>
         <source>Cloud Accounts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <source>Automatic Interval Detection</source>
         <translation>Automatická detekce intervalů</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
         <source>Definition of coloring rules for activities</source>
         <translation>Definice obarvovacích pravidel pro aktivity</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
         <source>Metrics shown in &apos;Intervals&apos; and &apos;Summary&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
         <source>User/Custom Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
         <source>Create or Edit a User Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
         <source>Measures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
         <source>Train View devices configuration and preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
         <source>Train View Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
         <source>Remote Controls Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
         <source>Add/Remove Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
         <source>Add Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="394"/>
         <source>Virtual Bicycle configuration for simulation rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14904,8 +14902,8 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
     </message>
     <message>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="219"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
         <source>Calendar</source>
         <translation>Kalendář</translation>
     </message>
@@ -14940,74 +14938,74 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
         <translation>Nastavení filtru/vyhledávání a časového rozsahu pro specifický diagram</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
         <source>Definition of points in time &apos;Events&apos; which are marked explicitely on time related diagrams</source>
         <translation>Definice bodů v čase &apos;Události&apos;, které jsou explicitně označené v časových diagramech</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="316"/>
         <source>Simple summary view</source>
         <translation>Pohled jednoduché shrnutí</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
         <source>Alternative access to the charts created for the main view</source>
         <translation>Alternativní přístup k diagramům vytvořeným pro hlavní pohled</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
         <source>Display the available and add new intervals using simple query methods</source>
         <translation>Zobrazit dostupné a přidat nové intervaly za použití jednoduchých dotazovacách metod</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="356"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
         <source>General</source>
         <translation>Obecné</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="337"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
         <source>Athlete</source>
         <translation>Sportovec</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
         <source>Training Zone definition for power</source>
         <translation>Definice tréninkových zón pro výkon</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
         <source>Training Zone definition for heartrate</source>
         <translation>Definice tréninkových zón pro tepovou frekvenci</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
         <source>Training Zone definition for Swim and Run</source>
         <translation>Definice tréninkových zón pro plavání a běh</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
         <source>Appearance</source>
         <translation>Vzhled</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="364"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
         <source>Data Fields</source>
         <translation>Datová pole</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
         <source>Definition of default value(s) for data fields</source>
         <translation>Definice výchozích hodnot pro datová pole</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
         <source>Definition of processing default parameters for the fix, adjust,... tools</source>
         <translation>Definice zpracování výchozích parametrů pro opravovací, upravovací atd. nástroje</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
         <source>Metrics</source>
         <translation>Metriky</translation>
     </message>
@@ -15207,47 +15205,43 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2437"/>
         <source>Add</source>
-        <translation>Přidat</translation>
+        <translation type="vanished">Přidat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2438"/>
         <source>Delete</source>
-        <translation>Smazat</translation>
+        <translation type="vanished">Smazat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2431"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2432"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2447"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2332"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2458"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2343"/>
         <source>Short</source>
         <translation>Zkratka</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2459"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2344"/>
         <source>Long</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2460"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2345"/>
         <source>Percent of LT</source>
         <translation>Procent z LT</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2461"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2346"/>
         <source>Trimp k</source>
         <translation>Trimp k</translation>
     </message>
@@ -15256,14 +15250,14 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
         <translation type="vanished">Maximum 10 zón dosaženo.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2506"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2513"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2390"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2397"/>
         <source>New</source>
         <translation>Nový</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2508"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2515"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2392"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2399"/>
         <source>New (%1)</source>
         <translation>Nový (%1)</translation>
     </message>
@@ -15453,17 +15447,17 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2245"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2395"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2292"/>
         <source>Lactate Threshold</source>
         <translation>Laktátový práh</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2396"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2293"/>
         <source>Default</source>
         <translation>Výchozí</translation>
     </message>
@@ -17616,545 +17610,542 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
 <context>
     <name>LTMTool</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1303"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1272"/>
         <source>Metric</source>
         <translation>Metrika</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="74"/>
+        <location filename="../../Charts/LTMTool.cpp" line="75"/>
         <source>Filter</source>
         <translation>Filtr</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="80"/>
+        <location filename="../../Charts/LTMTool.cpp" line="81"/>
         <source>Date range</source>
         <translation>Časový rozsah</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="84"/>
+        <location filename="../../Charts/LTMTool.cpp" line="85"/>
         <source>Days</source>
         <translation>Dny</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="85"/>
+        <location filename="../../Charts/LTMTool.cpp" line="86"/>
         <source>Weeks</source>
         <translation>Týdny</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="86"/>
+        <location filename="../../Charts/LTMTool.cpp" line="87"/>
         <source>Months</source>
         <translation>Měsíce</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="87"/>
+        <location filename="../../Charts/LTMTool.cpp" line="88"/>
         <source>Years</source>
         <translation>Roky</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="88"/>
+        <location filename="../../Charts/LTMTool.cpp" line="89"/>
         <source>Time Of Day</source>
         <translation>Čas dne</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="89"/>
+        <location filename="../../Charts/LTMTool.cpp" line="90"/>
         <source>All</source>
         <translation>Všechny</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="91"/>
+        <location filename="../../Charts/LTMTool.cpp" line="92"/>
         <source>Group by</source>
         <translation>Seskupit podle</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="102"/>
+        <location filename="../../Charts/LTMTool.cpp" line="103"/>
         <source>Shade Zones</source>
         <translation>Stínovat zóny</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="105"/>
+        <location filename="../../Charts/LTMTool.cpp" line="106"/>
         <source>Show Legend</source>
         <translation>Zobrazit legendu</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="109"/>
         <source>Show Events</source>
         <translation>Zobrazit události</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="351"/>
+        <location filename="../../Charts/LTMTool.cpp" line="325"/>
         <source>Skiba Long Term Stress</source>
         <translation>Skiba dlouhodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="353"/>
-        <location filename="../../Charts/LTMTool.cpp" line="368"/>
-        <location filename="../../Charts/LTMTool.cpp" line="429"/>
-        <location filename="../../Charts/LTMTool.cpp" line="444"/>
-        <location filename="../../Charts/LTMTool.cpp" line="505"/>
-        <location filename="../../Charts/LTMTool.cpp" line="520"/>
-        <location filename="../../Charts/LTMTool.cpp" line="580"/>
-        <location filename="../../Charts/LTMTool.cpp" line="595"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1080"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1095"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1156"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1171"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1309"/>
+        <location filename="../../Charts/LTMTool.cpp" line="327"/>
+        <location filename="../../Charts/LTMTool.cpp" line="342"/>
+        <location filename="../../Charts/LTMTool.cpp" line="403"/>
+        <location filename="../../Charts/LTMTool.cpp" line="418"/>
+        <location filename="../../Charts/LTMTool.cpp" line="479"/>
+        <location filename="../../Charts/LTMTool.cpp" line="494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="554"/>
+        <location filename="../../Charts/LTMTool.cpp" line="569"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1054"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1069"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1130"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1145"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1278"/>
         <source>Stress</source>
         <translation>Zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="366"/>
+        <location filename="../../Charts/LTMTool.cpp" line="340"/>
         <source>Skiba Short Term Stress</source>
         <translation>Skiba krátkodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="381"/>
+        <location filename="../../Charts/LTMTool.cpp" line="355"/>
         <source>Skiba Stress Balance</source>
         <translation>Skiba bilance zátěže</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="383"/>
-        <location filename="../../Charts/LTMTool.cpp" line="459"/>
-        <location filename="../../Charts/LTMTool.cpp" line="535"/>
-        <location filename="../../Charts/LTMTool.cpp" line="610"/>
-        <location filename="../../Charts/LTMTool.cpp" line="686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="762"/>
-        <location filename="../../Charts/LTMTool.cpp" line="838"/>
-        <location filename="../../Charts/LTMTool.cpp" line="914"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1110"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1186"/>
+        <location filename="../../Charts/LTMTool.cpp" line="357"/>
+        <location filename="../../Charts/LTMTool.cpp" line="433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="509"/>
+        <location filename="../../Charts/LTMTool.cpp" line="584"/>
+        <location filename="../../Charts/LTMTool.cpp" line="660"/>
+        <location filename="../../Charts/LTMTool.cpp" line="736"/>
+        <location filename="../../Charts/LTMTool.cpp" line="812"/>
+        <location filename="../../Charts/LTMTool.cpp" line="888"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1160"/>
         <source>Stress Balance</source>
         <translation>Bilance zátěže</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="396"/>
+        <location filename="../../Charts/LTMTool.cpp" line="370"/>
         <source>Skiba STS Ramp</source>
         <translation>Skiba STS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="398"/>
-        <location filename="../../Charts/LTMTool.cpp" line="413"/>
-        <location filename="../../Charts/LTMTool.cpp" line="474"/>
-        <location filename="../../Charts/LTMTool.cpp" line="489"/>
-        <location filename="../../Charts/LTMTool.cpp" line="550"/>
-        <location filename="../../Charts/LTMTool.cpp" line="565"/>
-        <location filename="../../Charts/LTMTool.cpp" line="625"/>
-        <location filename="../../Charts/LTMTool.cpp" line="640"/>
-        <location filename="../../Charts/LTMTool.cpp" line="701"/>
-        <location filename="../../Charts/LTMTool.cpp" line="716"/>
-        <location filename="../../Charts/LTMTool.cpp" line="777"/>
-        <location filename="../../Charts/LTMTool.cpp" line="792"/>
-        <location filename="../../Charts/LTMTool.cpp" line="853"/>
-        <location filename="../../Charts/LTMTool.cpp" line="868"/>
-        <location filename="../../Charts/LTMTool.cpp" line="929"/>
-        <location filename="../../Charts/LTMTool.cpp" line="944"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1005"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1020"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1125"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1140"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1201"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1216"/>
+        <location filename="../../Charts/LTMTool.cpp" line="372"/>
+        <location filename="../../Charts/LTMTool.cpp" line="387"/>
+        <location filename="../../Charts/LTMTool.cpp" line="448"/>
+        <location filename="../../Charts/LTMTool.cpp" line="463"/>
+        <location filename="../../Charts/LTMTool.cpp" line="524"/>
+        <location filename="../../Charts/LTMTool.cpp" line="539"/>
+        <location filename="../../Charts/LTMTool.cpp" line="599"/>
+        <location filename="../../Charts/LTMTool.cpp" line="614"/>
+        <location filename="../../Charts/LTMTool.cpp" line="675"/>
+        <location filename="../../Charts/LTMTool.cpp" line="690"/>
+        <location filename="../../Charts/LTMTool.cpp" line="751"/>
+        <location filename="../../Charts/LTMTool.cpp" line="766"/>
+        <location filename="../../Charts/LTMTool.cpp" line="827"/>
+        <location filename="../../Charts/LTMTool.cpp" line="842"/>
+        <location filename="../../Charts/LTMTool.cpp" line="903"/>
+        <location filename="../../Charts/LTMTool.cpp" line="918"/>
+        <location filename="../../Charts/LTMTool.cpp" line="979"/>
+        <location filename="../../Charts/LTMTool.cpp" line="994"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1099"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1114"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1175"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1190"/>
         <source>Ramp</source>
         <translation>Rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="411"/>
+        <location filename="../../Charts/LTMTool.cpp" line="385"/>
         <source>Skiba LTS Ramp</source>
         <translation>Skiba LTS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="427"/>
+        <location filename="../../Charts/LTMTool.cpp" line="401"/>
         <source>Aerobic TISS Long Term Stress</source>
         <translation>Aerobní TISS dlouhodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="442"/>
+        <location filename="../../Charts/LTMTool.cpp" line="416"/>
         <source>Aerobic TISS Short Term Stress</source>
         <translation>Aerobní TISS krátkodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="457"/>
+        <location filename="../../Charts/LTMTool.cpp" line="431"/>
         <source>Aerobic TISS Stress Balance</source>
         <translation>Aerobní TISS bilance zátěže</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="472"/>
+        <location filename="../../Charts/LTMTool.cpp" line="446"/>
         <source>Aerobic TISS STS Ramp</source>
         <translation>Aerobní TISS STS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="487"/>
+        <location filename="../../Charts/LTMTool.cpp" line="461"/>
         <source>Aerobic TISS LTS Ramp</source>
         <translation>Aerobní TISS LTS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="503"/>
+        <location filename="../../Charts/LTMTool.cpp" line="477"/>
         <source>Anaerobic TISS Long Term Stress</source>
         <translation>Anaerobní TISS dlouhodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="518"/>
+        <location filename="../../Charts/LTMTool.cpp" line="492"/>
         <source>Anaerobic TISS Short Term Stress</source>
         <translation>Anaerobní TISS krátkodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="533"/>
+        <location filename="../../Charts/LTMTool.cpp" line="507"/>
         <source>Anaerobic TISS Stress Balance</source>
         <translation>Anaerobní TISS bilance zátěže</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="548"/>
+        <location filename="../../Charts/LTMTool.cpp" line="522"/>
         <source>Anaerobic TISS STS Ramp</source>
         <translation>Anaerobní TISS STS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="537"/>
         <source>Anaerobic TISS LTS Ramp</source>
         <translation>Anaerobní TISS LTS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="578"/>
+        <location filename="../../Charts/LTMTool.cpp" line="552"/>
         <source>Daniels Long Term Stress</source>
         <translation>Danielsova dlouhodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="593"/>
+        <location filename="../../Charts/LTMTool.cpp" line="567"/>
         <source>Daniels Short Term Stress</source>
         <translation>Danielsova krátkodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="582"/>
         <source>Daniels Stress Balance</source>
         <translation>Danielsova bilance zátěže</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="623"/>
+        <location filename="../../Charts/LTMTool.cpp" line="597"/>
         <source>Daniels STS Ramp</source>
         <translation>Danielsova STS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="638"/>
+        <location filename="../../Charts/LTMTool.cpp" line="612"/>
         <source>Daniels LTS Ramp</source>
         <translation>Danielsova LTS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="628"/>
         <source>Work (Kj) Long Term Stress</source>
         <translation>Práce (kJ) dlouhodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="656"/>
-        <location filename="../../Charts/LTMTool.cpp" line="671"/>
-        <location filename="../../Charts/LTMTool.cpp" line="732"/>
-        <location filename="../../Charts/LTMTool.cpp" line="747"/>
-        <location filename="../../Charts/LTMTool.cpp" line="808"/>
-        <location filename="../../Charts/LTMTool.cpp" line="823"/>
+        <location filename="../../Charts/LTMTool.cpp" line="630"/>
+        <location filename="../../Charts/LTMTool.cpp" line="645"/>
+        <location filename="../../Charts/LTMTool.cpp" line="706"/>
+        <location filename="../../Charts/LTMTool.cpp" line="721"/>
+        <location filename="../../Charts/LTMTool.cpp" line="782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="797"/>
         <source>Stress (Kj)</source>
         <translation>Zátěž (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="669"/>
+        <location filename="../../Charts/LTMTool.cpp" line="643"/>
         <source>Work (Kj) Short Term Stress</source>
         <translation>Práce (kJ) krátkodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="684"/>
+        <location filename="../../Charts/LTMTool.cpp" line="658"/>
         <source>Work (Kj) Stress Balance</source>
         <translation>Práce (kJ) bilance zátěže</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="699"/>
+        <location filename="../../Charts/LTMTool.cpp" line="673"/>
         <source>Work (Kj) STS Ramp</source>
         <translation>Práce (kJ) STS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="714"/>
+        <location filename="../../Charts/LTMTool.cpp" line="688"/>
         <source>Work (Kj) LTS Ramp</source>
         <translation>Práce (kJ) LTS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="730"/>
+        <location filename="../../Charts/LTMTool.cpp" line="704"/>
         <source>W&apos; Work (Kj) Long Term Stress</source>
         <translation>W&apos; Práce (kJ) dlouhodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="745"/>
+        <location filename="../../Charts/LTMTool.cpp" line="719"/>
         <source>W&apos; Work (Kj) Short Term Stress</source>
         <translation>W&apos; Práce (kJ) krátkodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="760"/>
+        <location filename="../../Charts/LTMTool.cpp" line="734"/>
         <source>W&apos; Work (Kj) Stress Balance</source>
         <translation>W&apos; Práce (kJ) bilance zátěže</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="775"/>
+        <location filename="../../Charts/LTMTool.cpp" line="749"/>
         <source>W&apos; Work (Kj) STS Ramp</source>
         <translation>W&apos; Práce (kJ) STS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="790"/>
+        <location filename="../../Charts/LTMTool.cpp" line="764"/>
         <source>W&apos; Work (Kj) LTS Ramp</source>
         <translation>W&apos; Práce (kJ) LTS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="806"/>
+        <location filename="../../Charts/LTMTool.cpp" line="780"/>
         <source>Below CP Work (Kj) Long Term Stress</source>
         <translation>Práce pod CP (kJ) dlouhodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="821"/>
+        <location filename="../../Charts/LTMTool.cpp" line="795"/>
         <source>Below CP Work (Kj) Short Term Stress</source>
         <translation>Práce pod CP (kJ) krátkodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="836"/>
+        <location filename="../../Charts/LTMTool.cpp" line="810"/>
         <source>Below CP Work (Kj) Stress Balance</source>
         <translation>Práce pod CP (kJ) bilance zátěže</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="851"/>
+        <location filename="../../Charts/LTMTool.cpp" line="825"/>
         <source>Below CP Work (Kj) STS Ramp</source>
         <translation>Práce pod CP (kJ) STS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="866"/>
+        <location filename="../../Charts/LTMTool.cpp" line="840"/>
         <source>Below CP Work (Kj) LTS Ramp</source>
         <translation>Práce pod CP (kJ) LTS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="882"/>
+        <location filename="../../Charts/LTMTool.cpp" line="856"/>
         <source>Distance (km|mi) Long Term Stress</source>
         <translation>Vzdálenost (km|mi) dlouhodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="884"/>
-        <location filename="../../Charts/LTMTool.cpp" line="899"/>
+        <location filename="../../Charts/LTMTool.cpp" line="858"/>
+        <location filename="../../Charts/LTMTool.cpp" line="873"/>
         <source>Stress (km|mi)</source>
         <translation>Zátěž (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="897"/>
+        <location filename="../../Charts/LTMTool.cpp" line="871"/>
         <source>Distance (km|mi) Short Term Stress</source>
         <translation>Vzdálenost (km|mi) krátkodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="912"/>
+        <location filename="../../Charts/LTMTool.cpp" line="886"/>
         <source>Distance (km|mi) Stress Balance</source>
         <translation>Vzdálenost (km|mi) bilance zátěže</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="927"/>
+        <location filename="../../Charts/LTMTool.cpp" line="901"/>
         <source>Distance (km|mi) STS Ramp</source>
         <translation>Vzdálenost (km|mi) STS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="942"/>
+        <location filename="../../Charts/LTMTool.cpp" line="916"/>
         <source>Distance (km|mi) LTS Ramp</source>
         <translation>Vzdálenost (km|mi) LTS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="958"/>
+        <location filename="../../Charts/LTMTool.cpp" line="932"/>
         <source>Coggan Chronic Training Load</source>
         <translation>Cogganova chronická tréninková zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="973"/>
+        <location filename="../../Charts/LTMTool.cpp" line="947"/>
         <source>Coggan Acute Training Load</source>
         <translation>Cogganova akutní tréninková zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="988"/>
+        <location filename="../../Charts/LTMTool.cpp" line="962"/>
         <source>Coggan Training Stress Balance</source>
         <translation>Cogganova bilance tréninkové zátěže</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1003"/>
+        <location filename="../../Charts/LTMTool.cpp" line="977"/>
         <source>Coggan STS Ramp</source>
         <translation>Cogganova STS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1018"/>
+        <location filename="../../Charts/LTMTool.cpp" line="992"/>
         <source>Coggan LTS Ramp</source>
         <translation>Cogganova LTS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1033"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1007"/>
         <source>Coggan Expected Chronic Training Load</source>
         <translation>Cogganova očekávaná chronická tréninková zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1048"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1022"/>
         <source>Coggan Expected Acute Training Load</source>
         <translation>Cogganova očekávaná akutní tréninková zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1063"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1037"/>
         <source>Coggan Expected Training Stress Balance</source>
         <translation>Cogganova očekávaná bilance tréninkové zátěže</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1053"/>
         <source>TRIMP Long Term Stress</source>
         <translation>TRIMP dlouhodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1067"/>
         <source>TRIMP Short Term Stress</source>
         <translation>TRIMP krátkodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1082"/>
         <source>TRIMP Stress Balance</source>
         <translation>TRIMP bilance zátěže</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1123"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1097"/>
         <source>TRIMP STS Ramp</source>
         <translation>TRIMP STS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1138"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1112"/>
         <source>TRIMP LTS Ramp</source>
         <translation>TRIMP LTS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="268"/>
         <source>Edit</source>
-        <translation>Upravit</translation>
+        <translation type="vanished">Upravit</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="124"/>
+        <location filename="../../Charts/LTMTool.cpp" line="125"/>
         <source>Use sidebar chart settings</source>
         <translation>Použít nastavení postranního digramu</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Basic</source>
         <translation>Obecné</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="314"/>
+        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Preset</source>
         <translation>Přednastavení</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1307"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1276"/>
         <source>Estimate</source>
         <translation>Odhad</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1311"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1280"/>
         <source>Formula</source>
         <translation>Formule</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1282"/>
         <source>Measure</source>
         <translation>Míra</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1284"/>
         <source>Performance</source>
         <translation>Výkon</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1317"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1286"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1463"/>
         <source>Chart %1</source>
         <translation>Diagram %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="94"/>
+        <location filename="../../Charts/LTMTool.cpp" line="95"/>
         <source>Data Table</source>
         <translation>Datová tabulka</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="98"/>
+        <location filename="../../Charts/LTMTool.cpp" line="99"/>
         <source>Show Stack</source>
         <translation>Zobrazit nad sebou</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="121"/>
+        <location filename="../../Charts/LTMTool.cpp" line="122"/>
         <source>Stack Zoom</source>
         <translation>Přiblížení rozdělení</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="155"/>
+        <location filename="../../Charts/LTMTool.cpp" line="156"/>
         <source>Add Current</source>
         <translation>Přidat aktuální</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="146"/>
+        <location filename="../../Charts/LTMTool.cpp" line="147"/>
         <source>Charts</source>
         <translation>Diagramy</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="112"/>
         <source>Show Banister Helper</source>
         <translation>Zobrazit nápovědu pro banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="155"/>
         <source>Apply</source>
         <translation>Použít</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Up</source>
-        <translation>Nahoru</translation>
+        <translation type="vanished">Nahoru</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Down</source>
-        <translation>Dolů</translation>
+        <translation type="vanished">Dolů</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="289"/>
         <source>Curves</source>
         <translation>Křivky</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1128"/>
         <source>TriScore Long Term Stress</source>
         <translation>TriScore dlouhodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1169"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1143"/>
         <source>TriScore Short Term Stress</source>
         <translation>TriScore krátkodobá zátěž</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1184"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1158"/>
         <source>TriScore Stress Balance</source>
         <translation>TriScore bilance zátěže</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1173"/>
         <source>TriScore STS Ramp</source>
         <translation>TriScore STS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1214"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1188"/>
         <source>TriScore LTS Ramp</source>
         <translation>TriScore LTS rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Details</source>
         <translation>Detaily</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1305"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1274"/>
         <source>Peak</source>
         <translation>Spička</translation>
     </message>
@@ -18357,31 +18348,23 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
         <translation type="vanished">Aktualizovat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2590"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2602"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2591"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2603"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2596"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2608"/>
         <source>Add</source>
-        <translation>Přidat</translation>
+        <translation type="vanished">Přidat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2597"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2609"/>
         <source>Delete</source>
-        <translation>Smazat</translation>
+        <translation type="vanished">Smazat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2599"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2467"/>
         <source>Def</source>
         <translation>Výchozí</translation>
     </message>
@@ -18390,14 +18373,14 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
         <translation type="vanished">Od data</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2651"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2790"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2494"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2631"/>
         <source>Lactate Threshold</source>
         <translation>Laktátový práh</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2652"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2791"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2495"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2632"/>
         <source>Aerobic Threshold</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18406,45 +18389,45 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
         <translation type="vanished">Maximum 10 zón dosaženo.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2967"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2974"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2804"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2811"/>
         <source>New</source>
         <translation>Nový</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2969"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2976"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2806"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2813"/>
         <source>New (%1)</source>
         <translation>Nový (%1)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2653"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2496"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
         <source>Rest HR</source>
         <translation>Klidový tep</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2628"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2690"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2770"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2775"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2780"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2785"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2473"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2478"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2488"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2611"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2621"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2626"/>
         <source>bpm</source>
         <translation type="unfinished">tep/m</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2650"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2493"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2630"/>
         <source>Start Date</source>
         <translation type="unfinished">Datum začátkku</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2654"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2497"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2634"/>
         <source>Max HR</source>
         <translation>Maximální tep</translation>
     </message>
@@ -18453,22 +18436,22 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
         <translation type="vanished">MMM d, yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2701"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2544"/>
         <source>Short</source>
         <translation>Zkratka</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2702"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2545"/>
         <source>Long</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2703"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2546"/>
         <source>From BPM</source>
         <translation>Od bpm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2704"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2547"/>
         <source>Trimp k</source>
         <translation>Trimp k</translation>
     </message>
@@ -19209,62 +19192,62 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
 <context>
     <name>Library</name>
     <message>
+        <location filename="../../Train/Library.cpp" line="126"/>
         <location filename="../../Train/Library.cpp" line="130"/>
-        <location filename="../../Train/Library.cpp" line="134"/>
         <source>Import Videos, VideoSyncs and Workouts</source>
         <translation>Importovat videa, synchronizovaná videa a cvičení</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="127"/>
         <location filename="../../Train/Library.cpp" line="131"/>
-        <location filename="../../Train/Library.cpp" line="135"/>
         <source>No supported videos, videoSyncs or workouts were found to import</source>
         <translation>Žádná podporovaná videa, synchronizovaná videa nebo cvičení nebyla nalezena pro import</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="189"/>
         <location filename="../../Train/Library.cpp" line="193"/>
-        <location filename="../../Train/Library.cpp" line="197"/>
+        <location filename="../../Train/Library.cpp" line="198"/>
         <location filename="../../Train/Library.cpp" line="202"/>
-        <location filename="../../Train/Library.cpp" line="206"/>
         <source>Copy VideoSync Failed</source>
         <translation>Kopírování synchronizovaných videí selhalo</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="190"/>
         <location filename="../../Train/Library.cpp" line="194"/>
-        <location filename="../../Train/Library.cpp" line="198"/>
         <source>%1 already exists in videoSync library: %2</source>
         <translation>%1 už existuje ve videoSync knihovně: %2</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="203"/>
+        <location filename="../../Train/Library.cpp" line="199"/>
         <source>%1 cannot be written to videoSync library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="207"/>
+        <location filename="../../Train/Library.cpp" line="203"/>
         <source>%1 cannot be written to videoSync library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="253"/>
+        <location filename="../../Train/Library.cpp" line="249"/>
         <source>%1 cannot be written to workout library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="257"/>
+        <location filename="../../Train/Library.cpp" line="253"/>
         <source>%1 cannot be written to workout library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="239"/>
         <location filename="../../Train/Library.cpp" line="243"/>
-        <location filename="../../Train/Library.cpp" line="247"/>
+        <location filename="../../Train/Library.cpp" line="248"/>
         <location filename="../../Train/Library.cpp" line="252"/>
-        <location filename="../../Train/Library.cpp" line="256"/>
         <source>Copy Workout Failed</source>
         <translation>Kopírování cvičení selhalo</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="240"/>
         <location filename="../../Train/Library.cpp" line="244"/>
-        <location filename="../../Train/Library.cpp" line="248"/>
         <source>%1 already exists in workout library: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19272,89 +19255,89 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
 <context>
     <name>LibrarySearchDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="330"/>
+        <location filename="../../Train/Library.cpp" line="326"/>
         <source>Search for Workouts, Syncs and Media</source>
         <translation>Hledat cvičení, synchronizace a média</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="337"/>
+        <location filename="../../Train/Library.cpp" line="333"/>
         <source>Workout files (.erg, .mrc, .zwo etc)</source>
         <translation>Soubory cvičení (.erg, .mrc, .zwo atd.)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="339"/>
+        <location filename="../../Train/Library.cpp" line="335"/>
         <source>Video files (.mp4, .avi etc)</source>
         <translation>Video soubory (.mp4, .avi atd.)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="341"/>
+        <location filename="../../Train/Library.cpp" line="337"/>
         <source>VideoSync files (.rlv, .tts etc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="359"/>
+        <location filename="../../Train/Library.cpp" line="353"/>
         <source>Search Path</source>
         <translation>Hledat v</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="379"/>
+        <location filename="../../Train/Library.cpp" line="373"/>
         <source>Video references</source>
         <translation>Video reference</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="391"/>
+        <location filename="../../Train/Library.cpp" line="385"/>
         <source>Searching...</source>
         <translation>Hledání...</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="394"/>
+        <location filename="../../Train/Library.cpp" line="388"/>
         <source>Videos</source>
         <translation>Videa</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="396"/>
+        <location filename="../../Train/Library.cpp" line="390"/>
         <source>Workouts</source>
         <translation>Cvičení</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="398"/>
+        <location filename="../../Train/Library.cpp" line="392"/>
         <source>VideoSyncs</source>
         <translation>VideoSyncs</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="407"/>
-        <location filename="../../Train/Library.cpp" line="494"/>
+        <location filename="../../Train/Library.cpp" line="401"/>
+        <location filename="../../Train/Library.cpp" line="484"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="409"/>
+        <location filename="../../Train/Library.cpp" line="403"/>
         <source>Search</source>
         <translation>Hledat</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="412"/>
+        <location filename="../../Train/Library.cpp" line="406"/>
         <source>Files to search for:</source>
         <translation>Hledat soubory:</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="475"/>
+        <location filename="../../Train/Library.cpp" line="466"/>
         <source>Abort Search</source>
         <translation>Zrušit hledání</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="515"/>
-        <location filename="../../Train/Library.cpp" line="559"/>
+        <location filename="../../Train/Library.cpp" line="504"/>
+        <location filename="../../Train/Library.cpp" line="548"/>
         <source>Save</source>
         <translation>Uložit</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="557"/>
+        <location filename="../../Train/Library.cpp" line="546"/>
         <source>Search completed.</source>
         <translation>Hledání dokončeno.</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="645"/>
+        <location filename="../../Train/Library.cpp" line="634"/>
         <source>Select Directory</source>
         <translation>Zvolený adresář</translation>
     </message>
@@ -19362,12 +19345,12 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
 <context>
     <name>ListEditWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="623"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="654"/>
         <source>New</source>
         <translation type="unfinished">Nový</translation>
     </message>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="625"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="656"/>
         <source>New (%1)</source>
         <translation type="unfinished">Nový (%1)</translation>
     </message>
@@ -19380,7 +19363,12 @@ Nastavení kroutivého momentu - definuje absolutní hodnotu v psi nebo Nm, o kt
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="90"/>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="85"/>
+        <source>Initial Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="98"/>
         <source>Apply changes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19600,7 +19588,7 @@ zapnutá a display ukazuje &quot;PC Link&quot;</translation>
         <translation>Zobrazit postranní lištu</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>Delete Activity</source>
         <translation>Smazat aktivitu</translation>
     </message>
@@ -19762,90 +19750,90 @@ zapnutá a display ukazuje &quot;PC Link&quot;</translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Activity Import</source>
         <translation>Import aktivity</translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Closing of athlete window not possible while background activity import is in progress...</source>
         <translation>Nelze zavřít okno sportovce, když na pozadí probíhá import aktivit...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Chart Import</source>
         <translation>Import diagramu</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>Import Images Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>You can only import images on the activities view with an activity selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>Import Images to Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>%1 images imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1778"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1788"/>
         <source>Failed to export activity, please check permissions</source>
         <translation>Export aktivity selhal, prosím zkontrolujte oprávnění</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1814"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1824"/>
         <source>No Activity To Save</source>
         <translation>Žádná aktivita k uložení</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1815"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1825"/>
         <source>There is no currently selected activity to save.</source>
         <translation>Není zvolena žádná aktivita k uložení.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
         <location filename="../../Gui/MainWindow.cpp" line="1886"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Split Activity</source>
         <translation>Rozdělit aktivitu</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
         <source>No activity selected</source>
         <translation>Není zvolena aktivita</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
         <source>Current activity contains no data to split</source>
         <translation>Aktuální aktivita neobsahuje žádná data k rozdělení</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Current activity contains no data to merge</source>
         <translation>Aktuální aktivita neobsahuje žádná data ke spojení</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1904"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1914"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation>Opravdu chcete smazat tuto aktivitu:</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2400"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2421"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2410"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2431"/>
         <source>The workout directory is not configured, or the directory selected no longer exists.
 
 Please check your preference settings.</source>
@@ -19854,19 +19842,19 @@ Please check your preference settings.</source>
 Prosím zkontrolujte vaše nastavení.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2611"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2621"/>
         <source>Loading activities: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>CloudDB</source>
         <translation>CloudDB</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>Current athlete is not registered as curator - please contact the GoldenCheetah team</source>
         <translation>Aktuální sportovec není registrovaný kurátor - prosím kontaktujte GoldenCheetah tým</translation>
     </message>
@@ -19951,12 +19939,12 @@ Prosím zkontrolujte vaše nastavení.</translation>
         <translation>Chcete pokračovat?</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Imported %1 metric charts</source>
         <translation>Importováno %1 diagramů metrik</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2165"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2175"/>
         <source>&amp;New Athlete...</source>
         <translation>&amp;Nový sportovec...</translation>
     </message>
@@ -19976,23 +19964,23 @@ Prosím zkontrolujte vaše nastavení.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
         <source>Select Activity</source>
         <translation>Zvolit aktivitu</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>No activity selected!</source>
         <translation>Nebyla zvolena aktivita!</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1724"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1734"/>
         <source>Export Activity</source>
         <translation>Exportovat aktivitu</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1777"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1787"/>
         <source>Export Failed</source>
         <translation>Export selhal</translation>
     </message>
@@ -20249,34 +20237,34 @@ Prosím zkontrolujte vaše nastavení.</translation>
         <translation>O aplikaci &amp;GoldenCheetah</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1799"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2369"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1809"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2379"/>
         <source>Import from File</source>
         <translation>Importovat ze souboru</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2342"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2352"/>
         <source>Refresh in Progress</source>
         <translation>Obnovení probíhá</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Export Metrics</source>
         <translation>Exportovat metriky</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation>Formát CSV (*.csv)</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2399"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2420"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2409"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2430"/>
         <source>Workout Directory Invalid</source>
         <translation>Adresář pro cvičení není validní</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1906"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1916"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
@@ -21184,23 +21172,23 @@ Prosím zkontrolujte vaše nastavení.</translation>
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="656"/>
+        <location filename="../../Gui/AthletePages.cpp" line="641"/>
         <source>From Date - Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="780"/>
+        <location filename="../../Gui/AthletePages.cpp" line="751"/>
         <source>Start Date</source>
         <translation type="unfinished">Datum začátkku</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="893"/>
+        <location filename="../../Gui/AthletePages.cpp" line="864"/>
         <source>MMM d, yyyy - hh:mm:ss</source>
         <translation type="unfinished">MMM d, yyyy - hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="659"/>
-        <location filename="../../Gui/AthletePages.cpp" line="807"/>
+        <location filename="../../Gui/AthletePages.cpp" line="644"/>
+        <location filename="../../Gui/AthletePages.cpp" line="778"/>
         <source>Comment</source>
         <translation type="unfinished">Poznámka</translation>
     </message>
@@ -21209,32 +21197,24 @@ Prosím zkontrolujte vaše nastavení.</translation>
         <translation type="obsolete">Aktualizovat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="662"/>
         <source>+</source>
-        <translation type="unfinished">+</translation>
+        <translation type="obsolete">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="663"/>
         <source>-</source>
-        <translation type="unfinished">-</translation>
+        <translation type="obsolete">-</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="obsolete">Přidat</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="668"/>
-        <source>Add</source>
-        <translation type="unfinished">Přidat</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="669"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="698"/>
         <source>Source</source>
         <translation type="unfinished">Zdroj</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="699"/>
+        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Original Source</source>
         <translation type="unfinished">Původní zdroj</translation>
     </message>
@@ -21927,17 +21907,17 @@ Nebyly nalezeny žádné jízdy k importu.
 <context>
     <name>MultiDeviceDialog</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3048"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3060"/>
         <source>Multiple Device Configuration</source>
         <translation>Konfigurace s více zařízeními</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3103"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3115"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušit</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3106"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3118"/>
         <source>Apply</source>
         <translation type="unfinished">Použít</translation>
     </message>
@@ -22950,42 +22930,38 @@ Nebyly nalezeny žádné jízdy k importu.
 <context>
     <name>PaceSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3154"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3155"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3160"/>
         <source>Add</source>
-        <translation>Přidat</translation>
+        <translation type="vanished">Přidat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3161"/>
         <source>Delete</source>
-        <translation>Smazat</translation>
+        <translation type="vanished">Smazat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3176"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2987"/>
         <source>Short</source>
         <translation>Krátký</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3177"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2988"/>
         <source>Long</source>
         <translation>Dlouhý</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3178"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2989"/>
         <source>Percent of CV</source>
         <translation>Procento z CP</translation>
     </message>
@@ -22994,14 +22970,14 @@ Nebyly nalezeny žádné jízdy k importu.
         <translation type="vanished">Maximum 10 zón dosaženo.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3220"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3227"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3037"/>
         <source>New</source>
         <translation>Nový</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3222"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3229"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3032"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3039"/>
         <source>New (%1)</source>
         <translation>Nový (%1)</translation>
     </message>
@@ -23201,27 +23177,27 @@ Nebyly nalezeny žádné jízdy k importu.
 <context>
     <name>PaceZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3082"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2905"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3084"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2907"/>
         <source>Run</source>
         <translation>Běh</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3085"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2908"/>
         <source>Swim</source>
         <translation>Plavání</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3126"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2949"/>
         <source>Critical Velocity</source>
         <translation>Kritická rychlost</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2950"/>
         <source>Default</source>
         <translation>Výchozí</translation>
     </message>
@@ -25370,78 +25346,71 @@ Chcete pokračovat?</translation>
 <context>
     <name>PerspectiveDialog</name>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="34"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="35"/>
         <source>Manage Perspectives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="43"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="44"/>
         <source>Perspectives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="60"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="61"/>
         <source>Charts</source>
         <translation type="unfinished">Diagramy</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Edit</source>
-        <translation type="unfinished">Upravit</translation>
+        <translation type="obsolete">Upravit</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="83"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="78"/>
         <source>Import</source>
         <translation type="unfinished">Import</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="84"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="77"/>
         <source>Export</source>
         <translation type="unfinished">Export</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="90"/>
         <source>Add</source>
-        <translation type="unfinished">Přidat</translation>
+        <translation type="obsolete">Přidat</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="91"/>
-        <source>Delete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="98"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Drag charts to move to a perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="287"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="256"/>
         <source>Export Persepctive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
         <source>Export Perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>No perspective file selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
-        <source>Select Perspective file to export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
         <source>GoldenCheetah Perspective Files (*.gchartset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
+        <source>Select Perspective file to import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>Import Perspective</source>
         <translation type="unfinished"></translation>
     </message>
@@ -26601,307 +26570,307 @@ Python vypnutý v nastavení.</translation>
 <context>
     <name>RealtimeData</name>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="621"/>
+        <location filename="../../Train/RealtimeData.cpp" line="623"/>
         <source>None</source>
         <translation>Žádný</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="624"/>
+        <location filename="../../Train/RealtimeData.cpp" line="626"/>
         <source>Time</source>
         <translation>Čas</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="627"/>
+        <location filename="../../Train/RealtimeData.cpp" line="629"/>
         <source>Lap</source>
         <translation>Úsek</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="630"/>
+        <location filename="../../Train/RealtimeData.cpp" line="632"/>
         <source>Lap Time</source>
         <translation>Čas úseku</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="633"/>
+        <location filename="../../Train/RealtimeData.cpp" line="635"/>
         <source>Lap Time Remaining</source>
         <translation>Zbývající čas úseku</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="636"/>
+        <location filename="../../Train/RealtimeData.cpp" line="638"/>
         <source>Section Time Remaining</source>
         <translation>Zbývající čas sekce</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="639"/>
+        <location filename="../../Train/RealtimeData.cpp" line="641"/>
         <source>BikeStress</source>
         <translation>BikeStress</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="645"/>
+        <location filename="../../Train/RealtimeData.cpp" line="647"/>
         <source>kJoules</source>
         <translation>kJoules</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="648"/>
+        <location filename="../../Train/RealtimeData.cpp" line="650"/>
         <source>W&apos; bal</source>
         <translation>W&apos; poměr</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="651"/>
+        <location filename="../../Train/RealtimeData.cpp" line="653"/>
         <source>XPower</source>
         <translation>XVýkon</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="654"/>
+        <location filename="../../Train/RealtimeData.cpp" line="656"/>
         <source>Iso Power</source>
         <translation>IsoVýkon</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="657"/>
+        <location filename="../../Train/RealtimeData.cpp" line="659"/>
         <source>Intensity Factor</source>
         <translation>Faktor intenzity</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="660"/>
+        <location filename="../../Train/RealtimeData.cpp" line="662"/>
         <source>Relative Intensity</source>
         <translation>Relativní intenzita</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="663"/>
+        <location filename="../../Train/RealtimeData.cpp" line="665"/>
         <source>Skiba Variability Index</source>
         <translation>Skiba index variability</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="666"/>
+        <location filename="../../Train/RealtimeData.cpp" line="668"/>
         <source>Variability Index</source>
         <translation>Index variability</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="669"/>
+        <location filename="../../Train/RealtimeData.cpp" line="671"/>
         <source>Distance</source>
         <translation>Vzdálenost</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="672"/>
+        <location filename="../../Train/RealtimeData.cpp" line="674"/>
         <source>Route Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="675"/>
+        <location filename="../../Train/RealtimeData.cpp" line="677"/>
         <source>Distance Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="678"/>
+        <location filename="../../Train/RealtimeData.cpp" line="680"/>
         <source>Alternate Power</source>
         <translation>Alternativní výkon</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="681"/>
+        <location filename="../../Train/RealtimeData.cpp" line="683"/>
         <source>Power</source>
         <translation>Výkon</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="684"/>
+        <location filename="../../Train/RealtimeData.cpp" line="686"/>
         <source>Speed</source>
         <translation>Rychlost</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="687"/>
+        <location filename="../../Train/RealtimeData.cpp" line="689"/>
         <source>Virtual Speed</source>
         <translation>Virtuální rychlost</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="690"/>
+        <location filename="../../Train/RealtimeData.cpp" line="692"/>
         <source>Cadence</source>
         <translation>Kadence</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="693"/>
+        <location filename="../../Train/RealtimeData.cpp" line="695"/>
         <source>Heart Rate</source>
         <translation>Tepová frekvence</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="696"/>
+        <location filename="../../Train/RealtimeData.cpp" line="698"/>
         <source>Target Power</source>
         <translation>Cílový výkon</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="699"/>
+        <location filename="../../Train/RealtimeData.cpp" line="701"/>
         <source>Average Power</source>
         <translation>Průměrný výkon</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="702"/>
+        <location filename="../../Train/RealtimeData.cpp" line="704"/>
         <source>Average Speed</source>
         <translation>Průměrná rychlost</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="705"/>
+        <location filename="../../Train/RealtimeData.cpp" line="707"/>
         <source>Average Heartrate</source>
         <translation>Průměrná tepová frekvence</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="708"/>
+        <location filename="../../Train/RealtimeData.cpp" line="710"/>
         <source>Average Cadence</source>
         <translation>Průměrná kadence</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="711"/>
+        <location filename="../../Train/RealtimeData.cpp" line="713"/>
         <source>Lap Power</source>
         <translation>Výkon na úseku</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="714"/>
+        <location filename="../../Train/RealtimeData.cpp" line="716"/>
         <source>Lap Speed</source>
         <translation>Rychlost na úseku</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="717"/>
+        <location filename="../../Train/RealtimeData.cpp" line="719"/>
         <source>Lap Heartrate</source>
         <translation>TF na úseku</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="720"/>
+        <location filename="../../Train/RealtimeData.cpp" line="722"/>
         <source>Lap Cadence</source>
         <translation>Kadence na úseku</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="723"/>
+        <location filename="../../Train/RealtimeData.cpp" line="725"/>
         <source>Left/Right Balance</source>
         <translation>Levá/pravá poměr</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="726"/>
+        <location filename="../../Train/RealtimeData.cpp" line="728"/>
         <source>Total Hb Mass</source>
         <translation>Celková Hb hmotnost</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="729"/>
+        <location filename="../../Train/RealtimeData.cpp" line="731"/>
         <source>Hb O2 Saturation</source>
         <translation>Hb O2 Saturace</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="732"/>
+        <location filename="../../Train/RealtimeData.cpp" line="734"/>
         <source>Deoxy Hb</source>
         <translation>Deoxy Hb</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="735"/>
+        <location filename="../../Train/RealtimeData.cpp" line="737"/>
         <source>Oxy Hb</source>
         <translation>Oxy Hb</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="738"/>
+        <location filename="../../Train/RealtimeData.cpp" line="740"/>
         <source>Left Torque Effectiveness</source>
         <translation>Levá efektivita šlapání</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="741"/>
+        <location filename="../../Train/RealtimeData.cpp" line="743"/>
         <source>Right Torque Effectiveness</source>
         <translation>Pravá efektivita šlapání</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="744"/>
+        <location filename="../../Train/RealtimeData.cpp" line="746"/>
         <source>Left Pedal Smoothness</source>
         <translation>Levá plynulost šlapání</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="747"/>
+        <location filename="../../Train/RealtimeData.cpp" line="749"/>
         <source>Right Pedal Smoothness</source>
         <translation>Pravá plynulost šlapání</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="750"/>
+        <location filename="../../Train/RealtimeData.cpp" line="752"/>
         <source>Right Power Phase Start</source>
         <translation type="unfinished">Pravá fáze výkonu začátek</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="753"/>
+        <location filename="../../Train/RealtimeData.cpp" line="755"/>
         <source>Right Power Phase End</source>
         <translation type="unfinished">Pravá fáze výkonu konec</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="756"/>
+        <location filename="../../Train/RealtimeData.cpp" line="758"/>
         <source>Right Power Phase Peak Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="759"/>
+        <location filename="../../Train/RealtimeData.cpp" line="761"/>
         <source>Right Power Phase Peak End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="762"/>
+        <location filename="../../Train/RealtimeData.cpp" line="764"/>
         <source>Slope</source>
         <translation>Sklon</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="765"/>
+        <location filename="../../Train/RealtimeData.cpp" line="767"/>
         <source>Lap Distance</source>
         <translation>Vzdálenost úseku</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="768"/>
+        <location filename="../../Train/RealtimeData.cpp" line="770"/>
         <source>Lap Distance Remaining</source>
         <translation>Zbývající vzdálenost úseku</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="771"/>
+        <location filename="../../Train/RealtimeData.cpp" line="773"/>
         <source>Latitude</source>
         <translation>Zeměpisná šířka</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="774"/>
+        <location filename="../../Train/RealtimeData.cpp" line="776"/>
         <source>Longitude</source>
         <translation>Zeměpisná délka</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="777"/>
+        <location filename="../../Train/RealtimeData.cpp" line="779"/>
         <source>Altitude</source>
         <translation>Nadmořská výška</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="780"/>
+        <location filename="../../Train/RealtimeData.cpp" line="782"/>
         <source>Respiratory Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="783"/>
+        <location filename="../../Train/RealtimeData.cpp" line="785"/>
         <source>Ventilation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="786"/>
+        <location filename="../../Train/RealtimeData.cpp" line="788"/>
         <source>VO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="789"/>
+        <location filename="../../Train/RealtimeData.cpp" line="791"/>
         <source>VCO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="792"/>
+        <location filename="../../Train/RealtimeData.cpp" line="794"/>
         <source>Respiratory Exchange Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="795"/>
+        <location filename="../../Train/RealtimeData.cpp" line="797"/>
         <source>Tidal Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="798"/>
+        <location filename="../../Train/RealtimeData.cpp" line="800"/>
         <source>Fraction O2 Expired</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="801"/>
+        <location filename="../../Train/RealtimeData.cpp" line="803"/>
         <source>Temperature</source>
         <translation type="unfinished">Teplota</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="804"/>
+        <location filename="../../Train/RealtimeData.cpp" line="806"/>
         <source>CoreTemp</source>
         <translation type="unfinished"></translation>
     </message>
@@ -26997,22 +26966,22 @@ Python vypnutý v nastavení.</translation>
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Series</source>
         <translation>Série</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="172"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
         <source>Power</source>
         <translation>Výkon</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="176"/>
         <source>Heart Rate</source>
         <translation>Tepová frekvence</translation>
     </message>
@@ -29313,317 +29282,317 @@ GoldenCheetah. Chcete pokračovat v převodu?
 <context>
     <name>ScatterPlot</name>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="113"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
         <source>Power (watts)</source>
         <translation>Výkon (watty)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
         <source>Cadence (rpm)</source>
         <translation>Kadence (ot/m)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="116"/>
         <source>Heartrate (bpm)</source>
         <translation>Tepová frekvence (tepy/m)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="118"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="119"/>
         <source>Speed (kph)</source>
         <translation>Rychlost (km/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="120"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="121"/>
         <source>Speed (mph)</source>
         <translation>Rychlost (mi/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="124"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="125"/>
         <source>Altitude (meters)</source>
         <translation>Nadmořská výška (metry)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="126"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="127"/>
         <source>Altitude (feet)</source>
         <translation>Nadmořská výška (stopy)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="128"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
         <source>Torque (N)</source>
         <translation>Točivý moment (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="130"/>
         <source>Elapsed Time (secs)</source>
         <translation>Uplynulý čas (sekundy)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="132"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="133"/>
         <source>Elapsed Distance (km)</source>
         <translation>Uplynulá vzdálenost (km)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="134"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="135"/>
         <source>Elapsed Distance (mi)</source>
         <translation>Uplynulá vzdálenost (mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="136"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
         <source>Interval Number</source>
         <translation>Číslo intervalu</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
         <source>Latitude (degree offset)</source>
         <translation>Zeměpisná šířka (ofset ve stupních)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
         <source>Longitude (degree offset)</source>
         <translation>Zeměpisná délka (ofset ve stupních)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
         <source>Circumferential Pedal Velocity (m/s)</source>
         <translation>Obvodová rychlost pedálu (m/s)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="141"/>
         <source>Average Effective Pedal Force (N)</source>
         <translation>Průměrná efektivní síla na pedál (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="144"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
         <source>Time at X/Y (%)</source>
         <translation>Čas v X/Y (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
         <source>Power Zone</source>
         <translation>Zóna výkonu</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
         <source>Headwind (kph)</source>
         <translation>Protivítr (km/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
         <source>Slope (gradient)</source>
         <translation>Sklon (gradient)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
         <source>Temperature (C)</source>
         <translation>Teplota (C)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
         <source>L/R Balance</source>
         <translation>L/P poměr</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
         <source>Torque Efficiency</source>
         <translation>Efektivita šlapání</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
         <source>Pedal Smoothness</source>
         <translation>Plynulost šlapání</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
         <source>Running Vertical Oscillation</source>
         <translation>Vertikální oscilace běhu</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
         <source>Running Ground Contact Time</source>
         <translation>Doba kontaktu se zemí běhu</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
         <source>Running Cadence</source>
         <translation>Kadence běhu</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
         <source>Gear Ratio</source>
         <translation>Převodový poměr</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
         <source>Muscle Oxygen</source>
         <translation>Kyslík ve svalech</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
         <source>Haemoglobin Mass</source>
         <translation>Masa hemoglobinu</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
         <source>Deoxygenated Haemoglobin</source>
         <translation>Neokysličený hemoglobin</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="160"/>
         <source>Oxygenated Haemoglobin</source>
         <translation>Okysličený hemoglobin</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="161"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="162"/>
         <source>Unknown</source>
         <translation>Neznámý</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="165"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
         <source>Power</source>
         <translation>Výkon</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
         <source>Cadence</source>
         <translation>Kadence</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
         <source>Heartrate</source>
         <translation>Tepová frekvence</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
         <source>Speed</source>
         <translation>Rychlost</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
         <source>Altitude</source>
         <translation>Nadmořská výška</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
         <source>Pedal Force</source>
         <translation>Síla šlapání</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
         <source>Time</source>
         <translation>Čas</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
         <source>Distance</source>
         <translation>Vzdálenost</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
         <source>Interval</source>
         <translation>Interval</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
         <source>Latitude</source>
         <translation>Zeměpisná šířka</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
         <source>Longitude</source>
         <translation>Zeměpisná délka</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
         <source>Time at X/Y</source>
         <translation>Čas v X/Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
         <source>Zone</source>
         <translation>Zóna</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
         <source>CPV</source>
         <translation>CPV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
         <source>AEPF</source>
         <translation>AEPF</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
         <source>Headwind</source>
         <translation>Protivítr</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
         <source>Slope</source>
         <translation>Sklon</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
         <source>Temp</source>
         <translation>Teplota</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
         <source>Balance</source>
         <translation>Poměr</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
         <source>TE</source>
         <translation>TE</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
         <source>PS</source>
         <translation>PS</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
         <source>RV</source>
         <translation>RV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
         <source>GCT</source>
         <translation>GCT</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
         <source>Run Cad</source>
         <translation>Kad běh</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
         <source>Gear</source>
         <translation>Převod</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="194"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="195"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="196"/>
         <source>None</source>
         <translation>Žádný</translation>
     </message>
@@ -29861,42 +29830,38 @@ GoldenCheetah. Chcete pokračovat v převodu?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1012"/>
         <source>Add</source>
-        <translation>Přidat</translation>
+        <translation type="vanished">Přidat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1013"/>
         <source>Delete</source>
-        <translation>Smazat</translation>
+        <translation type="vanished">Smazat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1006"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1007"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1023"/>
+        <location filename="../../Gui/AthletePages.cpp" line="982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="988"/>
         <source>Short</source>
         <translation>Zkratka</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="989"/>
         <source>Long</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1031"/>
+        <location filename="../../Gui/AthletePages.cpp" line="990"/>
         <source>Percent of CP</source>
         <translation>Procent z CP</translation>
     </message>
@@ -29905,14 +29870,14 @@ GoldenCheetah. Chcete pokračovat v převodu?
         <translation type="vanished">Maximum 10 zón dosaženo.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1069"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1076"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1034"/>
         <source>New</source>
         <translation>Nový</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1071"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1078"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1036"/>
         <source>New (%1)</source>
         <translation>Nový (%1)</translation>
     </message>
@@ -30085,64 +30050,64 @@ GoldenCheetah. Chcete pokračovat v převodu?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3823"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3571"/>
         <source>Up</source>
         <translation>Nahoru</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3824"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3572"/>
         <source>Down</source>
         <translation>Dolů</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3557"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3810"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3558"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3804"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3835"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3583"/>
         <source>Name</source>
         <translation>Jméno</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3805"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3836"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3553"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3584"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3806"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3837"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3554"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3585"/>
         <source>From</source>
         <translation>Od</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3807"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3838"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3555"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3586"/>
         <source>To</source>
         <translation>Do</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3821"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3569"/>
         <source>Add</source>
         <translation>Přidat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3822"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3570"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3870"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3872"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3963"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3965"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3711"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3713"/>
         <source>ddd MMM d, yyyy</source>
         <translation>ddd MMM d, yyyy</translation>
     </message>
@@ -32446,25 +32411,25 @@ tab.</source>
 <context>
     <name>TrainSidebar</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="253"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="257"/>
         <source>Save workout data</source>
         <translation>Uložit data cvičení</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="259"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="263"/>
         <source>Devices</source>
         <translation>Zařízení</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="262"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="267"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="311"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="321"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="271"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="315"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="325"/>
         <source>Menu</source>
         <translation>Menu</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="270"/>
         <source>Workouts</source>
         <translation>Cvičení</translation>
     </message>
@@ -32473,143 +32438,143 @@ tab.</source>
         <translation type="obsolete">Filtrovat...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="303"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="307"/>
         <source>Workout Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="310"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="314"/>
         <source>Media</source>
         <translation>Média</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="320"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="324"/>
         <source>VideoSync</source>
         <translation>VideoSync</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="506"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
         <source>Import Workout from File</source>
         <translation>Importovat cvičení ze souboru</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="507"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="511"/>
         <source>Get Workouts from TrainerDay</source>
         <translation>Stáhnout cvičení z TrainerDay</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="509"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="513"/>
         <source>Create Workout via Wizard</source>
         <translation>Vytvořit cvičení pomocí průvodce</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="514"/>
         <source>Scan for Workouts</source>
         <translation>Vyhledat cvičení</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="534"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="538"/>
         <source>Delete selected Workout</source>
         <translation>Odstranit zvolené cvičení</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="541"/>
         <source>Delete %1 selected Workouts</source>
         <translation>Odstranit %1 zvolených cvičení</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Train mode active</source>
         <translation>Tréninkový mód aktivní</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Please stop the train mode before closing the window or application.</source>
         <translation>Prosím zastavte tréninkový mód než zavřete okno nebo ukončíte aplikaci.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="635"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="639"/>
         <source>Remove reference to selected video</source>
         <translation>Odstranit referenci pro zvolené video</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="650"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="654"/>
         <source>Import VideoSync from File</source>
         <translation>Importovat VideoSync ze souboru</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="651"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="655"/>
         <source>Scan for VideoSyncs</source>
         <translation>Vyhledat VideoSyncy</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="668"/>
         <source>Delete selected VideoSync</source>
         <translation>Odstranit vybraný VideoSync</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1064"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1068"/>
         <source>Are you sure you want to remove the reference to this video?</source>
         <translation>Jste si jistí, že chcete odstranit referenci k tomuto videu?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1066"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1128"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1204"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1070"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1132"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1208"/>
         <source>Remove</source>
         <translation>Odstranit</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1099"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1103"/>
         <source>Are you sure you want to delete this VideoSync?</source>
         <translation>Jste si jistí, že chcete smazat tento VideoSync?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1126"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1130"/>
         <source>The VideoSync file is either not valid or not existing and will be removed from the library.</source>
         <translation>Tento VideoSync soubor buď není validní nebo neexistuje a bude odstraněn z knihovny.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1160"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1164"/>
         <source>Are you sure you want to delete this Workout?</source>
         <translation>Jste si jistí, že chcete smazat toto cvičení?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1163"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1167"/>
         <source>Are you sure you want to delete this %1 workouts?</source>
         <translation>Jste si jistí, že chcete smazat těchto %1 cvičení?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1202"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1206"/>
         <source>The Workout file is either not valid or not existing and will be removed from the library.</source>
         <translation>Soubor tohoto cvičení buď není validní nebo neexistuje a bude odstraněn z knihovny.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1347"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1351"/>
         <source>Starting in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2225"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2237"/>
         <source>Recalibrating steering..</source>
         <translation>Probíhá rekalibrace řízení..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2521"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2525"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2594"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2645"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2649"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2533"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2606"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2657"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2661"/>
         <source>Requesting calibration..</source>
         <translation>Žádám o kalibraci..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2532"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2544"/>
         <source>Calibrating...</source>
         <translation>Kalibrování...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2536"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2548"/>
         <source>Calibrating...
 Current speed %1 kph
 Increase speed to %2 kph</source>
@@ -32618,14 +32583,14 @@ Aktuální rychlost %1 km/h
 Zvyšte rychlost na %2 km/h</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2540"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2552"/>
         <source>Calibrating...
 Stop pedalling until speed drops to 0</source>
         <translation>Kalibrování...
 Přestaňte šlapat, než se rychlost sníží na 0</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2545"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2557"/>
         <source>Calibration completed successfully!
 Spindown %1 ms
 Zero Offset %2</source>
@@ -32634,30 +32599,30 @@ Setrvačník zastavený po %1 ms
 Ofset od nuly %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2553"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2620"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2672"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2565"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2632"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2684"/>
         <source>Calibration failed!</source>
         <translation>Kalibrace selhala!</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2573"/>
         <source>Calibration Failed: Loosen Roller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2569"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2581"/>
         <source>Calibration Failed: Tighten Roller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2588"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2639"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2600"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2651"/>
         <source>Unclip or stop pedalling to begin calibration..</source>
         <translation>Vycvakněte nebo přestaňte šlapat pro začátek kalibrace..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2607"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2619"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Torque %1</source>
@@ -32666,7 +32631,7 @@ Vycvakněte nebo přestaňte šlapat než bude proces dokončen..
 Točivý moment %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2612"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2624"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Torque %2</source>
@@ -32675,7 +32640,7 @@ Ofset od nuly %1
 Točivý moment %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2659"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2671"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Zero Offset %1</source>
@@ -32684,7 +32649,7 @@ Vycvakněte nebo přestaňte šlapat než bude proces dokončen..
 Ofset od nuly %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2676"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Slope %2</source>
@@ -32693,169 +32658,169 @@ Ofset od nuly %1
 Sklon %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2693"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2705"/>
         <source>Give the pedal a kick to start calibration...
 The motor will run until calibration is complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2695"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
         <source>Allow wheel speed to settle, DO NOT PEDAL...
 The motor will run until calibration is complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2700"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2712"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Gathering enough samples to calculate average: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2719"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Waiting for value to stabilize (max %1s): %2 (%3W @ %4kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2722"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
         <source>Calibration completed successfully!
 Final calibration value %1 (%2W @ %3kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2746"/>
         <source>Calibration failed! Do not pedal while calibration is taking place.
 Allow wheel to run freely.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2780"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2792"/>
         <source>Fast forward..</source>
         <translation>Rychle dopředu..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2813"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2825"/>
         <source>Rewind..</source>
         <translation>Přetočit..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2843"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2855"/>
         <source>Next Lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2876"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2888"/>
         <source>Back Lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2902"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2914"/>
         <source>Increasing intensity..</source>
         <translation>Zvyšování intenzity..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2928"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2940"/>
         <source>Decreasing intensity..</source>
         <translation>Sniřování intenzity..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="621"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="625"/>
         <source>Import Video from File</source>
         <translation>Importovat video ze souboru</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="508"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="512"/>
         <source>Get Workouts from Strava Routes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="622"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="626"/>
         <source>Scan for Videos</source>
         <translation>Vyhledat videa</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1101"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1173"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3183"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1105"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1177"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3195"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1309"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1313"/>
         <source>Resuming..</source>
         <translation>Obnovování..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1336"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1340"/>
         <source>Paused..</source>
         <translation>Pozastaveno..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1465"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1469"/>
         <source>Starting..</source>
         <translation>Žačínání..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1673"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1677"/>
         <source>Stopped..</source>
         <translation>Zastaveno..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1763"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1769"/>
         <source>Connected..</source>
         <translation>Připojeno..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1787"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1793"/>
         <source>Disconnected..</source>
         <translation>Odpojeno..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2198"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2210"/>
         <source>New lap..</source>
         <translation>Nový úsek..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>No Devices Configured</source>
         <translation>Není nakonfigurováno žádné zařízení</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>Please configure a device in Preferences.</source>
         <translation>Prosím nakonfigurujte zařízení v preferencích.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2483"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2495"/>
         <source>Exiting calibration..</source>
         <translation>Ukončení kalibrace..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2498"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2510"/>
         <source>Calibration not supported for this device.</source>
         <translation>Kalibrace na tomto zařízení není podporována.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2505"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2517"/>
         <source>Calibrating...
 Press F3 on Controller when done.</source>
         <translation>Kalibrování...
 Stiskněte F3 na ovladači, jakmile bude dokončena.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3135"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3153"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3147"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3165"/>
         <source>Add Device</source>
         <translation>Přidat zařízení</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3140"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3158"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3152"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3170"/>
         <source>Delete Device</source>
         <translation>Odstranit zařízení</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3181"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3193"/>
         <source>Are you sure you want to delete this device?</source>
         <translation>Jste si jistí, že chcete smazat toto zařízení?</translation>
     </message>
@@ -33172,7 +33137,7 @@ Stiskněte F3 na ovladači, jakmile bude dokončena.</translation>
 <context>
     <name>UniqueLabelEditDelegate</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="77"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="108"/>
         <source>The given value &quot;%1&quot; is not unique</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33188,171 +33153,167 @@ Stiskněte F3 na ovladači, jakmile bude dokončena.</translation>
 <context>
     <name>UserChartSettings</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="772"/>
+        <location filename="../../Charts/UserChart.cpp" line="773"/>
         <source>Chart</source>
         <translation type="unfinished">Graf</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="782"/>
+        <location filename="../../Charts/UserChart.cpp" line="783"/>
         <source>Sub-title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="785"/>
+        <location filename="../../Charts/UserChart.cpp" line="786"/>
         <source>Description</source>
         <translation type="unfinished">Popis</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="791"/>
+        <location filename="../../Charts/UserChart.cpp" line="792"/>
         <source>Line Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="792"/>
+        <location filename="../../Charts/UserChart.cpp" line="793"/>
         <source>Scatter Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="793"/>
+        <location filename="../../Charts/UserChart.cpp" line="794"/>
         <source>Bar Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="794"/>
+        <location filename="../../Charts/UserChart.cpp" line="795"/>
         <source>Stacked Bar Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="795"/>
+        <location filename="../../Charts/UserChart.cpp" line="796"/>
         <source>Stacked Percent Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="796"/>
+        <location filename="../../Charts/UserChart.cpp" line="797"/>
         <source>Pie Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="800"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="801"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="804"/>
+        <location filename="../../Charts/UserChart.cpp" line="805"/>
         <source>Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="805"/>
+        <location filename="../../Charts/UserChart.cpp" line="806"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="808"/>
+        <location filename="../../Charts/UserChart.cpp" line="809"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="812"/>
+        <location filename="../../Charts/UserChart.cpp" line="813"/>
         <source>None</source>
         <translation type="unfinished">Žádný</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="813"/>
+        <location filename="../../Charts/UserChart.cpp" line="814"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="814"/>
+        <location filename="../../Charts/UserChart.cpp" line="815"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="815"/>
+        <location filename="../../Charts/UserChart.cpp" line="816"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="816"/>
+        <location filename="../../Charts/UserChart.cpp" line="817"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="820"/>
+        <location filename="../../Charts/UserChart.cpp" line="821"/>
         <source>Legend</source>
         <translation type="unfinished">Legenda</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="829"/>
+        <location filename="../../Charts/UserChart.cpp" line="830"/>
         <source>Font scaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="831"/>
-        <location filename="../../Charts/UserChart.cpp" line="833"/>
+        <location filename="../../Charts/UserChart.cpp" line="832"/>
+        <location filename="../../Charts/UserChart.cpp" line="834"/>
         <source>Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="836"/>
+        <location filename="../../Charts/UserChart.cpp" line="837"/>
         <source>Animate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="838"/>
+        <location filename="../../Charts/UserChart.cpp" line="839"/>
         <source>Single series per plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="841"/>
+        <location filename="../../Charts/UserChart.cpp" line="842"/>
         <source>Refresh for intervals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="848"/>
+        <location filename="../../Charts/UserChart.cpp" line="849"/>
         <source>Series</source>
         <translation type="unfinished">Série</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Name</source>
         <translation type="unfinished">Jméno</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Y Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="870"/>
-        <location filename="../../Charts/UserChart.cpp" line="932"/>
         <source>Edit</source>
-        <translation type="unfinished">Upravit</translation>
+        <translation type="obsolete">Upravit</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="889"/>
         <source>Up</source>
-        <translation type="unfinished">Nahoru</translation>
+        <translation type="obsolete">Nahoru</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="890"/>
         <source>Down</source>
-        <translation type="unfinished">Dolů</translation>
+        <translation type="obsolete">Dolů</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="911"/>
+        <location filename="../../Charts/UserChart.cpp" line="885"/>
         <source>Axes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34018,72 +33979,72 @@ Stiskněte F3 na ovladači, jakmile bude dokončena.</translation>
 <context>
     <name>VideoWindow</name>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> kph</source>
         <translation> km/h</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="119"/>
+        <location filename="../../Train/VideoWindow.cpp" line="144"/>
         <source>Meters layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="127"/>
+        <location filename="../../Train/VideoWindow.cpp" line="152"/>
         <source>Reset Meters layout to default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> m</source>
         <translation type="unfinished"> m</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> feet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="625"/>
+        <location filename="../../Train/VideoWindow.cpp" line="681"/>
         <source>w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="629"/>
+        <location filename="../../Train/VideoWindow.cpp" line="685"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> km</source>
         <translation type="unfinished"> km</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> mi</source>
         <translation type="unfinished"> mi</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="673"/>
+        <location filename="../../Train/VideoWindow.cpp" line="729"/>
         <source>Calibration required</source>
         <translation>Požadována kalibrace</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="678"/>
+        <location filename="../../Train/VideoWindow.cpp" line="734"/>
         <source>Configuration required</source>
         <translation>Požadována konfigurace</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="683"/>
+        <location filename="../../Train/VideoWindow.cpp" line="739"/>
         <source>brake fault</source>
         <translation>selhání brzdy</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="688"/>
+        <location filename="../../Train/VideoWindow.cpp" line="744"/>
         <source>Ready</source>
         <translation>Připraveno</translation>
     </message>
@@ -34518,27 +34479,27 @@ Stiskněte F3 na ovladači, jakmile bude dokončena.</translation>
 <context>
     <name>WheelSizeCalculator</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="202"/>
+        <location filename="../../Gui/AthletePages.cpp" line="187"/>
         <source>Wheel Size Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="221"/>
+        <location filename="../../Gui/AthletePages.cpp" line="206"/>
         <source>Rim Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="222"/>
+        <location filename="../../Gui/AthletePages.cpp" line="207"/>
         <source>Tire Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="223"/>
+        <location filename="../../Gui/AthletePages.cpp" line="208"/>
         <source>Wheel Size</source>
         <translation type="unfinished">Rozměr kol</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="227"/>
         <source>mm</source>
         <translation type="unfinished">mm</translation>
     </message>
@@ -34650,12 +34611,12 @@ Stiskněte F3 na ovladači, jakmile bude dokončena.</translation>
 <context>
     <name>WorkoutFilterBox</name>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="34"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="44"/>
         <source>Filter...</source>
         <translation type="unfinished">Filtrovat...</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="64"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="95"/>
         <source>ERROR: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34663,12 +34624,12 @@ Stiskněte F3 na ovladači, jakmile bude dokončena.</translation>
 <context>
     <name>WorkoutImportDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="820"/>
+        <location filename="../../Train/Library.cpp" line="809"/>
         <source>Import to Library</source>
         <translation>Importovat do knihovny</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="854"/>
+        <location filename="../../Train/Library.cpp" line="843"/>
         <source>Please note, that when importing or drag and dropping videos into the library we DO NOT copy the file into the GoldenCheetah library, instead we add a REFERENCE to it. We DO copy workout and videoSync files, since they are smaller.
 
 You can remove references when managing the library via the context menu options</source>
@@ -34677,24 +34638,107 @@ You can remove references when managing the library via the context menu options
 Reference můžete odstranit ve správě knihovny přes volby v kontextovém menu</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="868"/>
+        <location filename="../../Train/Library.cpp" line="857"/>
         <source>Files</source>
         <translation>Soubory</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="878"/>
+        <location filename="../../Train/Library.cpp" line="867"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="880"/>
+        <location filename="../../Train/Library.cpp" line="869"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="884"/>
+        <location filename="../../Train/Library.cpp" line="873"/>
         <source>Overwite existing files</source>
         <translation>Přepsat existující soubory</translation>
+    </message>
+</context>
+<context>
+    <name>WorkoutMenuProvider</name>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="271"/>
+        <source>Select Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="274"/>
+        <source>Manage Filters</source>
+        <translation type="unfinished">Spravovat filtry</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="275"/>
+        <source>Add Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="289"/>
+        <source>Add Tag to Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="292"/>
+        <source>Filter Tags...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="310"/>
+        <source>Match all selected tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="353"/>
+        <source>Manage Workout Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="360"/>
+        <source>Name</source>
+        <translation type="unfinished">Jméno</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="361"/>
+        <source>Filter</source>
+        <translation type="unfinished">Filtr</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="362"/>
+        <source>_index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="370"/>
+        <source>Execute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="371"/>
+        <source>Update</source>
+        <translation type="unfinished">Aktualizovat</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="423"/>
+        <source>Add Workout Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="426"/>
+        <source>Name of the Filter...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="467"/>
+        <source>New</source>
+        <translation type="unfinished">Nový</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="469"/>
+        <source>New (%1)</source>
+        <translation type="unfinished">Nový (%1)</translation>
     </message>
 </context>
 <context>
@@ -34709,41 +34753,41 @@ Reference můžete odstranit ve správě knihovny přes volby v kontextovém men
     <name>WorkoutPlotWindow</name>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="40"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="104"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
         <source>Ergmode specific settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="46"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
         <source>Color power zones</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="48"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="56"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="49"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="50"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="57"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="109"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="113"/>
         <source>When stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="54"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="110"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
         <source>Show tooltip</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34833,12 +34877,12 @@ Reference můžete odstranit ve správě knihovny přes volby v kontextovém men
 <context>
     <name>WorkoutWidget</name>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="1531"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="1532"/>
         <source>File save failed.</source>
         <translation>Uložení souboru selhalo.</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="2367"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="2368"/>
         <source>Intensity</source>
         <translation>Intenzita</translation>
     </message>
@@ -34992,26 +35036,22 @@ Reference můžete odstranit ve správě knihovny přes volby v kontextovém men
 <context>
     <name>XDataDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="44"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="45"/>
         <source>xData</source>
         <translation>xData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="58"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="59"/>
         <source>Data Series</source>
         <translation>Datová série</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="78"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="80"/>
         <source>Add</source>
-        <translation>Přidat</translation>
+        <translation type="vanished">Přidat</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="79"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="81"/>
         <source>Delete</source>
-        <translation>Smazat</translation>
+        <translation type="vanished">Smazat</translation>
     </message>
 </context>
 <context>
@@ -35088,32 +35128,32 @@ Reference můžete odstranit ve správě knihovny přes volby v kontextovém men
 <context>
     <name>XDataSeriesSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="333"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="315"/>
         <source>Name</source>
         <translation>Jméno</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="338"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="320"/>
         <source>Units</source>
         <translation>Jednotky</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="346"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="328"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="347"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="329"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Name is blank</source>
         <translation>Jméno je prázdné</translation>
     </message>
@@ -35121,48 +35161,48 @@ Reference můžete odstranit ve správě knihovny přes volby v kontextovém men
 <context>
     <name>XDataSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="262"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="244"/>
         <source>xData</source>
         <translation>xData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="269"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="251"/>
         <source>Data Series</source>
         <translation>Datová série</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="270"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="252"/>
         <source>Units</source>
         <translation>Jednotky</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="274"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="256"/>
         <source>Series %1</source>
         <translation>Série %1</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="281"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="263"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="282"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="264"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
         <source>XData name is blank</source>
         <translation>XData jméno je prázdné</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Must have at least one data series.</source>
         <translation>Musí mít alespoň jednu datovou sérii.</translation>
     </message>
@@ -35483,17 +35523,17 @@ Reference můžete odstranit ve správě knihovny přes volby v kontextovém men
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="915"/>
+        <location filename="../../Gui/AthletePages.cpp" line="886"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="962"/>
+        <location filename="../../Gui/AthletePages.cpp" line="933"/>
         <source>Critical Power</source>
         <translation>Kritický výkon</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="963"/>
+        <location filename="../../Gui/AthletePages.cpp" line="934"/>
         <source>Default</source>
         <translation>Výchozí</translation>
     </message>

--- a/src/Resources/translations/gc_de.ts
+++ b/src/Resources/translations/gc_de.ts
@@ -108,38 +108,38 @@ Sie müssen diesen möglicherweise manuell deaktivieren.</translation>
         <translation type="vanished">LTS-Durchschnitt (Tage)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="504"/>
+        <location filename="../../Gui/AthletePages.cpp" line="489"/>
         <source>s</source>
         <translation>s</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="517"/>
-        <location filename="../../Gui/AthletePages.cpp" line="522"/>
+        <location filename="../../Gui/AthletePages.cpp" line="502"/>
+        <location filename="../../Gui/AthletePages.cpp" line="507"/>
         <source>days</source>
         <translation>Tage</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="525"/>
+        <location filename="../../Gui/AthletePages.cpp" line="510"/>
         <source>PMC Stress Balance Today</source>
         <translation>PMC-Belastungsbilanz heute</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="528"/>
+        <location filename="../../Gui/AthletePages.cpp" line="513"/>
         <source>Restore Defaults</source>
         <translation>Standardwerte wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="517"/>
         <source>W&apos;bal tau</source>
         <translation>W&apos;-Bilanz tau</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="518"/>
         <source>Short Term Stress (STS) average</source>
         <translation>Kurzzeitbelastung (STS) Durchschnitt</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="534"/>
+        <location filename="../../Gui/AthletePages.cpp" line="519"/>
         <source>Long Term Stress (LTS) average</source>
         <translation>Langzeitbelastung (LTS) Durchschnitt</translation>
     </message>
@@ -155,96 +155,96 @@ Sie müssen diesen möglicherweise manuell deaktivieren.</translation>
 <context>
     <name>AboutRiderPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="372"/>
+        <location filename="../../Gui/AthletePages.cpp" line="357"/>
         <source>Nickname</source>
         <translation>Spitzname</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="373"/>
+        <location filename="../../Gui/AthletePages.cpp" line="358"/>
         <source>Date of Birth</source>
         <translation>Geburtsdatum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="374"/>
+        <location filename="../../Gui/AthletePages.cpp" line="359"/>
         <source>Sex</source>
         <translation>Geschlecht</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="376"/>
+        <location filename="../../Gui/AthletePages.cpp" line="361"/>
         <source>Weight</source>
         <translation>Gewicht</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="375"/>
+        <location filename="../../Gui/AthletePages.cpp" line="360"/>
         <source>Height</source>
         <translation>Körpergröße</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="279"/>
+        <location filename="../../Gui/AthletePages.cpp" line="264"/>
         <source>Male</source>
         <translation>männlich</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="280"/>
+        <location filename="../../Gui/AthletePages.cpp" line="265"/>
         <source>Female</source>
         <translation>weiblich</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> kg</source>
         <translation> kg</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> lb</source>
         <translation> lb</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> cm</source>
         <translation> cm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> in</source>
         <translation> in</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="359"/>
+        <location filename="../../Gui/AthletePages.cpp" line="344"/>
         <source>Calculate...</source>
         <translation>Berechnen...</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="378"/>
+        <location filename="../../Gui/AthletePages.cpp" line="363"/>
         <source>Bike</source>
         <translation>Fahrrad Einstellungen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="379"/>
+        <location filename="../../Gui/AthletePages.cpp" line="364"/>
         <source>Crank Length</source>
         <translation>Kurbelarmlänge</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="380"/>
+        <location filename="../../Gui/AthletePages.cpp" line="365"/>
         <source>Wheelsize</source>
         <translation>Laufradgröße</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="356"/>
+        <location filename="../../Gui/AthletePages.cpp" line="341"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="437"/>
+        <location filename="../../Gui/AthletePages.cpp" line="422"/>
         <source>Choose Picture</source>
         <translation>Bild wählen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="438"/>
+        <location filename="../../Gui/AthletePages.cpp" line="423"/>
         <source>Images</source>
         <translation>Bilder</translation>
     </message>
@@ -2279,398 +2279,395 @@ Gerät gefunden.
 <context>
     <name>AllPlotWindow</name>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="190"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="444"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="165"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
         <source>Smooth</source>
         <translation>Glätten</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="198"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="173"/>
         <source>Stacked</source>
         <translation>Gestapelt</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="199"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="174"/>
         <source>by series</source>
         <translation>pro Datenreihe</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="200"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="175"/>
         <source>Fullplot</source>
         <translation>Gesamtdiagramm</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="201"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="176"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="239"/>
         <source>Overlay</source>
         <translation>Intervallfenster</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="229"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="204"/>
         <source>View</source>
         <translation>Ansicht</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="206"/>
         <source>Stack</source>
         <translation>Gestapelt</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="210"/>
         <source>By Series</source>
         <translation>pro Datenreihe</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="246"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="221"/>
         <source>Stack Zoom</source>
         <translation>Skala</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="248"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="223"/>
         <source>Full plot</source>
         <translation>Gesamtdiagramm</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="227"/>
         <source>Show Interval Markers</source>
         <translation>Intervallmarkierungen anzeigen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="256"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
         <source>Interval Navigator</source>
         <translation>Intervallnavigator</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="260"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
         <source>Hover intervals</source>
         <translation>Intervalle per Maus anzeigen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="268"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="243"/>
         <source>Fill Curves</source>
         <translation>Kurven füllen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="247"/>
         <source>Grid</source>
         <translation>Raster</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="277"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
         <source>Acceleration</source>
         <translation>Beschleunigung</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="279"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="254"/>
         <source>Delta Series</source>
         <translation>Deltareihen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="280"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="255"/>
         <source>Power %1</source>
         <translation>Leistung %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="283"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="258"/>
         <source>Cadence %1</source>
         <translation>Trittfrequenz %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="261"/>
         <source>Torque %1</source>
         <translation>Drehmoment %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="289"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
         <source>Heartrate %1</source>
         <translation>Herzfrequenz %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="295"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="270"/>
         <source>Balance</source>
         <translation>Leistungsverteilung</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
         <source>Left/Right</source>
         <translation>Links/Rechts</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="274"/>
         <source>Torque Effectiveness</source>
         <translation>Drehmoment-Effektivität</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="303"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="278"/>
         <source>Smoothness</source>
         <translation>Gleichmäßigkeit des Tretens</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="282"/>
         <source>Pedal Center Offset</source>
         <translation>Pedal Center Offset</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="290"/>
         <source>Peak Power Phase</source>
         <translation>Max. Power Phase</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="322"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
         <source>Vertical Oscillation</source>
         <translation>Vertikale Bewegung</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="324"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
         <source>Running</source>
         <translation>Laufen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="326"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="301"/>
         <source>Ground Contact Time</source>
         <translation>Bodenkontakzeit</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="313"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="340"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
         <source>Moxy</source>
         <translation>Moxy</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="317"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="321"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="325"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="355"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="330"/>
         <source>Heart Rate</source>
         <translation>Herzfrequenz</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="357"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
         <source>Data series</source>
         <translation>Datenreihen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="359"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="334"/>
         <source>Core Temperature</source>
         <translation>Kerntemperatur</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="363"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
         <source>Speed</source>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="367"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
         <source>Cadence</source>
         <translation>Trittfrequenz</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="94"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="95"/>
         <source>Basic</source>
         <translatorcomment>	</translatorcomment>
         <translation>Grundeinstellungen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="109"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="110"/>
         <source>Curves</source>
         <translation>Daten</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="116"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="117"/>
         <source>User Data</source>
         <translation>Benutzerdaten</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="132"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="134"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Formula</source>
         <translation>Formel</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="144"/>
         <source>Edit</source>
-        <translation>Bearbeiten</translation>
+        <translation type="vanished">Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="163"/>
         <source>Up</source>
-        <translation>Hoch</translation>
+        <translation type="vanished">Hoch</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="164"/>
         <source>Down</source>
-        <translation>Runter</translation>
+        <translation type="vanished">Runter</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="311"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
         <source>Power Phase</source>
         <translation>Power Phase</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
         <source>Cadence </source>
         <translation>Schrittfrequenz </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="371"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
         <source>Altitude</source>
         <translation>Höhe</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
         <source>Temperature</source>
         <translation>Temperatur</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="379"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="354"/>
         <source>Headwind</source>
         <translation>Gegenwind</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="383"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="358"/>
         <source>Torque</source>
         <translation>Drehmoment</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="387"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="362"/>
         <source>Gear Ratio</source>
         <translation>Übersetzung</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="391"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="366"/>
         <source>Slope</source>
         <translation>Steigung</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="373"/>
         <source>No Alt/Slope</source>
         <translation>Keine Höhe/Steigung</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="399"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="374"/>
         <source>0.1km|mi -  1min</source>
         <translation>0.1km|mi -  1min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="400"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
         <source>0.5km|mi -  5min</source>
         <translation>0.5km|mi -  5min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="401"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="376"/>
         <source>1.0km|mi - 10min</source>
         <translation>1.0km|mi - 10min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1528"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="377"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="1503"/>
         <source>Alt/Slope</source>
         <translation>Höhe/Steigung</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="382"/>
         <source>Anaerobic TISS</source>
         <translation>Anaerober TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="384"/>
         <source>Metrics</source>
         <translation>Metriken</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="411"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="386"/>
         <source>Aerobic TISS</source>
         <translation>Aerober TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="390"/>
         <source>Iso Power</source>
         <translation>Normalisierte Leistung (IsoPower)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="394"/>
         <source>Skiba xPower</source>
         <translation>Skiba xPower</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="423"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
         <source>Altitude Power</source>
         <translation>Höhenkorrigierte Leistung</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="427"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
         <source>W&apos; balance</source>
         <translation>W&apos;-Bilanz</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="441"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="416"/>
         <source>Time of day</source>
         <translation>Tageszeit</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="742"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="717"/>
         <source>Intervals</source>
         <translation>Intervalle</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="2253"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="2228"/>
         <source>Selection #%1 </source>
         <translation>Auswahl #%1 </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="432"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
         <source>Power + shade</source>
         <translation>Leistung + Zonen einblenden</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="433"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="408"/>
         <source>Power - shade</source>
         <translation>Leistung + Zonen ausblenden</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="434"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
         <source>No Power</source>
         <translation>Keine Leistung</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="435"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="410"/>
         <source>Shading</source>
         <translation>Leistungsanzeige</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="439"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="414"/>
         <source>Time</source>
         <translation>Zeit</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="440"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
         <source>Distance</source>
         <translation>Distanz</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="442"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="417"/>
         <source>X Axis</source>
         <translation>X-Achse</translation>
     </message>
@@ -3482,51 +3479,45 @@ gespeichert</translation>
 <context>
     <name>AutoImportPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4028"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4029"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
         <source>Browse</source>
         <translation type="vanished">Durchsuchen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4040"/>
         <source>Add</source>
-        <translation>Hinzufügen</translation>
+        <translation type="vanished">Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4041"/>
         <source>Delete</source>
-        <translation>Löschen</translation>
+        <translation type="vanished">Löschen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4042"/>
         <source>Up</source>
-        <translation>Hoch</translation>
+        <translation type="vanished">Hoch</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4043"/>
         <source>Down</source>
-        <translation>Runter</translation>
+        <translation type="vanished">Runter</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4054"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3779"/>
         <source>Enter a directory</source>
         <translation>Ein Verzeichnis eingeben</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4059"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3784"/>
         <source>Directory</source>
         <translation>Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4060"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3785"/>
         <source>Import Rule</source>
         <translation>Importregel</translation>
     </message>
@@ -4344,37 +4335,37 @@ gespeichert</translation>
 <context>
     <name>BackupPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="608"/>
+        <location filename="../../Gui/AthletePages.cpp" line="593"/>
         <source>Enter a directory</source>
         <translation>Ein Verzeichnis eingeben</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="601"/>
         <source>every</source>
         <translation>jedes</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="617"/>
+        <location filename="../../Gui/AthletePages.cpp" line="602"/>
         <source>times</source>
         <translation>mal</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="603"/>
         <source>never</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="605"/>
         <source>Backup now</source>
         <translation>Jetzt sichern</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="623"/>
+        <location filename="../../Gui/AthletePages.cpp" line="608"/>
         <source>Auto Backup Folder</source>
         <translation>Verzeichnis für automatische Sicherung</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="624"/>
+        <location filename="../../Gui/AthletePages.cpp" line="609"/>
         <source>Auto Backup after closing the athlete</source>
         <translation>Automatische Sicherung nach dem Schließen des Athleten</translation>
     </message>
@@ -5204,41 +5195,33 @@ Setup durchführen.</translation>
         <translation type="vanished">Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1202"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1203"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1204"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1150"/>
         <source>Review...</source>
         <translation>Überprüfen...</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1206"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1152"/>
         <source>Changed power estimates are available</source>
         <translation>Geschätzte Leistungswerte aus dem CP-Modell verfügbar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1213"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1225"/>
         <source>Add</source>
-        <translation>Hinzufügen</translation>
+        <translation type="vanished">Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1214"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1226"/>
         <source>Delete</source>
-        <translation>Löschen</translation>
+        <translation type="vanished">Löschen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1216"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1158"/>
         <source>Def</source>
         <translatorcomment>???</translatorcomment>
         <translation>Standardwert</translation>
@@ -5248,27 +5231,27 @@ Setup durchführen.</translation>
         <translation type="vanished">Ab Datum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1218"/>
         <source>Critical Power</source>
         <translation>Critical Power</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1305"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>AeTP</source>
         <translation>Aerobe Schwelle (AeT)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1306"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>FTP</source>
         <translation>FTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1307"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1221"/>
         <source>W&apos;</source>
         <translation>W&apos;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1308"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1222"/>
         <source>Pmax</source>
         <translation>Pmax</translation>
     </message>
@@ -5281,207 +5264,207 @@ Setup durchführen.</translation>
         <translation type="vanished">Critical Power muss &gt; 0 sein</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1347"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1261"/>
         <source>Short</source>
         <translation>Zone</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1247"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1169"/>
         <source>Use CP for all metrics</source>
         <translation>CP für alle Metriken verwenden</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1240"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1162"/>
         <source>Manual</source>
         <translation>Manuell</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1241"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1163"/>
         <source>Semi-Automatic (CP2)</source>
         <translation>Halbautomatisch (CP2)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1164"/>
         <source>Semi-Automatic (CP3)</source>
         <translation>Halbautomatisch (CP3)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1243"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1165"/>
         <source>Semi-Automatic (Extended)</source>
         <translation>Halbautomatisch (Extended)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1170"/>
         <source>Use FTP for Coggan metrics</source>
         <translation>FTP für Coggan-Metriken verwenden</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1273"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1279"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1285"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1342"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1618"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1631"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2283"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2289"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2310"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1187"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1193"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1199"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1211"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1537"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1545"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2180"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2186"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2194"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2207"/>
         <source>W</source>
         <translation>W</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1205"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1547"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2201"/>
         <source>J</source>
         <translation>J</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1303"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1217"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2145"/>
         <source>Start Date</source>
         <translation>Startdatum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1309"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1223"/>
         <source>Model Fit</source>
         <translation>Modellanpassung</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1262"/>
         <source>Long</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1349"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1263"/>
         <source>From Watts</source>
         <translation>Von Leistung</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1598"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1512"/>
         <source>Review range starting on %1</source>
         <translation>Überprüfungsbereich beginnend ab den %1</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1614"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1528"/>
         <source>Current</source>
         <translation>Aktuell</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1615"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1529"/>
         <source>Estimate</source>
         <translation>Schätzung</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1530"/>
         <source>Accept</source>
         <translation>Akzeptieren</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1788"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1691"/>
         <source>🗹</source>
         <translation>🗹</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1692"/>
         <source>Estimate and settings &lt;b&gt;match&lt;/b&gt;</source>
         <translation>Schätzung und Einstellungen &lt;b&gt;stimmen überein&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1695"/>
         <source>☐</source>
         <translation>☐</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1696"/>
         <source>Estimate and settings &lt;b&gt;differ&lt;/b&gt;</source>
         <translation>Schätzung und Einstellungen sind &lt;b&gt;unterscheidlich&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1797"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1700"/>
         <source>⏲</source>
         <translation>⏲</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1800"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1703"/>
         <source>Range is %1 days older than closest estimate</source>
         <translation>Bereich ist %1 Tage älter als die nächstliegende Schätzung</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1802"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1705"/>
         <source>Range is %1 days younger than closest estimate</source>
         <translation>Bereich ist %1 Tage jünger als die nächstliegende Schätzung</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1808"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1711"/>
         <source>∅</source>
         <translation>∅</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1712"/>
         <source>No estimate available</source>
         <translation>Keine Schätzung verfügbar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1902"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1805"/>
         <source>New range from estimate</source>
         <translation>Neuer Bereich aus der Schätzung</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2237"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2134"/>
         <source>The proposed value for AeTP is a very rough estimate, assuming %1 % of CP. Usually it is determined by a&lt;ul&gt;&lt;li&gt;Metabolic test&lt;/li&gt;&lt;li&gt;Lactate ramp test&lt;/li&gt;&lt;li&gt;Run / Cycling ‘conversational’ test&lt;/li&gt;&lt;li&gt;Run Decoupling test&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>Der vorgeschlagene AeT-Wert ist eine sehr grobe Schätzung, er basiert auf %1 % des CP-Wert. In der Regel wird er durch einen&lt;ul&gt;&lt;li&gt;Metabolischen Test&lt;/li&gt;&lt;li&gt;Laktat-Rampentest&lt;/li&gt;&lt;li&gt;Lauf-/Radfahr-„Konversationstest“&lt;/li&gt;&lt;li&gt;Laufen Entkopplungstest&lt;/li&gt;&lt;/ul&gt; ermittelt</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2239"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2136"/>
         <source>Updating FTP internally to match CP</source>
         <translation>FTP intern aktualisieren, um mit CP übereinzustimmen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2139"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>Das von Ihnen gewählte Modell liefert keine Werte für&lt;ul&gt;&lt;li&gt;FTP, verwenden Sie stattdessen CP&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2244"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2141"/>
         <source>Your selected model does not deliver values for PMax, using default value of %1 W instead</source>
         <translation>Ihr ausgewähltes Modell liefert keine Werte für PMax, stattdessen wird der Standardwert von %1 W verwendet</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2246"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2143"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;li&gt;PMax, assuming a default of %1 W&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>Das von Ihnen gewählte Modell liefert keine Werte für&lt;ul&gt;&lt;li&gt;FTP, stattdessen wird CP verwendet&lt;/li&gt;&lt;li&gt;PMax, wobei ein Standardwert von %1 W angenommen wird&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2250"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2147"/>
         <source>Critical Power (CP)</source>
         <translation>Critical Power (CP)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2252"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2149"/>
         <source>Aerobic Threshold Power (AeTP)</source>
         <translation>Aerobe Schwellenleistung (AeT)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2254"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2151"/>
         <source>Functional Threshold Power (FTP)</source>
         <translation>Leistungsbezogene anaerobe Schwelle (FTP)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2153"/>
         <source>Anaerobic Work Capacity (W&apos;)</source>
         <translation>Anaerobe Kapazität (W&apos;)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2258"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2155"/>
         <source>Maximum Power (PMax)</source>
         <translation>Maximale Leistung (PMax)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2270"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2167"/>
         <source>Manual range</source>
         <translation>Manuelle Eingabe</translation>
     </message>
@@ -5490,14 +5473,14 @@ Setup durchführen.</translation>
         <translation type="vanished">Maximale Anzahl von 10 Zonen erreicht.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2018"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2025"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1917"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1924"/>
         <source>New</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2020"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1919"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1926"/>
         <source>New (%1)</source>
         <translation>Neu (%1)</translation>
     </message>
@@ -5950,52 +5933,44 @@ ddd, dd.MMM yyyy</translation>
         <translation type="vanished">Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3307"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3319"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3308"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3320"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3313"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3325"/>
         <source>Add</source>
-        <translation>Hinzufügen</translation>
+        <translation type="vanished">Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3314"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3326"/>
         <source>Delete</source>
-        <translation>Löschen</translation>
+        <translation type="vanished">Löschen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3316"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3109"/>
         <source>Def</source>
         <translation>Standardwert</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3359"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3506"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3272"/>
         <source>Start Date</source>
         <translation>Startdatum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3249"/>
         <source>New range</source>
         <translation>Neuen Eintrag erstellen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3507"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3273"/>
         <source>Critical Velocity (CV)</source>
         <translation>Critical Velocity (CV)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3508"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3274"/>
         <source>Aerobic Threshold (AeT)</source>
         <translation>Aerobe Schwelle (AeT)</translation>
     </message>
@@ -6004,12 +5979,12 @@ ddd, dd.MMM yyyy</translation>
         <translation type="vanished">Ab Datum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3360"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3128"/>
         <source>Critical Velocity</source>
         <translation>Critical Velocity</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3361"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3129"/>
         <source>Aerobic Threshold</source>
         <translation>Aerobe Schwelle</translation>
     </message>
@@ -6022,17 +5997,17 @@ ddd, dd.MMM yyyy</translation>
         <translation type="vanished">dd.MMM yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3403"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
         <source>Short</source>
         <translation>Zone</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3404"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3172"/>
         <source>Long</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3405"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3173"/>
         <source>From</source>
         <translation>Von Geschwindigkeit</translation>
     </message>
@@ -6041,14 +6016,14 @@ ddd, dd.MMM yyyy</translation>
         <translation type="vanished">Maximale Anzahl von 10 Zonen erreicht.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3679"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3686"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3441"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3448"/>
         <source>New</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3681"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3688"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3443"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3450"/>
         <source>New (%1)</source>
         <translation>Neu (%1)</translation>
     </message>
@@ -7586,37 +7561,32 @@ Möchten Sie die Änderung durchführen und GoldenCheetah neu starten?</translat
 <context>
     <name>CredentialsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="67"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
+    </message>
+    <message>
+        <source>-</source>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="vanished">Bearbeiten</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">Hinzufügen</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">Löschen</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="68"/>
-        <source>-</source>
-        <translation>-</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="69"/>
-        <source>Edit</source>
-        <translation>Bearbeiten</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="74"/>
-        <source>Add</source>
-        <translation>Hinzufügen</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="75"/>
-        <source>Delete</source>
-        <translation>Löschen</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="86"/>
         <source>Service</source>
         <translation>Dienst</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="87"/>
+        <location filename="../../Gui/AthletePages.cpp" line="69"/>
         <source>Description</source>
         <translation>Beschreibung</translation>
     </message>
@@ -8303,7 +8273,7 @@ Möchten Sie die Änderung durchführen und GoldenCheetah neu starten?</translat
 <context>
     <name>DataFilterEdit</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2743"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2712"/>
         <source>Warning: sample() is slow -- update code to use samples()</source>
         <translation>Warnung: sample() ist langsam - Code auf samples() aktualisieren</translation>
     </message>
@@ -8662,7 +8632,7 @@ Möchten Sie die Änderung durchführen und GoldenCheetah neu starten?</translat
 <context>
     <name>DirectoryPathWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="277"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="308"/>
         <source>Browse</source>
         <translation>Durchsuchen</translation>
     </message>
@@ -8897,28 +8867,28 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>Dropbox</name>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="68"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="77"/>
         <source>Problem accessing Dropbox data</source>
         <translation>Problem beim Zugriff auf die Dropbox-Daten</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="130"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="139"/>
         <source>You must authorise with Dropbox first</source>
         <translation>Sie müssen sich zuerst bei Dropbox autorisieren</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="205"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="214"/>
         <source>Parsing Error: %1</source>
         <translation>Fehler beim Parsen: %1</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="293"/>
-        <location filename="../../Cloud/Dropbox.cpp" line="312"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="302"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="321"/>
         <source>Completed.</source>
         <translation>Abgeschlossen.</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="297"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="306"/>
         <source>Network Error - Upload failed.</source>
         <translation>Netzwerkfehler - Hochladen fehlgeschlagen.</translation>
     </message>
@@ -9063,136 +9033,136 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2064"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2033"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2034"/>
         <source>Axis Label / Units</source>
         <translation>Achsenbeschriftung / Einheiten</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1597"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1566"/>
         <source>Curve Settings</source>
         <translation>Kurveneinstellungen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1558"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1527"/>
         <source>Estimate %1 %2 Power</source>
         <translation>Schätzung %1 %2 Leistung</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1562"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1531"/>
         <source>Endurance Index</source>
         <translation>Ausdauerindex</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1532"/>
         <source>Vo2Max Estimate</source>
         <translation>VO2max-Schätzung</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1605"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1574"/>
         <source>Metric</source>
         <translation>Metrik</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1606"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1575"/>
         <source>Best</source>
         <translation>Beste</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1607"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1576"/>
         <source>Estimate</source>
         <translation>Schätzung</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1577"/>
         <source>PMC</source>
         <translation>PMC</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1609"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1578"/>
         <source>Formula</source>
         <translation>Formel</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1610"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1579"/>
         <source>Measure</source>
         <translation>Messwert</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1611"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1580"/>
         <source>Performance</source>
         <translation>Leistung</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1612"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1581"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1684"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1767"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1653"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1736"/>
         <source>seconds</source>
         <translation>Sekunden</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1685"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1768"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1737"/>
         <source>minutes</source>
         <translation>Minuten</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1769"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1655"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1738"/>
         <source>hours</source>
         <translation>Stunden</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1723"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1816"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1692"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1785"/>
         <source>Peak</source>
         <translation>Spitze</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1781"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1750"/>
         <source>Absolute</source>
         <translation>Absolut</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1751"/>
         <source>Per Kilogram</source>
         <translation>Per Kilogramm</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1813"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
         <source>Total</source>
         <translation>Summe</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1814"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1783"/>
         <source>Running Total</source>
         <translation>Summe Laufen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1815"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1784"/>
         <source>Average</source>
         <translation>Durchschnitt</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1817"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1786"/>
         <source>Low</source>
         <translation>Niedrigster</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1820"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1789"/>
         <source>Aggregate:</source>
         <translation>Aggregiere:</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1828"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1797"/>
         <source># type in a formula to use
 # for e.g. BikeStress / Duration
 # as you type the available metrics
@@ -9207,295 +9177,295 @@ then click &quot;Rescan&quot; to check again.</source>
 </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1839"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1808"/>
         <source>Weekly Best Performances</source>
         <translation>Wochenbestleistungen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1840"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1809"/>
         <source>Submaximal Weekly Best</source>
         <translation>Submaximale Wochenbestleistungen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1841"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1810"/>
         <source>Performance Tests</source>
         <translation>Leistungstests</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1933"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1902"/>
         <source>Short Term Stress (STS/ATL)</source>
         <translation>Kurzzeitbelastung (STS/ATL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1934"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1903"/>
         <source>Long Term Stress  (LTS/CTL)</source>
         <translation>Langzeitbelastung (LTS/CTL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1935"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1904"/>
         <source>Stress Balance    (SB/TSB)</source>
         <translation>Belastungsbilanz (SB/TSB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1936"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1905"/>
         <source>Stress Ramp Rate  (RR)</source>
         <translation>Belastungssteigerungsrate (RR)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1944"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1913"/>
         <source>Stress Type</source>
         <translation>Belastungstyp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1949"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1918"/>
         <source>Negative Training Effect (NTE)</source>
         <translation>Negativer Trainingseffekt (NTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1950"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1919"/>
         <source>Positive Training Effect (PTE)</source>
         <translation>Positiver Trainingseffekt (PTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1951"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1920"/>
         <source>Performance (Power Index)</source>
         <translation>Leistung (Leistungsindex)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1952"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1921"/>
         <source>Predicted CP (Watts)</source>
         <translation>Vorhergesagte CP (Watt)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1969"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1938"/>
         <source>Curve Type</source>
         <translation>Kurventyp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1945"/>
         <source>Perf. Metric</source>
         <translation>Leist. Metrik</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2006"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1975"/>
         <source>Metadata Field</source>
         <translation>Metadatenfeld</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2007"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
         <source>PMC metric</source>
         <translation>PMC-Metrik</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2032"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2001"/>
         <source>Measure Group</source>
         <translation>Messwertgruppe</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2009"/>
         <source>Measure Field</source>
         <translation>Messwertfeld</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2029"/>
         <source>Filter</source>
         <translation>Filter</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2071"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
         <source>Style</source>
         <translation>Darstellung</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2042"/>
         <source>Bar</source>
         <translation>Balken</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2074"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2043"/>
         <source>Line</source>
         <translation>Linie</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2075"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2044"/>
         <source>Sticks</source>
         <translatorcomment>???</translatorcomment>
         <translation>Stöcke</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2076"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2045"/>
         <source>Dots</source>
         <translation>Punkte</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2048"/>
         <source>Stack</source>
         <translation>Stapel</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2053"/>
         <source>Symbol</source>
         <translation>Symbol</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2086"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2055"/>
         <source>None</source>
         <translation>Kein(e)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2087"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2056"/>
         <source>Circle</source>
         <translation>Kreis</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2057"/>
         <source>Square</source>
         <translation>Quadrat</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2089"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2058"/>
         <source>Diamond</source>
         <translation>Raute</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2090"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2059"/>
         <source>Triangle</source>
         <translation>Dreieck</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2091"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
         <source>Cross</source>
         <translation>Kreuz</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2092"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2061"/>
         <source>Hexagon</source>
         <translation>Sechseck</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2062"/>
         <source>Star</source>
         <translation>Stern</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
         <source>Color</source>
         <translation>Farbe</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2100"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2069"/>
         <source>Fill curve</source>
         <translation>Kurve füllen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
         <source>Data labels</source>
         <translatorcomment>???</translatorcomment>
         <translation>Beschriftungen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2080"/>
         <source>Highlight Highest</source>
         <translation>Höchste hervorheben</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
         <source>Highlight Lowest</source>
         <translation>Niedrigste hervorheben</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2127"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
         <source>Highlight Outliers</source>
         <translation>Ausreißer hervorheben</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2135"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
         <source>Baseline</source>
         <translatorcomment>???</translatorcomment>
         <translation>Grundwert</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2143"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2112"/>
         <source>Smooth Curve</source>
         <translation>Kurve glätten</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2147"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2116"/>
         <source>No trend Line</source>
         <translation>Keine Trendlinie</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2148"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2117"/>
         <source>Linear Trend</source>
         <translation>Linearer Trend</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2149"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2118"/>
         <source>Quadratic Trend</source>
         <translation>Quadratischer Trend</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2150"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
         <source>Moving Average</source>
         <translation>Gleitender Durchschnitt</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2151"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2120"/>
         <source>Simple Average</source>
         <translation>Einfacher Durchschnitt</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2123"/>
         <source>Ignore Zeros</source>
         <translation>Nullwerte ignorieren</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2168"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2201"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2170"/>
         <source>&amp;Cancel</source>
         <translation>Abbre&amp;chen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2431"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2400"/>
         <source>Peak %1</source>
         <translation>Spitze %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2402"/>
         <source> second </source>
         <translation> Sekunde </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2434"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2403"/>
         <source> minute </source>
         <translation> Minute </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2436"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2405"/>
         <source> hour </source>
         <translation> Stunde </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2456"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2425"/>
         <source>%1 - %2</source>
         <translation>%1 - %2</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2470"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2439"/>
         <source>Performances</source>
         <translation>Leistungen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2471"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2440"/>
         <source>Power Index</source>
         <translation>Leistungsindex</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2588"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2557"/>
         <source>Performances_%1_%2_%3</source>
         <translation>Leistungen_%1_%2_%3</translation>
     </message>
@@ -9825,93 +9795,93 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>EditUserAxisDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1731"/>
+        <location filename="../../Charts/UserChart.cpp" line="1689"/>
         <source>Edit Axis</source>
         <translation>Achse bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1741"/>
+        <location filename="../../Charts/UserChart.cpp" line="1699"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1742"/>
+        <location filename="../../Charts/UserChart.cpp" line="1700"/>
         <source>&amp;Cancel</source>
         <translation>Abbre&amp;chen</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1750"/>
+        <location filename="../../Charts/UserChart.cpp" line="1708"/>
         <source>Units</source>
         <translation>Einheiten</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1760"/>
+        <location filename="../../Charts/UserChart.cpp" line="1718"/>
         <source>Logarithmic Scale</source>
         <translation>Logarithmische Skala</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1757"/>
+        <location filename="../../Charts/UserChart.cpp" line="1715"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1761"/>
-        <location filename="../../Charts/UserChart.cpp" line="1780"/>
+        <location filename="../../Charts/UserChart.cpp" line="1719"/>
+        <location filename="../../Charts/UserChart.cpp" line="1738"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1763"/>
+        <location filename="../../Charts/UserChart.cpp" line="1721"/>
         <source>Fixed</source>
         <translation>Festgelegt</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1774"/>
+        <location filename="../../Charts/UserChart.cpp" line="1732"/>
         <source> from </source>
         <translation> von </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1776"/>
+        <location filename="../../Charts/UserChart.cpp" line="1734"/>
         <source> to </source>
         <translation> bis </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1779"/>
+        <location filename="../../Charts/UserChart.cpp" line="1737"/>
         <source>Range</source>
         <translation>Bereich</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1787"/>
+        <location filename="../../Charts/UserChart.cpp" line="1745"/>
         <source>Smoothing</source>
         <translation>Glättung</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1792"/>
+        <location filename="../../Charts/UserChart.cpp" line="1750"/>
         <source>None</source>
         <translation>Keine</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1793"/>
+        <location filename="../../Charts/UserChart.cpp" line="1751"/>
         <source>Day</source>
         <translation>Tag</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1794"/>
+        <location filename="../../Charts/UserChart.cpp" line="1752"/>
         <source>Week</source>
         <translation>Woche</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1795"/>
+        <location filename="../../Charts/UserChart.cpp" line="1753"/>
         <source>Month</source>
         <translation>Monat</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1796"/>
+        <location filename="../../Charts/UserChart.cpp" line="1754"/>
         <source>Year</source>
         <translation>Jahr</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1798"/>
+        <location filename="../../Charts/UserChart.cpp" line="1756"/>
         <source>Group By</source>
         <translation>Gruppieren nach</translation>
     </message>
@@ -10110,158 +10080,158 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>EditUserSeriesDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1398"/>
+        <location filename="../../Charts/UserChart.cpp" line="1356"/>
         <source>Edit Data Series</source>
         <translation>Datenreihen bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1414"/>
+        <location filename="../../Charts/UserChart.cpp" line="1372"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1415"/>
+        <location filename="../../Charts/UserChart.cpp" line="1373"/>
         <source>&amp;Cancel</source>
         <translation>Abbre&amp;chen</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1422"/>
+        <location filename="../../Charts/UserChart.cpp" line="1380"/>
         <source>Group</source>
         <translation>Gruppe</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1430"/>
+        <location filename="../../Charts/UserChart.cpp" line="1388"/>
         <source>Series Name</source>
         <translation>Name der Datenreihe</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1519"/>
+        <location filename="../../Charts/UserChart.cpp" line="1477"/>
         <source>Y units</source>
         <translation>Y-Einheiten</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1524"/>
+        <location filename="../../Charts/UserChart.cpp" line="1482"/>
         <source>X units</source>
         <translation>X-Einheiten</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1528"/>
+        <location filename="../../Charts/UserChart.cpp" line="1486"/>
         <source>Sum</source>
         <translation>Summe</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1529"/>
+        <location filename="../../Charts/UserChart.cpp" line="1487"/>
         <source>Average</source>
         <translation>Durchschnitt</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1530"/>
+        <location filename="../../Charts/UserChart.cpp" line="1488"/>
         <source>Peak</source>
         <translation>Spitze</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1531"/>
+        <location filename="../../Charts/UserChart.cpp" line="1489"/>
         <source>Low</source>
         <translation>Niedrigster</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1532"/>
+        <location filename="../../Charts/UserChart.cpp" line="1490"/>
         <source>Running Total</source>
         <translation>Summe Laufen</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1533"/>
+        <location filename="../../Charts/UserChart.cpp" line="1491"/>
         <source>Mean Square Root</source>
         <translation>Quadratisches Mittel</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1534"/>
+        <location filename="../../Charts/UserChart.cpp" line="1492"/>
         <source>Std Deviation</source>
         <translation>Standardabweichung</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1537"/>
+        <location filename="../../Charts/UserChart.cpp" line="1495"/>
         <source>Aggregate</source>
         <translation>Aggregieren</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1541"/>
-        <location filename="../../Charts/UserChart.cpp" line="1557"/>
+        <location filename="../../Charts/UserChart.cpp" line="1499"/>
+        <location filename="../../Charts/UserChart.cpp" line="1515"/>
         <source>None</source>
         <translation>Keine</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1542"/>
+        <location filename="../../Charts/UserChart.cpp" line="1500"/>
         <source>Solid</source>
         <translation>Durchgehend</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1543"/>
+        <location filename="../../Charts/UserChart.cpp" line="1501"/>
         <source>Dashed</source>
         <translation>Gestrichelt</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1544"/>
+        <location filename="../../Charts/UserChart.cpp" line="1502"/>
         <source>Dot</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1545"/>
+        <location filename="../../Charts/UserChart.cpp" line="1503"/>
         <source>Dash Dot</source>
         <translation>Strichpunkt</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1546"/>
+        <location filename="../../Charts/UserChart.cpp" line="1504"/>
         <source>Fast Graphics</source>
         <translation>Schnelle Grafiken</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1547"/>
+        <location filename="../../Charts/UserChart.cpp" line="1505"/>
         <source>Show on Legend</source>
         <translation>Legende anzeigen</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1548"/>
+        <location filename="../../Charts/UserChart.cpp" line="1506"/>
         <source>Show Data Labels</source>
         <translation>Datenlabels anzeigen</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1554"/>
+        <location filename="../../Charts/UserChart.cpp" line="1512"/>
         <source>Line Style</source>
         <translation>Linienart</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1558"/>
+        <location filename="../../Charts/UserChart.cpp" line="1516"/>
         <source>Circle</source>
         <translation>Kreis</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1559"/>
+        <location filename="../../Charts/UserChart.cpp" line="1517"/>
         <source>Rectangle</source>
         <translation>Rechteck</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1564"/>
+        <location filename="../../Charts/UserChart.cpp" line="1522"/>
         <source>Symbol</source>
         <translation>Symbol</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1572"/>
+        <location filename="../../Charts/UserChart.cpp" line="1530"/>
         <source>Color</source>
         <translation>Farbe</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1575"/>
+        <location filename="../../Charts/UserChart.cpp" line="1533"/>
         <source>Fill curve</source>
         <translation>Kurve füllen</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1583"/>
+        <location filename="../../Charts/UserChart.cpp" line="1541"/>
         <source>Opacity (%)</source>
         <translation>Transparenz (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1589"/>
+        <location filename="../../Charts/UserChart.cpp" line="1547"/>
         <source>Size/Width</source>
         <translation>Größe/Breite</translation>
     </message>
@@ -10309,6 +10279,24 @@ then click &quot;Rescan&quot; to check again.</source>
         <location filename="../../Metrics/BasicRideMetrics.cpp" line="144"/>
         <source>Only useful for intervals, time the interval started</source>
         <translation>Zeitpunkt bei dem das Interval startet (nur sinnvoll bei Intervallen)</translation>
+    </message>
+</context>
+<context>
+    <name>ElevationChartWindow</name>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="221"/>
+        <source>Profile Distance (m)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="229"/>
+        <source>Seconds for delta slope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="237"/>
+        <source>Elevation window size (%) relative to current altitude</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10747,7 +10735,7 @@ then click &quot;Rescan&quot; to check again.</source>
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ExhaustionDialog.cpp" line="160"/>
+        <location filename="../../Charts/ExhaustionDialog.cpp" line="162"/>
         <source>Time</source>
         <translation>Zeit</translation>
     </message>
@@ -13423,42 +13411,42 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
 <context>
     <name>GcCrashDialog</name>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="78"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="74"/>
         <source>%1 Crash Recovery</source>
         <translation>%1 Wiederherstellung nach Absturz</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="116"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="112"/>
         <source>&lt;b&gt;GoldenCheetah appears to have PREVIOUSLY crashed for this athlete. &lt;/b&gt;&lt;br&gt;&lt;br&gt;The report below gives some diagnostic information that will be useful to the developers. Feel free to post this with a short description of what was occurring when the crash happened to the &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah forums&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;We respect privacy - this log does NOT contain ids, passwords or personal information.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;When this dialog is closed the athlete will be opened.&lt;/b&gt;</source>
         <translation>&lt;b&gt;GoldenCheetah ist anscheinend abgestürzt, als dieser Athlet zuletzt bearbeitet wurde. &lt;/b&gt;&lt;br&gt;&lt;br&gt;Der unten stehende Bericht enthält einige Informationen, die den Entwicklern helfen können, das Problem zu beheben. Bitte sende diesen Bericht mit einer kurzen Beschreibung an das &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah-Forum&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;Datenschutzhinweis: Dieser Bericht enthält keine IDs, Passwörter oder persönliche Informationen.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;Nach Schließen dieses Dialogs wird der Athlet in GoldenCheetah geöffnet.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="141"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="137"/>
         <source>Save Crash Report...</source>
         <translation>Absturzbericht speichern...</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="143"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="139"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="225"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="221"/>
         <source>&lt;p&gt;Build date: %1 %2&lt;br&gt;Build id: %3&lt;br&gt;Version: %4&lt;br&gt;DB Schema: %5&lt;br&gt;Metrics: %7&lt;br&gt;OS: %6&lt;br&gt;OpenGL: %10&lt;br&gt;UI: dpi scale (%8) font size (%9)&lt;br&gt;</source>
         <translation>&lt;p&gt;Erstellungsdatum: %1 %2&lt;br&gt;Erstellungskennung: %3&lt;br&gt;Version: %4&lt;br&gt;DB-Schema: %5&lt;br&gt;Metriken: %7&lt;br&gt;Betriebssystem: %6&lt;br&gt;OpenGL: %10&lt;br&gt;UI: dpi-Skalierung (%8) Schriftgröße (%9)&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="255"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="251"/>
         <source>&lt;table&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QT&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QWT&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;%3&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SRMIO&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;D2XX&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;ICAL&lt;/td&gt;&lt;td&gt;%9&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;USBXPRESS&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LIBUSB&lt;/td&gt;&lt;td&gt;%11&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VLC&lt;/td&gt;&lt;td&gt;%12&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VIDEO&lt;/td&gt;&lt;td&gt;%13&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SAMPLERATE&lt;/td&gt;&lt;td&gt;%14&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SSL&lt;/td&gt;&lt;td&gt;%15&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;R&lt;/td&gt;&lt;td&gt;%16&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;Python&lt;/td&gt;&lt;td&gt;%18&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LMFIT&lt;/td&gt;&lt;td&gt;7.0&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;GSL&lt;/td&gt;&lt;td&gt;%19&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</source>
         <translation>&lt;table&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QT&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QWT&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;%3&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SRMIO&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;D2XX&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;ICAL&lt;/td&gt;&lt;td&gt;%9&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;USBXPRESS&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LIBUSB&lt;/td&gt;&lt;td&gt;%11&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VLC&lt;/td&gt;&lt;td&gt;%12&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VIDEO&lt;/td&gt;&lt;td&gt;%13&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SAMPLERATE&lt;/td&gt;&lt;td&gt;%14&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SSL&lt;/td&gt;&lt;td&gt;%15&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;R&lt;/td&gt;&lt;td&gt;%16&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;Python&lt;/td&gt;&lt;td&gt;%18&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LMFIT&lt;/td&gt;&lt;td&gt;7.0&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;GSL&lt;/td&gt;&lt;td&gt;%19&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Save Diagnostics</source>
         <translation>Diagnoseinformationen speichern</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Text File (*.txt)</source>
         <translation>Textdatei (*.txt)</translation>
     </message>
@@ -13793,168 +13781,173 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
 <context>
     <name>GcWindowRegistry</name>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
         <source>Performance</source>
         <translation>Leistung</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="89"/>
         <source>Histogram</source>
         <translation>Histogramm</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
         <source>Distribution</source>
         <translation>Verteilung</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
         <source>Pedal Force vs Velocity</source>
         <translation>Pedalkraft über Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
         <source>Heartrate vs Power</source>
         <translation>Herzfrequenz über Leistung</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
         <source>Python Chart</source>
         <translation>Python-Diagramm</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
         <source>Python Chart </source>
         <translation>Python-Diagramm </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="101"/>
         <source>Calendar</source>
         <translation>Kalender</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
         <source>Navigator</source>
         <translation>Navigator</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="71"/>
         <source>Season Overview</source>
         <translation>Saisonübersicht</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="72"/>
         <source>Blank Overview </source>
         <translation>Leere Übersicht </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="76"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="73"/>
         <source>User Chart</source>
         <translation>Benutzerdiagramm</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
         <source>Trends</source>
         <translation>Trends</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="78"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
         <source>TreeMap</source>
         <translation>Baumkarte</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
         <source>Power Duration </source>
         <translation>Leistungskurve </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="83"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
         <source>Activity Overview</source>
         <translation>Aktivitätsübersicht</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="81"/>
         <source>Blank Overview</source>
         <translation>Leere Übersicht</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="85"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="82"/>
         <source>User Chart </source>
         <translation>Benutzerdiagramm </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
         <source>Data</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="88"/>
         <source>Power Duration</source>
         <translation>Leistungskurve</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
         <source>Scatter</source>
         <translation>Streudiagramm</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="103"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
         <source>Aerolab</source>
         <translation>Aerolabor</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
         <source>Telemetry</source>
         <translation>Telemetrie</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
         <source>Workout</source>
         <translation>Workout</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="106"/>
         <source>Realtime</source>
         <translation>Echtzeit</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
         <source>Pedal Stroke</source>
         <translatorcomment>???</translatorcomment>
         <translation>Pedaltritt</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="113"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
         <source>Live Map</source>
         <translation>Echtzeit-Kartendarstellung</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="114"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <source>Elevation Chart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
         <source>Web page</source>
         <translation>Webseite</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
         <source>Map</source>
         <translation>Karte</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
         <source>R Chart</source>
         <translation>R-Diagramm</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="98"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
         <source>R Chart </source>
         <translation>R-Diagramm </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
         <source>Video Player</source>
         <translation>Video Player</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
         <source>Workout Editor</source>
         <translation>Workout-Editor</translation>
     </message>
@@ -15058,142 +15051,147 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
         <translation>Echtzeitanzeige der Route von Simulationstrainings in einer Open Street Map</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="296"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="294"/>
+        <source>Show elevation profile of instant position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
         <source>Predefined and configurable set of data ranges for selection of activities to be analysed</source>
         <translation>Vordefinierter und konfigurierbarer Satz von Datenbereichen zur Auswahl der zu analysierenden Aktivitäten</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
         <source>Powerful filter and search engine to determine the activities which are considered in diagram</source>
         <translation>Leistungsstarke Filter und Suchmaschine zur Bestimmung der Aktivitäten, die im Diagramm berücksichtigt werden</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
         <source>Configurable list of activities</source>
         <translation>Konfigurierbare Liste von Aktivitäten</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="317"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
         <source>Configurable list of training devices</source>
         <translation>Konfigurierbare Liste von Trainingsgeräten</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
         <source>Configurable list of workout files</source>
         <translation>Konfigurierbare Liste von Workout-Dateien</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
         <source>Configurable list of video files</source>
         <translation>Konfigurierbare Liste von Videodateien</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="325"/>
         <source>Configurable list of video sync files</source>
         <translation>Konfigurierbare Liste von Video-Synchronisationsdateien</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="327"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
         <source>Entry field for sophisticated Searching and Filtering of activities</source>
         <translation>Eingabefeld für anspruchsvolle Suche und Filterung von Aktivitäten</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
         <source>Adding intervals to an activity using simple query methods</source>
         <translation>Intervalle mit Hilfe von Suchmethoden in eine Aktivität hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
         <source>To compare Activities/Intervals in Activity View and Date Ranges in Trends View</source>
         <translation>So vergleichen Sie Aktivitäten/Intervalle in der Aktivitätsansicht und Datumsbereiche in der Trendansicht</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="335"/>
         <source>Workout Control, Intensity Adjustments and Notifications Display</source>
         <translation>Trainingssteuerung, Intensitätsanpassung und Benachrichtigungsanzeige</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
         <source>Athlete Model</source>
         <translation>Athletenmodell</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
         <source>Athlete Measures</source>
         <translation>Messwerte für Athleten</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
         <source>Auto Import</source>
         <translation>Auto-Import</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
         <source>Backup</source>
         <translation>Sicherung</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="355"/>
         <source>Cloud Accounts</source>
         <translation>Cloud-Konten</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <source>Automatic Interval Detection</source>
         <translation>Automatische Intervallerkennung</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
         <source>Definition of coloring rules for activities</source>
         <translation>Definition von Farbregeln für Aktivitäten</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
         <source>Metrics shown in &apos;Intervals&apos; and &apos;Summary&apos;</source>
         <translation>Metriken werden in &quot;Intervalle&quot; und &quot;Zusammenfassung&quot; angezeigte</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
         <source>User/Custom Metrics</source>
         <translation>Benutzermetriken, die heruntergeladen, importiert oder selbst erstellt wurden</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
         <source>Create or Edit a User Metric</source>
         <translation>Benutzermetrik erstellen oder bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
         <source>Measures</source>
         <translation>Messwerte</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
         <source>Train View devices configuration and preferences</source>
         <translation>Konfiguration und Einstellungen von Trainingsgeräten</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
         <source>Train View Preferences</source>
         <translation>Einstellungen der Trainingsgeräte</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
         <source>Remote Controls Configuration</source>
         <translation>Konfiguration der Fernbedienungen</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
         <source>Add/Remove Train Devices</source>
         <translation>Hinzufügen/Löschen von Trainingsgeräten</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
         <source>Add Train Devices</source>
         <translation>Fügt Trainingsgeräte hinzu</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="394"/>
         <source>Virtual Bicycle configuration for simulation rides</source>
         <translation>Virtuelle Fahrradkonfiguration für Simulationsfahrten</translation>
     </message>
@@ -15227,8 +15225,8 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
     </message>
     <message>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="219"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
         <source>Calendar</source>
         <translation>Kalender</translation>
     </message>
@@ -15263,74 +15261,74 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
         <translation>Diagrammspezifische Filter-/Such- und Datumsbereichseinstellungen</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
         <source>Definition of points in time &apos;Events&apos; which are marked explicitely on time related diagrams</source>
         <translation>Definition von Zeitpunkten &quot;Events&quot;, die in zeitbezogenen Diagrammen explizit markiert werden</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="316"/>
         <source>Simple summary view</source>
         <translation>Einfache Übersichtsansicht</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
         <source>Alternative access to the charts created for the main view</source>
         <translation>Alternativer Zugriff auf die für die Hauptansicht erstellten Diagramme</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
         <source>Display the available and add new intervals using simple query methods</source>
         <translation>Anzeige der verfügbaren Intervalle und Hinzufügen neuer Intervalle mit einfachen Abfragemethoden</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="356"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
         <source>General</source>
         <translation>Allgemein</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="337"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
         <source>Athlete</source>
         <translation>Athlet</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
         <source>Training Zone definition for power</source>
         <translation>Trainingszonen-Definition für Leistung</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
         <source>Training Zone definition for heartrate</source>
         <translation>Trainingszonen-Definition für Herzfrequenz</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
         <source>Training Zone definition for Swim and Run</source>
         <translation>Trainingszonen-Definition für Schwimmen und Laufen</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
         <source>Appearance</source>
         <translation>Erscheinungsbild</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="364"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
         <source>Data Fields</source>
         <translation>Datenfelder</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
         <source>Definition of default value(s) for data fields</source>
         <translation>Definition des/der Standardwerte(s) für Datenfelder</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
         <source>Definition of processing default parameters for the fix, adjust,... tools</source>
         <translation>Definition von Verarbeitungsvorgaben für das Korrigieren, Anpassen... Werkzeuge</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
         <source>Metrics</source>
         <translation>Metriken</translation>
     </message>
@@ -15530,47 +15528,43 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2437"/>
         <source>Add</source>
-        <translation>Hinzufügen</translation>
+        <translation type="vanished">Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2438"/>
         <source>Delete</source>
-        <translation>Löschen</translation>
+        <translation type="vanished">Löschen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2431"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2432"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2447"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2332"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2458"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2343"/>
         <source>Short</source>
         <translation>Zone</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2459"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2344"/>
         <source>Long</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2460"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2345"/>
         <source>Percent of LT</source>
         <translation>Prozentsatz der Anaerobe Schwelle</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2461"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2346"/>
         <source>Trimp k</source>
         <translation>TRIMP k</translation>
     </message>
@@ -15579,14 +15573,14 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
         <translation type="vanished">Maximale Anzahl von 10 Zonen erreicht.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2506"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2513"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2390"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2397"/>
         <source>New</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2508"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2515"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2392"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2399"/>
         <source>New (%1)</source>
         <translation>Neu (%1)</translation>
     </message>
@@ -15776,17 +15770,17 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2245"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2395"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2292"/>
         <source>Lactate Threshold</source>
         <translation>Anaerobe Schwelle</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2396"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2293"/>
         <source>Default</source>
         <translation>Standardeinstellung</translation>
     </message>
@@ -18034,545 +18028,542 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
 <context>
     <name>LTMTool</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1303"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1272"/>
         <source>Metric</source>
         <translation>Metrik</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="74"/>
+        <location filename="../../Charts/LTMTool.cpp" line="75"/>
         <source>Filter</source>
         <translation>Filter</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="80"/>
+        <location filename="../../Charts/LTMTool.cpp" line="81"/>
         <source>Date range</source>
         <translation>Datumsbereich</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="84"/>
+        <location filename="../../Charts/LTMTool.cpp" line="85"/>
         <source>Days</source>
         <translation>Tage</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="85"/>
+        <location filename="../../Charts/LTMTool.cpp" line="86"/>
         <source>Weeks</source>
         <translation>Wochen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="86"/>
+        <location filename="../../Charts/LTMTool.cpp" line="87"/>
         <source>Months</source>
         <translation>Monate</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="87"/>
+        <location filename="../../Charts/LTMTool.cpp" line="88"/>
         <source>Years</source>
         <translation>Jahre</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="88"/>
+        <location filename="../../Charts/LTMTool.cpp" line="89"/>
         <source>Time Of Day</source>
         <translation>Tageszeit</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="89"/>
+        <location filename="../../Charts/LTMTool.cpp" line="90"/>
         <source>All</source>
         <translation>Alles</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="91"/>
+        <location filename="../../Charts/LTMTool.cpp" line="92"/>
         <source>Group by</source>
         <translation>Gruppieren nach</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="102"/>
+        <location filename="../../Charts/LTMTool.cpp" line="103"/>
         <source>Shade Zones</source>
         <translation>Zonen anzeigen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="105"/>
+        <location filename="../../Charts/LTMTool.cpp" line="106"/>
         <source>Show Legend</source>
         <translation>Legende anzeigen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="109"/>
         <source>Show Events</source>
         <translation>Events anzeigen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="112"/>
         <source>Show Banister Helper</source>
         <translation>Banister-Hilfsfenster anzeigen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="121"/>
+        <location filename="../../Charts/LTMTool.cpp" line="122"/>
         <source>Stack Zoom</source>
         <translation>Zoom Stapelanzeige</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="146"/>
+        <location filename="../../Charts/LTMTool.cpp" line="147"/>
         <source>Charts</source>
         <translation>Diagramme</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Up</source>
-        <translation>Hoch</translation>
+        <translation type="vanished">Hoch</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Down</source>
-        <translation>Runter</translation>
+        <translation type="vanished">Runter</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="351"/>
+        <location filename="../../Charts/LTMTool.cpp" line="325"/>
         <source>Skiba Long Term Stress</source>
         <translation>Skiba Langzeitbelastung (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="353"/>
-        <location filename="../../Charts/LTMTool.cpp" line="368"/>
-        <location filename="../../Charts/LTMTool.cpp" line="429"/>
-        <location filename="../../Charts/LTMTool.cpp" line="444"/>
-        <location filename="../../Charts/LTMTool.cpp" line="505"/>
-        <location filename="../../Charts/LTMTool.cpp" line="520"/>
-        <location filename="../../Charts/LTMTool.cpp" line="580"/>
-        <location filename="../../Charts/LTMTool.cpp" line="595"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1080"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1095"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1156"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1171"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1309"/>
+        <location filename="../../Charts/LTMTool.cpp" line="327"/>
+        <location filename="../../Charts/LTMTool.cpp" line="342"/>
+        <location filename="../../Charts/LTMTool.cpp" line="403"/>
+        <location filename="../../Charts/LTMTool.cpp" line="418"/>
+        <location filename="../../Charts/LTMTool.cpp" line="479"/>
+        <location filename="../../Charts/LTMTool.cpp" line="494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="554"/>
+        <location filename="../../Charts/LTMTool.cpp" line="569"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1054"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1069"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1130"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1145"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1278"/>
         <source>Stress</source>
         <translation>Belastung</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="366"/>
+        <location filename="../../Charts/LTMTool.cpp" line="340"/>
         <source>Skiba Short Term Stress</source>
         <translation>Skiba Kurzzeitbelastung (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="381"/>
+        <location filename="../../Charts/LTMTool.cpp" line="355"/>
         <source>Skiba Stress Balance</source>
         <translation>Skiba Belastungsbilanz</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="383"/>
-        <location filename="../../Charts/LTMTool.cpp" line="459"/>
-        <location filename="../../Charts/LTMTool.cpp" line="535"/>
-        <location filename="../../Charts/LTMTool.cpp" line="610"/>
-        <location filename="../../Charts/LTMTool.cpp" line="686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="762"/>
-        <location filename="../../Charts/LTMTool.cpp" line="838"/>
-        <location filename="../../Charts/LTMTool.cpp" line="914"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1110"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1186"/>
+        <location filename="../../Charts/LTMTool.cpp" line="357"/>
+        <location filename="../../Charts/LTMTool.cpp" line="433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="509"/>
+        <location filename="../../Charts/LTMTool.cpp" line="584"/>
+        <location filename="../../Charts/LTMTool.cpp" line="660"/>
+        <location filename="../../Charts/LTMTool.cpp" line="736"/>
+        <location filename="../../Charts/LTMTool.cpp" line="812"/>
+        <location filename="../../Charts/LTMTool.cpp" line="888"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1160"/>
         <source>Stress Balance</source>
         <translation>Belastungsbilanz</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="396"/>
+        <location filename="../../Charts/LTMTool.cpp" line="370"/>
         <source>Skiba STS Ramp</source>
         <translation>Skiba STS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="398"/>
-        <location filename="../../Charts/LTMTool.cpp" line="413"/>
-        <location filename="../../Charts/LTMTool.cpp" line="474"/>
-        <location filename="../../Charts/LTMTool.cpp" line="489"/>
-        <location filename="../../Charts/LTMTool.cpp" line="550"/>
-        <location filename="../../Charts/LTMTool.cpp" line="565"/>
-        <location filename="../../Charts/LTMTool.cpp" line="625"/>
-        <location filename="../../Charts/LTMTool.cpp" line="640"/>
-        <location filename="../../Charts/LTMTool.cpp" line="701"/>
-        <location filename="../../Charts/LTMTool.cpp" line="716"/>
-        <location filename="../../Charts/LTMTool.cpp" line="777"/>
-        <location filename="../../Charts/LTMTool.cpp" line="792"/>
-        <location filename="../../Charts/LTMTool.cpp" line="853"/>
-        <location filename="../../Charts/LTMTool.cpp" line="868"/>
-        <location filename="../../Charts/LTMTool.cpp" line="929"/>
-        <location filename="../../Charts/LTMTool.cpp" line="944"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1005"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1020"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1125"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1140"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1201"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1216"/>
+        <location filename="../../Charts/LTMTool.cpp" line="372"/>
+        <location filename="../../Charts/LTMTool.cpp" line="387"/>
+        <location filename="../../Charts/LTMTool.cpp" line="448"/>
+        <location filename="../../Charts/LTMTool.cpp" line="463"/>
+        <location filename="../../Charts/LTMTool.cpp" line="524"/>
+        <location filename="../../Charts/LTMTool.cpp" line="539"/>
+        <location filename="../../Charts/LTMTool.cpp" line="599"/>
+        <location filename="../../Charts/LTMTool.cpp" line="614"/>
+        <location filename="../../Charts/LTMTool.cpp" line="675"/>
+        <location filename="../../Charts/LTMTool.cpp" line="690"/>
+        <location filename="../../Charts/LTMTool.cpp" line="751"/>
+        <location filename="../../Charts/LTMTool.cpp" line="766"/>
+        <location filename="../../Charts/LTMTool.cpp" line="827"/>
+        <location filename="../../Charts/LTMTool.cpp" line="842"/>
+        <location filename="../../Charts/LTMTool.cpp" line="903"/>
+        <location filename="../../Charts/LTMTool.cpp" line="918"/>
+        <location filename="../../Charts/LTMTool.cpp" line="979"/>
+        <location filename="../../Charts/LTMTool.cpp" line="994"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1099"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1114"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1175"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1190"/>
         <source>Ramp</source>
         <translation>Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="411"/>
+        <location filename="../../Charts/LTMTool.cpp" line="385"/>
         <source>Skiba LTS Ramp</source>
         <translation>Skiba LTS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="427"/>
+        <location filename="../../Charts/LTMTool.cpp" line="401"/>
         <source>Aerobic TISS Long Term Stress</source>
         <translation>Aerobe TISS Langzeitbelastung (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="442"/>
+        <location filename="../../Charts/LTMTool.cpp" line="416"/>
         <source>Aerobic TISS Short Term Stress</source>
         <translation>Aerobe TISS Kurzzeitbelastung (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="457"/>
+        <location filename="../../Charts/LTMTool.cpp" line="431"/>
         <source>Aerobic TISS Stress Balance</source>
         <translation>Aerobe TISS Belastungsbilanz (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="472"/>
+        <location filename="../../Charts/LTMTool.cpp" line="446"/>
         <source>Aerobic TISS STS Ramp</source>
         <translation>Aerober TISS STS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="487"/>
+        <location filename="../../Charts/LTMTool.cpp" line="461"/>
         <source>Aerobic TISS LTS Ramp</source>
         <translation>Aerober TISS LTS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="503"/>
+        <location filename="../../Charts/LTMTool.cpp" line="477"/>
         <source>Anaerobic TISS Long Term Stress</source>
         <translation>Anaerobe TISS Langzeitbelastung (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="518"/>
+        <location filename="../../Charts/LTMTool.cpp" line="492"/>
         <source>Anaerobic TISS Short Term Stress</source>
         <translation>Anaerobe TISS Kurzzeitbelastung (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="533"/>
+        <location filename="../../Charts/LTMTool.cpp" line="507"/>
         <source>Anaerobic TISS Stress Balance</source>
         <translation>Anerobe TISS Belastungsbilanz (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="548"/>
+        <location filename="../../Charts/LTMTool.cpp" line="522"/>
         <source>Anaerobic TISS STS Ramp</source>
         <translation>Anerober TISS STS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="537"/>
         <source>Anaerobic TISS LTS Ramp</source>
         <translation>Anaerober TISS LTS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="578"/>
+        <location filename="../../Charts/LTMTool.cpp" line="552"/>
         <source>Daniels Long Term Stress</source>
         <translation>Daniels Langzeitbelastung (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="593"/>
+        <location filename="../../Charts/LTMTool.cpp" line="567"/>
         <source>Daniels Short Term Stress</source>
         <translation>Daniels Kurzzeitbelastung (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="582"/>
         <source>Daniels Stress Balance</source>
         <translation>Daniels Belastungsbilanz (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="623"/>
+        <location filename="../../Charts/LTMTool.cpp" line="597"/>
         <source>Daniels STS Ramp</source>
         <translation>Daniels STS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="638"/>
+        <location filename="../../Charts/LTMTool.cpp" line="612"/>
         <source>Daniels LTS Ramp</source>
         <translation>Daniels LTS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="628"/>
         <source>Work (Kj) Long Term Stress</source>
         <translation>Arbeit (kJ) Langzeitbelastung (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="656"/>
-        <location filename="../../Charts/LTMTool.cpp" line="671"/>
-        <location filename="../../Charts/LTMTool.cpp" line="732"/>
-        <location filename="../../Charts/LTMTool.cpp" line="747"/>
-        <location filename="../../Charts/LTMTool.cpp" line="808"/>
-        <location filename="../../Charts/LTMTool.cpp" line="823"/>
+        <location filename="../../Charts/LTMTool.cpp" line="630"/>
+        <location filename="../../Charts/LTMTool.cpp" line="645"/>
+        <location filename="../../Charts/LTMTool.cpp" line="706"/>
+        <location filename="../../Charts/LTMTool.cpp" line="721"/>
+        <location filename="../../Charts/LTMTool.cpp" line="782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="797"/>
         <source>Stress (Kj)</source>
         <translation>Belastung (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="669"/>
+        <location filename="../../Charts/LTMTool.cpp" line="643"/>
         <source>Work (Kj) Short Term Stress</source>
         <translation>Arbeit (kJ) Kurzzeitbelastung ( STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="684"/>
+        <location filename="../../Charts/LTMTool.cpp" line="658"/>
         <source>Work (Kj) Stress Balance</source>
         <translation>Arbeit (kJ) Belastungsbilanz</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="699"/>
+        <location filename="../../Charts/LTMTool.cpp" line="673"/>
         <source>Work (Kj) STS Ramp</source>
         <translation>Arbeit (kJ) STS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="714"/>
+        <location filename="../../Charts/LTMTool.cpp" line="688"/>
         <source>Work (Kj) LTS Ramp</source>
         <translation>Arbeit (kJ) LTS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="730"/>
+        <location filename="../../Charts/LTMTool.cpp" line="704"/>
         <source>W&apos; Work (Kj) Long Term Stress</source>
         <translation>W&apos;-Arbeit (kJ) Langzeitbelastung (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="745"/>
+        <location filename="../../Charts/LTMTool.cpp" line="719"/>
         <source>W&apos; Work (Kj) Short Term Stress</source>
         <translation>W&apos;-Arbeit (kJ) Kurzzeitbelastung (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="760"/>
+        <location filename="../../Charts/LTMTool.cpp" line="734"/>
         <source>W&apos; Work (Kj) Stress Balance</source>
         <translation>W&apos;-Arbeit (kJ) Belastungsbilanz (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="775"/>
+        <location filename="../../Charts/LTMTool.cpp" line="749"/>
         <source>W&apos; Work (Kj) STS Ramp</source>
         <translation>W&apos;-Arbeit (kJ) STS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="790"/>
+        <location filename="../../Charts/LTMTool.cpp" line="764"/>
         <source>W&apos; Work (Kj) LTS Ramp</source>
         <translation>W&apos;-Arbeit (kJ) LTS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="806"/>
+        <location filename="../../Charts/LTMTool.cpp" line="780"/>
         <source>Below CP Work (Kj) Long Term Stress</source>
         <translation>Sub-CP-Arbeit (kJ) Langzeitbelastung (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="821"/>
+        <location filename="../../Charts/LTMTool.cpp" line="795"/>
         <source>Below CP Work (Kj) Short Term Stress</source>
         <translation>Sub-CP-Arbeit (kJ) Kurzzeitbelastung (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="836"/>
+        <location filename="../../Charts/LTMTool.cpp" line="810"/>
         <source>Below CP Work (Kj) Stress Balance</source>
         <translation>Sub-CP-Arbeit (kJ) Belastungsbilanz (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="851"/>
+        <location filename="../../Charts/LTMTool.cpp" line="825"/>
         <source>Below CP Work (Kj) STS Ramp</source>
         <translation>Sub-CP-Arbeit (kJ) STS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="866"/>
+        <location filename="../../Charts/LTMTool.cpp" line="840"/>
         <source>Below CP Work (Kj) LTS Ramp</source>
         <translation>Sub-CP-Arbeit (kJ) LTS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="882"/>
+        <location filename="../../Charts/LTMTool.cpp" line="856"/>
         <source>Distance (km|mi) Long Term Stress</source>
         <translation>Distanz (km|mi) LTS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="884"/>
-        <location filename="../../Charts/LTMTool.cpp" line="899"/>
+        <location filename="../../Charts/LTMTool.cpp" line="858"/>
+        <location filename="../../Charts/LTMTool.cpp" line="873"/>
         <source>Stress (km|mi)</source>
         <translation>Belastung (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="897"/>
+        <location filename="../../Charts/LTMTool.cpp" line="871"/>
         <source>Distance (km|mi) Short Term Stress</source>
         <translation>Distanz (km|mi) Kurzzeitbelastung (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="912"/>
+        <location filename="../../Charts/LTMTool.cpp" line="886"/>
         <source>Distance (km|mi) Stress Balance</source>
         <translation>Distanz (km|mi) Belastungsbilanz (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="927"/>
+        <location filename="../../Charts/LTMTool.cpp" line="901"/>
         <source>Distance (km|mi) STS Ramp</source>
         <translation>Distanz (km|mi) STS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="942"/>
+        <location filename="../../Charts/LTMTool.cpp" line="916"/>
         <source>Distance (km|mi) LTS Ramp</source>
         <translation>Distanz (km|mi) LTS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="958"/>
+        <location filename="../../Charts/LTMTool.cpp" line="932"/>
         <source>Coggan Chronic Training Load</source>
         <translation>Coggan Langzeit-Trainingsbelastung (CTL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="973"/>
+        <location filename="../../Charts/LTMTool.cpp" line="947"/>
         <source>Coggan Acute Training Load</source>
         <translation>Coggan Kurzzeit-Trainingsbelastung (ATL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="988"/>
+        <location filename="../../Charts/LTMTool.cpp" line="962"/>
         <source>Coggan Training Stress Balance</source>
         <translation>Coggan Trainingsbelastungsbilanz (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1003"/>
+        <location filename="../../Charts/LTMTool.cpp" line="977"/>
         <source>Coggan STS Ramp</source>
         <translation>Coggan STS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1018"/>
+        <location filename="../../Charts/LTMTool.cpp" line="992"/>
         <source>Coggan LTS Ramp</source>
         <translation>Coggan LTS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1033"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1007"/>
         <source>Coggan Expected Chronic Training Load</source>
         <translation>Coggan Erwartete Langzeit-Trainingsbelastung (CTL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1048"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1022"/>
         <source>Coggan Expected Acute Training Load</source>
         <translation>Coggan Erwartete Kurzzeit-Trainingsbelastung (ATL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1063"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1037"/>
         <source>Coggan Expected Training Stress Balance</source>
         <translation>Coggan Erwartete Trainingsbelastungsbilanz (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1053"/>
         <source>TRIMP Long Term Stress</source>
         <translation>TRIMP Langzeitbelastung (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1067"/>
         <source>TRIMP Short Term Stress</source>
         <translation>TRIMP Kurzzeitbelastung (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1082"/>
         <source>TRIMP Stress Balance</source>
         <translation>TRIMP Belastungsbilanz (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1123"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1097"/>
         <source>TRIMP STS Ramp</source>
         <translation>TRIMP STS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1138"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1112"/>
         <source>TRIMP LTS Ramp</source>
         <translation>TRIMP LTS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="268"/>
         <source>Edit</source>
-        <translation>Bearbeiten</translation>
+        <translation type="vanished">Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="124"/>
+        <location filename="../../Charts/LTMTool.cpp" line="125"/>
         <source>Use sidebar chart settings</source>
         <translation>Verwende Diagrammeinstellungen aus der Seitenleiste</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Basic</source>
         <translation>Grundeinstellungen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="314"/>
+        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Preset</source>
         <translation>Voreinstellungen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1128"/>
         <source>TriScore Long Term Stress</source>
         <translation>TriScore Langzeitbelastung (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1169"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1143"/>
         <source>TriScore Short Term Stress</source>
         <translation>TriScore Kurzzeitbelastung (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1184"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1158"/>
         <source>TriScore Stress Balance</source>
         <translation>TriScore Belastungsbilanz (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1173"/>
         <source>TriScore STS Ramp</source>
         <translation>TriScore STS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1214"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1188"/>
         <source>TriScore LTS Ramp</source>
         <translation>TriScore LTS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1307"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1276"/>
         <source>Estimate</source>
         <translation>Schätzen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1311"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1280"/>
         <source>Formula</source>
         <translation>Formel</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1282"/>
         <source>Measure</source>
         <translation>Messwert</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1284"/>
         <source>Performance</source>
         <translation>Leistung</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1317"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1286"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1463"/>
         <source>Chart %1</source>
         <translation>Diagramm %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="94"/>
+        <location filename="../../Charts/LTMTool.cpp" line="95"/>
         <source>Data Table</source>
         <translation>Daten als Tabelle</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="98"/>
+        <location filename="../../Charts/LTMTool.cpp" line="99"/>
         <source>Show Stack</source>
         <translation>Gestapelt anzeigen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="155"/>
+        <location filename="../../Charts/LTMTool.cpp" line="156"/>
         <source>Add Current</source>
         <translation>Aktuelles hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="155"/>
         <source>Apply</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="289"/>
         <source>Curves</source>
         <translation>Daten</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1305"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1274"/>
         <source>Peak</source>
         <translation>Spitze</translation>
     </message>
@@ -18775,50 +18766,42 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
         <translation type="vanished">Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2590"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2602"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2591"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2603"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2596"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2608"/>
         <source>Add</source>
-        <translation>Hinzufügen</translation>
+        <translation type="vanished">Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2597"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2609"/>
         <source>Delete</source>
-        <translation>Löschen</translation>
+        <translation type="vanished">Löschen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2599"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2467"/>
         <source>Def</source>
         <translation>Standardwert</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2628"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2690"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2770"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2775"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2780"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2785"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2473"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2478"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2488"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2611"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2621"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2626"/>
         <source>bpm</source>
         <translation>1/min</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2650"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2493"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2630"/>
         <source>Start Date</source>
         <translation>Startdatum</translation>
     </message>
@@ -18827,26 +18810,26 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
         <translation type="vanished">Ab Datum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2651"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2790"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2494"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2631"/>
         <source>Lactate Threshold</source>
         <translation>Anaerobe Schwelle</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2652"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2791"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2495"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2632"/>
         <source>Aerobic Threshold</source>
         <translation>Aerobe Schwelle</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2653"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2496"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
         <source>Rest HR</source>
         <translation>Ruhe-HF</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2654"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2497"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2634"/>
         <source>Max HR</source>
         <translation>Max. HF</translation>
     </message>
@@ -18855,22 +18838,22 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
         <translation type="vanished">dd.MMM yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2701"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2544"/>
         <source>Short</source>
         <translation>Zone</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2702"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2545"/>
         <source>Long</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2703"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2546"/>
         <source>From BPM</source>
         <translation>Von HF</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2704"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2547"/>
         <source>Trimp k</source>
         <translation>TRIMP K</translation>
     </message>
@@ -18883,14 +18866,14 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
         <translation type="vanished">Maximal Anzahl von 10 Zonen erreicht.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2967"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2974"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2804"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2811"/>
         <source>New</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2969"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2976"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2806"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2813"/>
         <source>New (%1)</source>
         <translation>Neu (%1)</translation>
     </message>
@@ -19632,62 +19615,62 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
 <context>
     <name>Library</name>
     <message>
+        <location filename="../../Train/Library.cpp" line="126"/>
         <location filename="../../Train/Library.cpp" line="130"/>
-        <location filename="../../Train/Library.cpp" line="134"/>
         <source>Import Videos, VideoSyncs and Workouts</source>
         <translation>Videos, VideoSyncs und Workouts finden und importieren</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="127"/>
         <location filename="../../Train/Library.cpp" line="131"/>
-        <location filename="../../Train/Library.cpp" line="135"/>
         <source>No supported videos, videoSyncs or workouts were found to import</source>
         <translation>Es wurden keine unterstützten Videos, VideoSyncs oder Workouts zum Import gefunden</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="189"/>
         <location filename="../../Train/Library.cpp" line="193"/>
-        <location filename="../../Train/Library.cpp" line="197"/>
+        <location filename="../../Train/Library.cpp" line="198"/>
         <location filename="../../Train/Library.cpp" line="202"/>
-        <location filename="../../Train/Library.cpp" line="206"/>
         <source>Copy VideoSync Failed</source>
         <translation>VideoSync kopieren fehlgeschlagen</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="190"/>
         <location filename="../../Train/Library.cpp" line="194"/>
-        <location filename="../../Train/Library.cpp" line="198"/>
         <source>%1 already exists in videoSync library: %2</source>
         <translation>%1 ist bereits in der VideoSync-Bibliothek: %2 vorhanden</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="203"/>
+        <location filename="../../Train/Library.cpp" line="199"/>
         <source>%1 cannot be written to videoSync library %2. Check library path, permissions and free space</source>
         <translation>%1 kann nicht in die videoSync-Bibliothek %2 geschrieben werden, überprüfen Sie den Bibliothekspfad, die Berechtigungen und auf ausreichenden freien Speicherplatz</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="207"/>
+        <location filename="../../Train/Library.cpp" line="203"/>
         <source>%1 cannot be written to videoSync library %2, check permissions and free space</source>
         <translation>%1 kann nicht in die videoSync-Bibliothek %2 geschrieben werden, überprüfen Sie den Bibliothekspfad, die Berechtigungen und auf ausreichenden freien Speicherplatz</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="253"/>
+        <location filename="../../Train/Library.cpp" line="249"/>
         <source>%1 cannot be written to workout library %2. Check library path, permissions and free space</source>
         <translation>%1 kann nicht in die Workout-Bibliothek %2 geschrieben werden, überprüfen Sie den Bibliothekspfad, die Berechtigungen und auf ausreichenden freien Speicherplatz</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="257"/>
+        <location filename="../../Train/Library.cpp" line="253"/>
         <source>%1 cannot be written to workout library %2, check permissions and free space</source>
         <translation>%1 kann nicht in die Workout-Bibliothek %2 geschrieben werden, überprüfen Sie den Bibliothekspfad, die Berechtigungen und auf ausreichenden freien Speicherplatz</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="239"/>
         <location filename="../../Train/Library.cpp" line="243"/>
-        <location filename="../../Train/Library.cpp" line="247"/>
+        <location filename="../../Train/Library.cpp" line="248"/>
         <location filename="../../Train/Library.cpp" line="252"/>
-        <location filename="../../Train/Library.cpp" line="256"/>
         <source>Copy Workout Failed</source>
         <translation>Workout kopieren fehlgeschlagen</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="240"/>
         <location filename="../../Train/Library.cpp" line="244"/>
-        <location filename="../../Train/Library.cpp" line="248"/>
         <source>%1 already exists in workout library: %2</source>
         <translation>%1 existiert bereits in der Workout-Bibliothek: %2</translation>
     </message>
@@ -19695,89 +19678,89 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
 <context>
     <name>LibrarySearchDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="330"/>
+        <location filename="../../Train/Library.cpp" line="326"/>
         <source>Search for Workouts, Syncs and Media</source>
         <translation>Nach Workouts, VideoSyncs und Medien suchen</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="337"/>
+        <location filename="../../Train/Library.cpp" line="333"/>
         <source>Workout files (.erg, .mrc, .zwo etc)</source>
         <translation>Workout-Dateien (.erg, .mrc, .zwo usw.)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="339"/>
+        <location filename="../../Train/Library.cpp" line="335"/>
         <source>Video files (.mp4, .avi etc)</source>
         <translation>Videodateien (.mp4, .avi usw.)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="341"/>
+        <location filename="../../Train/Library.cpp" line="337"/>
         <source>VideoSync files (.rlv, .tts etc)</source>
         <translation>VideoSync-Dateien (.rlv, .tts etc)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="359"/>
+        <location filename="../../Train/Library.cpp" line="353"/>
         <source>Search Path</source>
         <translation>Dateipfad durchsuchen</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="379"/>
+        <location filename="../../Train/Library.cpp" line="373"/>
         <source>Video references</source>
         <translation>Videoreferenzen</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="391"/>
+        <location filename="../../Train/Library.cpp" line="385"/>
         <source>Searching...</source>
         <translation>Suche...</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="394"/>
+        <location filename="../../Train/Library.cpp" line="388"/>
         <source>Videos</source>
         <translation>Videos</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="396"/>
+        <location filename="../../Train/Library.cpp" line="390"/>
         <source>Workouts</source>
         <translation>Workouts</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="398"/>
+        <location filename="../../Train/Library.cpp" line="392"/>
         <source>VideoSyncs</source>
         <translation>VideoSyncs</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="407"/>
-        <location filename="../../Train/Library.cpp" line="494"/>
+        <location filename="../../Train/Library.cpp" line="401"/>
+        <location filename="../../Train/Library.cpp" line="484"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="409"/>
+        <location filename="../../Train/Library.cpp" line="403"/>
         <source>Search</source>
         <translation>Suchen</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="412"/>
+        <location filename="../../Train/Library.cpp" line="406"/>
         <source>Files to search for:</source>
         <translation>Nach welchen Dateien suchen:</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="475"/>
+        <location filename="../../Train/Library.cpp" line="466"/>
         <source>Abort Search</source>
         <translation>Suche abbrechen</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="515"/>
-        <location filename="../../Train/Library.cpp" line="559"/>
+        <location filename="../../Train/Library.cpp" line="504"/>
+        <location filename="../../Train/Library.cpp" line="548"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="557"/>
+        <location filename="../../Train/Library.cpp" line="546"/>
         <source>Search completed.</source>
         <translation>Suche abgeschlossen.</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="645"/>
+        <location filename="../../Train/Library.cpp" line="634"/>
         <source>Select Directory</source>
         <translation>Verzeichnis auswählen</translation>
     </message>
@@ -19785,12 +19768,12 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
 <context>
     <name>ListEditWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="623"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="654"/>
         <source>New</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="625"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="656"/>
         <source>New (%1)</source>
         <translation>Neu (%1)</translation>
     </message>
@@ -19803,7 +19786,12 @@ Drehmomentkorrektur - Der absolute Korrekturwert in Nm (oder Pfund pro Quadratin
         <translation>OSM-Base-URL</translation>
     </message>
     <message>
-        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="90"/>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="85"/>
+        <source>Initial Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="98"/>
         <source>Apply changes</source>
         <translation>Änderungen anwenden</translation>
     </message>
@@ -20022,7 +20010,7 @@ on and that its display says, &quot;PC Link&quot;</source>
         <translation>Seitenleiste an/aus</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>Delete Activity</source>
         <translation>Aktivität löschen</translation>
     </message>
@@ -20077,51 +20065,51 @@ on and that its display says, &quot;PC Link&quot;</source>
         <translation>Metriken als .CSV exportieren...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Chart Import</source>
         <translation>Diagramm-Import</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1778"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1788"/>
         <source>Failed to export activity, please check permissions</source>
         <translation>Konnte Aktivität nicht exportieren, bitte Dateizugriffsrechte prüfen</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1814"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1824"/>
         <source>No Activity To Save</source>
         <translation>Keine Aktivität zum Speichern vorhanden</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1815"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1825"/>
         <source>There is no currently selected activity to save.</source>
         <translation>Keine der aktuell ausgewählten Aktivitäten muss gespeichert werden.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
         <location filename="../../Gui/MainWindow.cpp" line="1886"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Split Activity</source>
         <translation>Aktivität aufteilen</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
         <source>No activity selected</source>
         <translation>Keine Aktivität ausgewählt</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
         <source>Current activity contains no data to split</source>
         <translation>Aktuelle Aktivität enthält keine Daten zum Aufteilien</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Current activity contains no data to merge</source>
         <translation>Aktuelle Aktivität enthält keine Daten zum Zusammenführen</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1904"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1914"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation>Sollen diese Aktivitäten wirklich gelöscht werden:</translation>
     </message>
@@ -20167,23 +20155,23 @@ Sie sind dabei, alle Diagramme auf die Voreinstellungen zurückzusetzen</transla
         <translation>Möchten Sie die Diagramme zurücksetzen?</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
         <source>Select Activity</source>
         <translation>Aktivität auswählen</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>No activity selected!</source>
         <translation>Keine Aktivität ausgewählt!</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1724"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1734"/>
         <source>Export Activity</source>
         <translation>Aktivität exportieren</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1777"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1787"/>
         <source>Export Failed</source>
         <translation>Export nicht erfolgreich</translation>
     </message>
@@ -20304,33 +20292,33 @@ Sie sind dabei, alle Diagramme auf die Voreinstellungen zurückzusetzen</transla
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Activity Import</source>
         <translation>Aktivitäten importieren</translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Closing of athlete window not possible while background activity import is in progress...</source>
         <translation>Das Schließen des Athleten-Fensters ist nicht möglich, solange im Hintergrund der Import von Aktivitäten läuft...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2165"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2175"/>
         <source>&amp;New Athlete...</source>
         <translation>&amp;Neuer Athlet...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2400"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2421"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2410"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2431"/>
         <source>The workout directory is not configured, or the directory selected no longer exists.
 
 Please check your preference settings.</source>
         <translation>Das Workout-Verzeichnis ist nicht konfiguriert oder das definierte Verzeichnis existiert nicht (mehr). Bitte Einstellungen überprüfen.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2611"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2621"/>
         <source>Loading activities: %1%</source>
         <translation>Lade Aktivitäten: %1%</translation>
     </message>
@@ -20343,14 +20331,14 @@ Please check your preference settings.</source>
         <translation type="vanished">Verwalten von Python-Fixes...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>CloudDB</source>
         <translation>CloudDB</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>Current athlete is not registered as curator - please contact the GoldenCheetah team</source>
         <translation>Aktueller Athlet ist nicht als Verwalter registriert - bitte das GoldenCheetah-Team kontaktieren</translation>
     </message>
@@ -20661,59 +20649,59 @@ Please check your preference settings.</source>
         <translation>Perspektive importieren</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Imported %1 metric charts</source>
         <translation>%1 Metrik-Diagramme importiert</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>Import Images Failed</source>
         <translation>Bilder importieren fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>You can only import images on the activities view with an activity selected.</source>
         <translation>Bilder können nur in der Aktivitätenansicht importieren, wenn eine Aktivität ausgewählt ist.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>Import Images to Activity</source>
         <translation>Bilder in Aktivität importieren</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>%1 images imported.</source>
         <translation>%1 Bilder importiert.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1799"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2369"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1809"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2379"/>
         <source>Import from File</source>
         <translation>Aus Datei importieren</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2342"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2352"/>
         <source>Refresh in Progress</source>
         <translation>Aktualisierung läuft</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Export Metrics</source>
         <translation>Metriken exportieren</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation>Comma Separated Values (*.csv)</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2399"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2420"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2409"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2430"/>
         <source>Workout Directory Invalid</source>
         <translation>Verzeichnis für Workouts ist ungültig</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1906"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1916"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
@@ -21670,23 +21658,23 @@ Please check your preference settings.</source>
         <translation type="vanished">Zeitabhängige %1-Messungen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="656"/>
+        <location filename="../../Gui/AthletePages.cpp" line="641"/>
         <source>From Date - Time</source>
         <translation>Ab Datum/Uhrzeit</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="780"/>
+        <location filename="../../Gui/AthletePages.cpp" line="751"/>
         <source>Start Date</source>
         <translation>Startdatum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="893"/>
+        <location filename="../../Gui/AthletePages.cpp" line="864"/>
         <source>MMM d, yyyy - hh:mm:ss</source>
         <translation>ddd, dd.MMM yyyy - hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="659"/>
-        <location filename="../../Gui/AthletePages.cpp" line="807"/>
+        <location filename="../../Gui/AthletePages.cpp" line="644"/>
+        <location filename="../../Gui/AthletePages.cpp" line="778"/>
         <source>Comment</source>
         <translation>Kommentar</translation>
     </message>
@@ -21695,32 +21683,28 @@ Please check your preference settings.</source>
         <translation type="vanished">Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="662"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="663"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">Hinzufügen</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">Löschen</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="668"/>
-        <source>Add</source>
-        <translation>Hinzufügen</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="669"/>
-        <source>Delete</source>
-        <translation>Löschen</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="698"/>
         <source>Source</source>
         <translation>Quelle</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="699"/>
+        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Original Source</source>
         <translation>Ursprungsquelle</translation>
     </message>
@@ -22421,17 +22405,17 @@ Keine Aktivitäten zum Importieren gefunden.
 <context>
     <name>MultiDeviceDialog</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3048"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3060"/>
         <source>Multiple Device Configuration</source>
         <translation>Mehrere Geräte konfigurieren</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3103"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3115"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3106"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3118"/>
         <source>Apply</source>
         <translation>OK</translation>
     </message>
@@ -23466,42 +23450,38 @@ Keine Aktivitäten zum Importieren gefunden.
 <context>
     <name>PaceSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3154"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3155"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3160"/>
         <source>Add</source>
-        <translation>Hinzufügen</translation>
+        <translation type="vanished">Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3161"/>
         <source>Delete</source>
-        <translation>Löschen</translation>
+        <translation type="vanished">Löschen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2982"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3176"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2987"/>
         <source>Short</source>
         <translation>Zone</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3177"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2988"/>
         <source>Long</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3178"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2989"/>
         <source>Percent of CV</source>
         <translation>Prozentsatz der Critical Velocity</translation>
     </message>
@@ -23510,14 +23490,14 @@ Keine Aktivitäten zum Importieren gefunden.
         <translation type="vanished">Maximale Anzahl von 10 Zonen erreicht.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3220"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3227"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3037"/>
         <source>New</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3222"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3229"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3032"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3039"/>
         <source>New (%1)</source>
         <translation>Neu (%1)</translation>
     </message>
@@ -23717,27 +23697,27 @@ Keine Aktivitäten zum Importieren gefunden.
 <context>
     <name>PaceZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3082"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2905"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3084"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2907"/>
         <source>Run</source>
         <translation>Laufen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3085"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2908"/>
         <source>Swim</source>
         <translation>Schwimmen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3126"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2949"/>
         <source>Critical Velocity</source>
         <translation>Critical Velocity</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2950"/>
         <source>Default</source>
         <translation>Standardeinstellung</translation>
     </message>
@@ -25885,78 +25865,79 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PerspectiveDialog</name>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="34"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="35"/>
         <source>Manage Perspectives</source>
         <translation>Perspektiven verwalten</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="43"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="44"/>
         <source>Perspectives</source>
         <translation>Perspektiven</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="60"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="61"/>
         <source>Charts</source>
         <translation>Diagramme</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Edit</source>
-        <translation>Bearbeiten</translation>
+        <translation type="vanished">Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="83"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="78"/>
         <source>Import</source>
         <translation>Importieren</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="84"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="77"/>
         <source>Export</source>
         <translation>Exportieren</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="90"/>
         <source>Add</source>
-        <translation>Hinzufügen</translation>
+        <translation type="vanished">Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="91"/>
         <source>Delete</source>
-        <translation>Löschen</translation>
+        <translation type="vanished">Löschen</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="98"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Drag charts to move to a perspective</source>
         <translation>Ziehe das Diagramm in die gewünschte Perspektive</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="287"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="256"/>
         <source>Export Persepctive</source>
         <translation>Perspektive exportieren</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
         <source>Export Perspective</source>
         <translation>Perspektive exportieren</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>No perspective file selected!</source>
         <translation>Keine Perspektivdatei ausgewählt!</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
         <source>Select Perspective file to export</source>
-        <translation>Perspektivdatei für das Exportiern auswählen</translation>
+        <translation type="vanished">Perspektivdatei für das Exportiern auswählen</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
         <source>GoldenCheetah Perspective Files (*.gchartset)</source>
         <translation>GoldenCheetah-Perspektivdateien (*.gchartset)</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
+        <source>Select Perspective file to import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>Import Perspective</source>
         <translation>Perspektive importieren</translation>
     </message>
@@ -27118,307 +27099,307 @@ Python wird in den Einstellungen deaktiviert.</translation>
 <context>
     <name>RealtimeData</name>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="621"/>
+        <location filename="../../Train/RealtimeData.cpp" line="623"/>
         <source>None</source>
         <translation>Kein(e)</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="624"/>
+        <location filename="../../Train/RealtimeData.cpp" line="626"/>
         <source>Time</source>
         <translation>Zeit</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="627"/>
+        <location filename="../../Train/RealtimeData.cpp" line="629"/>
         <source>Lap</source>
         <translation>Runde</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="630"/>
+        <location filename="../../Train/RealtimeData.cpp" line="632"/>
         <source>Lap Time</source>
         <translation>Zwischenzeit</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="633"/>
+        <location filename="../../Train/RealtimeData.cpp" line="635"/>
         <source>Lap Time Remaining</source>
         <translation>Verbleibende Rundenzeit</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="636"/>
+        <location filename="../../Train/RealtimeData.cpp" line="638"/>
         <source>Section Time Remaining</source>
         <translation>Verbleibende Abschnittszeit</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="639"/>
+        <location filename="../../Train/RealtimeData.cpp" line="641"/>
         <source>BikeStress</source>
         <translation>BikeStress</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="645"/>
+        <location filename="../../Train/RealtimeData.cpp" line="647"/>
         <source>kJoules</source>
         <translation>kJoule</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="648"/>
+        <location filename="../../Train/RealtimeData.cpp" line="650"/>
         <source>W&apos; bal</source>
         <translation>W&apos;-Bilanz</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="651"/>
+        <location filename="../../Train/RealtimeData.cpp" line="653"/>
         <source>XPower</source>
         <translation>XPower</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="654"/>
+        <location filename="../../Train/RealtimeData.cpp" line="656"/>
         <source>Iso Power</source>
         <translation>Normalisierte Leistung (IsoPower)</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="657"/>
+        <location filename="../../Train/RealtimeData.cpp" line="659"/>
         <source>Intensity Factor</source>
         <translation>Intensitätsfaktor</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="660"/>
+        <location filename="../../Train/RealtimeData.cpp" line="662"/>
         <source>Relative Intensity</source>
         <translation>Relative Intensität</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="663"/>
+        <location filename="../../Train/RealtimeData.cpp" line="665"/>
         <source>Skiba Variability Index</source>
         <translation>Skiba-Variabilitätsindex</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="666"/>
+        <location filename="../../Train/RealtimeData.cpp" line="668"/>
         <source>Variability Index</source>
         <translation>Variabilitätsindex</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="669"/>
+        <location filename="../../Train/RealtimeData.cpp" line="671"/>
         <source>Distance</source>
         <translation>Distanz</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="672"/>
+        <location filename="../../Train/RealtimeData.cpp" line="674"/>
         <source>Route Distance</source>
         <translation>Route-Distanz</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="675"/>
+        <location filename="../../Train/RealtimeData.cpp" line="677"/>
         <source>Distance Remaining</source>
         <translation>Verbleibende Distanz</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="678"/>
+        <location filename="../../Train/RealtimeData.cpp" line="680"/>
         <source>Alternate Power</source>
         <translation>Alternative Leistung</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="681"/>
+        <location filename="../../Train/RealtimeData.cpp" line="683"/>
         <source>Power</source>
         <translation>Leistung</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="684"/>
+        <location filename="../../Train/RealtimeData.cpp" line="686"/>
         <source>Speed</source>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="687"/>
+        <location filename="../../Train/RealtimeData.cpp" line="689"/>
         <source>Virtual Speed</source>
         <translation>Virtuelle Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="690"/>
+        <location filename="../../Train/RealtimeData.cpp" line="692"/>
         <source>Cadence</source>
         <translation>Trittfrequenz</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="693"/>
+        <location filename="../../Train/RealtimeData.cpp" line="695"/>
         <source>Heart Rate</source>
         <translation>Herzfrequenz</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="696"/>
+        <location filename="../../Train/RealtimeData.cpp" line="698"/>
         <source>Target Power</source>
         <translation>Zielleistung</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="699"/>
+        <location filename="../../Train/RealtimeData.cpp" line="701"/>
         <source>Average Power</source>
         <translation>ø Leistung</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="702"/>
+        <location filename="../../Train/RealtimeData.cpp" line="704"/>
         <source>Average Speed</source>
         <translation>ø Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="705"/>
+        <location filename="../../Train/RealtimeData.cpp" line="707"/>
         <source>Average Heartrate</source>
         <translation>ø Herzfrequenz</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="708"/>
+        <location filename="../../Train/RealtimeData.cpp" line="710"/>
         <source>Average Cadence</source>
         <translation>ø Trittfrequenz</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="711"/>
+        <location filename="../../Train/RealtimeData.cpp" line="713"/>
         <source>Lap Power</source>
         <translation>Rundenleistung</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="714"/>
+        <location filename="../../Train/RealtimeData.cpp" line="716"/>
         <source>Lap Speed</source>
         <translation>Rundengeschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="717"/>
+        <location filename="../../Train/RealtimeData.cpp" line="719"/>
         <source>Lap Heartrate</source>
         <translation>Rundenherzfrequenz</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="720"/>
+        <location filename="../../Train/RealtimeData.cpp" line="722"/>
         <source>Lap Cadence</source>
         <translation>Rundentrittfrequenz</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="723"/>
+        <location filename="../../Train/RealtimeData.cpp" line="725"/>
         <source>Left/Right Balance</source>
         <translation>Links/Rechts-Verteilung</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="726"/>
+        <location filename="../../Train/RealtimeData.cpp" line="728"/>
         <source>Total Hb Mass</source>
         <translation>Total Hb-Masse</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="729"/>
+        <location filename="../../Train/RealtimeData.cpp" line="731"/>
         <source>Hb O2 Saturation</source>
         <translation>Hb O2 Sättigung</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="732"/>
+        <location filename="../../Train/RealtimeData.cpp" line="734"/>
         <source>Deoxy Hb</source>
         <translation>Deoxy Hb</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="735"/>
+        <location filename="../../Train/RealtimeData.cpp" line="737"/>
         <source>Oxy Hb</source>
         <translation>Oxy Hb</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="738"/>
+        <location filename="../../Train/RealtimeData.cpp" line="740"/>
         <source>Left Torque Effectiveness</source>
         <translation>Drehmoment-Effektivität - Links</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="741"/>
+        <location filename="../../Train/RealtimeData.cpp" line="743"/>
         <source>Right Torque Effectiveness</source>
         <translation>Drehmoment-Effektivität - Rechts</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="744"/>
+        <location filename="../../Train/RealtimeData.cpp" line="746"/>
         <source>Left Pedal Smoothness</source>
         <translation>Gleichm. Treten - Links</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="747"/>
+        <location filename="../../Train/RealtimeData.cpp" line="749"/>
         <source>Right Pedal Smoothness</source>
         <translation>Gleichm. Treten - Rechts</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="750"/>
+        <location filename="../../Train/RealtimeData.cpp" line="752"/>
         <source>Right Power Phase Start</source>
         <translation>Anfang Power Phase - Rechts</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="753"/>
+        <location filename="../../Train/RealtimeData.cpp" line="755"/>
         <source>Right Power Phase End</source>
         <translation>Ende Power Phase - Rechts</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="756"/>
+        <location filename="../../Train/RealtimeData.cpp" line="758"/>
         <source>Right Power Phase Peak Start</source>
         <translation>Anfang max. Power Phase - Rechts</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="759"/>
+        <location filename="../../Train/RealtimeData.cpp" line="761"/>
         <source>Right Power Phase Peak End</source>
         <translation>Ende max. Power Phase - Rechts</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="762"/>
+        <location filename="../../Train/RealtimeData.cpp" line="764"/>
         <source>Slope</source>
         <translation>Steigung</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="765"/>
+        <location filename="../../Train/RealtimeData.cpp" line="767"/>
         <source>Lap Distance</source>
         <translation>Rundendistanz</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="768"/>
+        <location filename="../../Train/RealtimeData.cpp" line="770"/>
         <source>Lap Distance Remaining</source>
         <translation>Verbleibende Rundendistanz</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="771"/>
+        <location filename="../../Train/RealtimeData.cpp" line="773"/>
         <source>Latitude</source>
         <translation>Breitengrad</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="774"/>
+        <location filename="../../Train/RealtimeData.cpp" line="776"/>
         <source>Longitude</source>
         <translation>Längengrad</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="777"/>
+        <location filename="../../Train/RealtimeData.cpp" line="779"/>
         <source>Altitude</source>
         <translation>Höhe</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="780"/>
+        <location filename="../../Train/RealtimeData.cpp" line="782"/>
         <source>Respiratory Frequency</source>
         <translation>Atemfrequenz</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="783"/>
+        <location filename="../../Train/RealtimeData.cpp" line="785"/>
         <source>Ventilation</source>
         <translation>Ventilation</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="786"/>
+        <location filename="../../Train/RealtimeData.cpp" line="788"/>
         <source>VO2</source>
         <translation>VO2</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="789"/>
+        <location filename="../../Train/RealtimeData.cpp" line="791"/>
         <source>VCO2</source>
         <translation>VCO2</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="792"/>
+        <location filename="../../Train/RealtimeData.cpp" line="794"/>
         <source>Respiratory Exchange Ratio</source>
         <translation>Atmungsaustauschverhältnis</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="795"/>
+        <location filename="../../Train/RealtimeData.cpp" line="797"/>
         <source>Tidal Volume</source>
         <translation>Atemzugvolumen</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="798"/>
+        <location filename="../../Train/RealtimeData.cpp" line="800"/>
         <source>Fraction O2 Expired</source>
         <translation>Fraktion O2 Abgelaufen</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="801"/>
+        <location filename="../../Train/RealtimeData.cpp" line="803"/>
         <source>Temperature</source>
         <translation type="unfinished">Temperatur</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="804"/>
+        <location filename="../../Train/RealtimeData.cpp" line="806"/>
         <source>CoreTemp</source>
         <translation type="unfinished"></translation>
     </message>
@@ -27514,22 +27495,22 @@ Python wird in den Einstellungen deaktiviert.</translation>
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Series</source>
         <translation>Datenreihe</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="172"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
         <source>Power</source>
         <translation>Leistung</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="176"/>
         <source>Heart Rate</source>
         <translation>Herzfrequenz</translation>
     </message>
@@ -29829,318 +29810,318 @@ Möchten Sie fortfahren?
 <context>
     <name>ScatterPlot</name>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="113"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
         <source>Power (watts)</source>
         <translation>Leistung (Watt)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
         <source>Cadence (rpm)</source>
         <translation>Trittfrequenz (1/min)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="116"/>
         <source>Heartrate (bpm)</source>
         <translation>Herzfrequenz (1/min)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="118"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="119"/>
         <source>Speed (kph)</source>
         <translation>Geschwindigkeit (km/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="120"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="121"/>
         <source>Speed (mph)</source>
         <translation>Geschwindigkeit (mi/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="124"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="125"/>
         <source>Altitude (meters)</source>
         <translation>Höhe (m)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="126"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="127"/>
         <source>Altitude (feet)</source>
         <translation>Höhe (Fuß)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="128"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
         <source>Torque (N)</source>
         <translatorcomment>??? N is Force, Torque is Nm</translatorcomment>
         <translation>Drehmoment (Nm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="130"/>
         <source>Elapsed Time (secs)</source>
         <translation>Vergangene Zeit (sek)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="132"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="133"/>
         <source>Elapsed Distance (km)</source>
         <translation>Zurückgelegte Distanz (km)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="134"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="135"/>
         <source>Elapsed Distance (mi)</source>
         <translation>Zurückgelegte Distanz (mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="136"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
         <source>Interval Number</source>
         <translation>Intervallnummer</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
         <source>Latitude (degree offset)</source>
         <translation>Breitengrad (Gradoffset)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
         <source>Longitude (degree offset)</source>
         <translation>Längengrad (Gradoffset)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
         <source>Circumferential Pedal Velocity (m/s)</source>
         <translation>Umlaufgeschwindigkeit des Pedals (m/s)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="141"/>
         <source>Average Effective Pedal Force (N)</source>
         <translation>ø effektive Pedalkraft (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="144"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
         <source>Time at X/Y (%)</source>
         <translation>Zeit bei X/Y (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
         <source>Power Zone</source>
         <translation>Leistungszone</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
         <source>Headwind (kph)</source>
         <translation>Gegenwind (km/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
         <source>Slope (gradient)</source>
         <translation>Steigung (Prozent)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
         <source>Temperature (C)</source>
         <translation>Temperatur (C)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
         <source>L/R Balance</source>
         <translation>Leistungsverteilung L/R</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
         <source>Torque Efficiency</source>
         <translation>Drehmoment-Eff.</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
         <source>Pedal Smoothness</source>
         <translation>Gleichm. Treten</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
         <source>Running Vertical Oscillation</source>
         <translation>Laufen Vertikale Bewegung</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
         <source>Running Ground Contact Time</source>
         <translation>Laufen Bodenkontaktzeit</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
         <source>Running Cadence</source>
         <translation>Laufen Schrittfrequenz</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
         <source>Gear Ratio</source>
         <translation>Übersetzung</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
         <source>Muscle Oxygen</source>
         <translation>Muskelsauerstoff</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
         <source>Haemoglobin Mass</source>
         <translation>Hämoglobinmenge</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
         <source>Deoxygenated Haemoglobin</source>
         <translation>Desoxyhämoglobin</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="160"/>
         <source>Oxygenated Haemoglobin</source>
         <translation>Oxyhämoglobin</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="161"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="162"/>
         <source>Unknown</source>
         <translation>Unbekannt</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="165"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
         <source>Power</source>
         <translation>Leistung</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
         <source>Cadence</source>
         <translation>Trittfrequenz</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
         <source>Heartrate</source>
         <translation>Herzfrequenz</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
         <source>Speed</source>
         <translation>Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
         <source>Altitude</source>
         <translation>Höhe</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
         <source>Pedal Force</source>
         <translation>Pedalkraft</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
         <source>Time</source>
         <translation>Zeit</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
         <source>Distance</source>
         <translation>Distanz</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
         <source>Interval</source>
         <translation>Intervall</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
         <source>Latitude</source>
         <translation>Breitengrad</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
         <source>Longitude</source>
         <translation>Längengrad</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
         <source>Time at X/Y</source>
         <translation>Zeit bei X/Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
         <source>Zone</source>
         <translation>Zone</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
         <source>CPV</source>
         <translation>CPV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
         <source>AEPF</source>
         <translation>AEPF</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
         <source>Headwind</source>
         <translation>Gegenwind</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
         <source>Slope</source>
         <translation>Steigung</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
         <source>Temp</source>
         <translation>Temperatur</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
         <source>Balance</source>
         <translation>Beinkraftverteilung</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
         <source>TE</source>
         <translation>DE</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
         <source>PS</source>
         <translation>GT</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
         <source>RV</source>
         <translation>RV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
         <source>GCT</source>
         <translation>BKZ</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
         <source>Run Cad</source>
         <translation>Schrittfrequenz</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
         <source>Gear</source>
         <translation>Gang</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="194"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="195"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="196"/>
         <source>None</source>
         <translation>Kein</translation>
     </message>
@@ -30378,42 +30359,38 @@ Möchten Sie fortfahren?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1012"/>
         <source>Add</source>
-        <translation>Hinzufügen</translation>
+        <translation type="vanished">Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1013"/>
         <source>Delete</source>
-        <translation>Löschen</translation>
+        <translation type="vanished">Löschen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1006"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1007"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1023"/>
+        <location filename="../../Gui/AthletePages.cpp" line="982"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="988"/>
         <source>Short</source>
         <translation>Zone</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="989"/>
         <source>Long</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1031"/>
+        <location filename="../../Gui/AthletePages.cpp" line="990"/>
         <source>Percent of CP</source>
         <translation>Prozentsatz der Critical Power</translation>
     </message>
@@ -30422,14 +30399,14 @@ Möchten Sie fortfahren?
         <translation type="vanished">Maximale Anzahl von 10 Zonen erreicht.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1069"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1076"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1034"/>
         <source>New</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1071"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1078"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1036"/>
         <source>New (%1)</source>
         <translation>Neu (%1)</translation>
     </message>
@@ -30602,64 +30579,64 @@ Möchten Sie fortfahren?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3821"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3569"/>
         <source>Add</source>
         <translation>Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3822"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3570"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3823"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3571"/>
         <source>Up</source>
         <translation>Hoch</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3824"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3572"/>
         <source>Down</source>
         <translation>Runter</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3870"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3872"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3963"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3965"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3711"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3713"/>
         <source>ddd MMM d, yyyy</source>
         <translation>ddd, d.MMM yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3557"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3810"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3558"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3804"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3835"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3583"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3805"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3836"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3553"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3584"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3806"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3837"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3554"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3585"/>
         <source>From</source>
         <translation>Von (untere Grenze)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3807"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3838"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3555"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3586"/>
         <source>To</source>
         <translation>Bis (obere Grenze)</translation>
     </message>
@@ -33116,25 +33093,25 @@ Der Wert für „Derzeitige Höhe des Trainers“ kann unter dem Reiter „Spezi
 <context>
     <name>TrainSidebar</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="253"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="257"/>
         <source>Save workout data</source>
         <translation>Aktivität speichern</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="259"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="263"/>
         <source>Devices</source>
         <translation>Geräte</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="262"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="267"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="311"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="321"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="271"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="315"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="325"/>
         <source>Menu</source>
         <translation>Menü</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="270"/>
         <source>Workouts</source>
         <translation>Workouts</translation>
     </message>
@@ -33143,114 +33120,114 @@ Der Wert für „Derzeitige Höhe des Trainers“ kann unter dem Reiter „Spezi
         <translation type="vanished">Filtern...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="303"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="307"/>
         <source>Workout Info</source>
         <translation>Infos zum Workout</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="310"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="314"/>
         <source>Media</source>
         <translation>Medien</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="320"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="324"/>
         <source>VideoSync</source>
         <translation>VideoSync</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="506"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
         <source>Import Workout from File</source>
         <translation>Workout aus Datei importieren</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="507"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="511"/>
         <source>Get Workouts from TrainerDay</source>
         <translation>Workouts von TrainerDay laden</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="509"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="513"/>
         <source>Create Workout via Wizard</source>
         <translation>Workout mit Assistenten erstellen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="514"/>
         <source>Scan for Workouts</source>
         <translation>Nach Workouts suchen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="534"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="538"/>
         <source>Delete selected Workout</source>
         <translation>Ausgewähltes Workout löschen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="541"/>
         <source>Delete %1 selected Workouts</source>
         <translation>%1 ausgewählte Workouts löschen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Train mode active</source>
         <translation>Trainingsmodus ist aktiv</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Please stop the train mode before closing the window or application.</source>
         <translation>Bitte den Trainingsmodus vor dem Schließen des Fenster oder der Anwendung beenden.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="635"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="639"/>
         <source>Remove reference to selected video</source>
         <translation>Referenz zum gewählten Video entfernen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="650"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="654"/>
         <source>Import VideoSync from File</source>
         <translation>VideoSync aus Datei impotieren</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="651"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="655"/>
         <source>Scan for VideoSyncs</source>
         <translation>Nach VideoSyncs suchen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="668"/>
         <source>Delete selected VideoSync</source>
         <translation>Ausgewähltes VideoSync löschen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1064"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1068"/>
         <source>Are you sure you want to remove the reference to this video?</source>
         <translation>Die Referenz zu diesem Video wirklich entfernen?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1066"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1128"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1204"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1070"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1132"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1208"/>
         <source>Remove</source>
         <translation>Entfernen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1099"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1103"/>
         <source>Are you sure you want to delete this VideoSync?</source>
         <translation>Dieses VideoSync löschen?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1126"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1130"/>
         <source>The VideoSync file is either not valid or not existing and will be removed from the library.</source>
         <translation>Die VideoSync-Datei ist entweder ungültig oder existiert nicht und wird aus der Bibliothek entfernt.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1160"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1164"/>
         <source>Are you sure you want to delete this Workout?</source>
         <translation>Dieses Workout löschen?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1163"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1167"/>
         <source>Are you sure you want to delete this %1 workouts?</source>
         <translation>Diese %1 Workouts wirklich löschen?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1202"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1206"/>
         <source>The Workout file is either not valid or not existing and will be removed from the library.</source>
         <translation>Die Workout-Datei ist entweder ungültig oder existiert nicht und wird aus der Bibliothek entfernt.</translation>
     </message>
@@ -33259,31 +33236,31 @@ Der Wert für „Derzeitige Höhe des Trainers“ kann unter dem Reiter „Spezi
         <translation type="vanished">Fehler: %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1347"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1351"/>
         <source>Starting in %1</source>
         <translation>Starten in %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2225"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2237"/>
         <source>Recalibrating steering..</source>
         <translation>Kalibriere die Steuerung neu..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2521"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2525"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2594"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2645"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2649"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2533"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2606"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2657"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2661"/>
         <source>Requesting calibration..</source>
         <translation>Starte Kalibrierung..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2532"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2544"/>
         <source>Calibrating...</source>
         <translation>Kalibriere...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2536"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2548"/>
         <source>Calibrating...
 Current speed %1 kph
 Increase speed to %2 kph</source>
@@ -33292,14 +33269,14 @@ Aktuelle Geschwindigkeit %1 km/h
 Erhöhe Geschwindigkeit auf %2 km/h</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2540"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2552"/>
         <source>Calibrating...
 Stop pedalling until speed drops to 0</source>
         <translation>Kalibriere...
 Nicht treten bis die Geschwindigkeit auf Null gesunken ist</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2545"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2557"/>
         <source>Calibration completed successfully!
 Spindown %1 ms
 Zero Offset %2</source>
@@ -33308,30 +33285,30 @@ Ausrollen/Spindown %1 ms
 Null Offset %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2553"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2620"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2672"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2565"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2632"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2684"/>
         <source>Calibration failed!</source>
         <translation>Kalibrierung fehlgeschlagen!</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2573"/>
         <source>Calibration Failed: Loosen Roller</source>
         <translation>Kalibrierung fehlgeschlagen: Rolle lockern</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2569"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2581"/>
         <source>Calibration Failed: Tighten Roller</source>
         <translation>Kalibrierung fehlgeschlagen: Rolle festziehen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2588"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2639"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2600"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2651"/>
         <source>Unclip or stop pedalling to begin calibration..</source>
         <translation>Um die Kalibrierung zu starten, nicht treten..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2607"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2619"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Torque %1</source>
@@ -33340,7 +33317,7 @@ Nicht treten, bis der Prozess beendet ist..
 Drehmoment %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2612"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2624"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Torque %2</source>
@@ -33349,7 +33326,7 @@ Null Offset %1
 Drehmoment %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2659"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2671"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Zero Offset %1</source>
@@ -33358,7 +33335,7 @@ Nicht treten, bis der Prozess beendet ist..
 Null Offset %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2676"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Slope %2</source>
@@ -33367,175 +33344,175 @@ Null Offset %1
 Steigung %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2693"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2705"/>
         <source>Give the pedal a kick to start calibration...
 The motor will run until calibration is complete.</source>
         <translation>Treten Sie das Pedal, um die Kalibrierung zu starten...
 Der Motor läuft, bis die Kalibrierung abgeschlossen ist.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2695"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
         <source>Allow wheel speed to settle, DO NOT PEDAL...
 The motor will run until calibration is complete.</source>
         <translation>Lassen Sie die Radgeschwindigkeit  sich einpendeln, treten Sie NICHT aufs Pedal...
 Der Motor läuft, bis die Kalibrierung abgeschlossen ist.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2700"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2712"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Gathering enough samples to calculate average: %1</source>
         <translation>Kalibriere... NICHT TRETEN, sitzen bleiben...
 Genügend Proben für die Berechnung des Durchschnitts gesammelt: %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2719"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Waiting for value to stabilize (max %1s): %2 (%3W @ %4kph)</source>
         <translation>Kalibriere... NICHT TRETEN, sondern sitzen bleiben...
 Warten auf die Stabilisierung des Wertes (max. %1s): %2 (%3W @ %4kph)</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2722"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
         <source>Calibration completed successfully!
 Final calibration value %1 (%2W @ %3kph)</source>
         <translation>Kalibrierung erfolgreich abgeschlossen!
 Endgültiger Kalibrierungswert %1 (%2W @ %3kph)</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2746"/>
         <source>Calibration failed! Do not pedal while calibration is taking place.
 Allow wheel to run freely.</source>
         <translation>Kalibrierung fehlgeschlagen! Treten Sie nicht in die Pedale, während die Kalibrierung durchgeführt wird.
 Lassen Sie das Rad frei laufen.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2780"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2792"/>
         <source>Fast forward..</source>
         <translation>Vorspulen..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2813"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2825"/>
         <source>Rewind..</source>
         <translation>Zurückspulen..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2843"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2855"/>
         <source>Next Lap..</source>
         <translation>Nächste Runde..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2876"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2888"/>
         <source>Back Lap..</source>
         <translation>Vorherige Runde..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2902"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2914"/>
         <source>Increasing intensity..</source>
         <translation>Intensität erhöht..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2928"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2940"/>
         <source>Decreasing intensity..</source>
         <translation>Intensität verringert..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="621"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="625"/>
         <source>Import Video from File</source>
         <translation>Video aus Datei importieren</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="508"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="512"/>
         <source>Get Workouts from Strava Routes</source>
         <translation>Workouts aus Strava-Routen herunterladen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="622"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="626"/>
         <source>Scan for Videos</source>
         <translation>Nach Videos suchen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1101"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1173"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3183"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1105"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1177"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3195"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1309"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1313"/>
         <source>Resuming..</source>
         <translation>Weitermachen..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1336"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1340"/>
         <source>Paused..</source>
         <translation>Unterbrochen..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1465"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1469"/>
         <source>Starting..</source>
         <translation>Starte..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1673"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1677"/>
         <source>Stopped..</source>
         <translation>Gestoppt..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1763"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1769"/>
         <source>Connected..</source>
         <translation>Verbunden..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1787"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1793"/>
         <source>Disconnected..</source>
         <translation>Getrennt..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2198"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2210"/>
         <source>New lap..</source>
         <translation>Neue Runde..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>No Devices Configured</source>
         <translation>Keine Geräte konfiguriert</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>Please configure a device in Preferences.</source>
         <translation>Bitte konfigurieren Sie ein Gerät in den Einstellungen.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2483"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2495"/>
         <source>Exiting calibration..</source>
         <translation>Beende Kalibrierung..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2498"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2510"/>
         <source>Calibration not supported for this device.</source>
         <translation>Kalibrierung wird für dieses Gerät nicht unterstützt.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2505"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2517"/>
         <source>Calibrating...
 Press F3 on Controller when done.</source>
         <translation>Kalibriere...
 F3 drücken, wenn fertig.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3135"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3153"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3147"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3165"/>
         <source>Add Device</source>
         <translation>Gerät hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3140"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3158"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3152"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3170"/>
         <source>Delete Device</source>
         <translation>Gerät löschen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3181"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3193"/>
         <source>Are you sure you want to delete this device?</source>
         <translation>Dieses Gerät wirklich löschen?</translation>
     </message>
@@ -33852,7 +33829,7 @@ F3 drücken, wenn fertig.</translation>
 <context>
     <name>UniqueLabelEditDelegate</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="77"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="108"/>
         <source>The given value &quot;%1&quot; is not unique</source>
         <translation>Der angegebene Wert „%1“ ist mehrfach vorhanden</translation>
     </message>
@@ -33868,171 +33845,167 @@ F3 drücken, wenn fertig.</translation>
 <context>
     <name>UserChartSettings</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="772"/>
+        <location filename="../../Charts/UserChart.cpp" line="773"/>
         <source>Chart</source>
         <translation>Diagramm</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="782"/>
+        <location filename="../../Charts/UserChart.cpp" line="783"/>
         <source>Sub-title</source>
         <translation>Untertitel</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="785"/>
+        <location filename="../../Charts/UserChart.cpp" line="786"/>
         <source>Description</source>
         <translation>Beschreibung</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="791"/>
+        <location filename="../../Charts/UserChart.cpp" line="792"/>
         <source>Line Chart</source>
         <translation>Liniendiagramm</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="792"/>
+        <location filename="../../Charts/UserChart.cpp" line="793"/>
         <source>Scatter Chart</source>
         <translation>Streudiagramm</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="793"/>
+        <location filename="../../Charts/UserChart.cpp" line="794"/>
         <source>Bar Chart</source>
         <translation>Balkendiagramm</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="794"/>
+        <location filename="../../Charts/UserChart.cpp" line="795"/>
         <source>Stacked Bar Chart</source>
         <translation>Gestapeltes Balkendiagramm</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="795"/>
+        <location filename="../../Charts/UserChart.cpp" line="796"/>
         <source>Stacked Percent Chart</source>
         <translation>Gestapeltes Prozentdiagramm</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="796"/>
+        <location filename="../../Charts/UserChart.cpp" line="797"/>
         <source>Pie Chart</source>
         <translation>Kreisdiagramm</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="800"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="801"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="804"/>
+        <location filename="../../Charts/UserChart.cpp" line="805"/>
         <source>Vertical</source>
         <translation>Vertikal</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="805"/>
+        <location filename="../../Charts/UserChart.cpp" line="806"/>
         <source>Horizontal</source>
         <translation>Horizontal</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="808"/>
+        <location filename="../../Charts/UserChart.cpp" line="809"/>
         <source>Layout</source>
         <translation>Layout</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="812"/>
+        <location filename="../../Charts/UserChart.cpp" line="813"/>
         <source>None</source>
         <translation>Keine</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="813"/>
+        <location filename="../../Charts/UserChart.cpp" line="814"/>
         <source>Top</source>
         <translation>Oben</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="814"/>
+        <location filename="../../Charts/UserChart.cpp" line="815"/>
         <source>Left</source>
         <translation>Links</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="815"/>
+        <location filename="../../Charts/UserChart.cpp" line="816"/>
         <source>Right</source>
         <translation>Rechts</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="816"/>
+        <location filename="../../Charts/UserChart.cpp" line="817"/>
         <source>Bottom</source>
         <translation>Unten</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="820"/>
+        <location filename="../../Charts/UserChart.cpp" line="821"/>
         <source>Legend</source>
         <translation>Legende</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="829"/>
+        <location filename="../../Charts/UserChart.cpp" line="830"/>
         <source>Font scaling</source>
         <translation>Skalieren der Schrift</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="831"/>
-        <location filename="../../Charts/UserChart.cpp" line="833"/>
+        <location filename="../../Charts/UserChart.cpp" line="832"/>
+        <location filename="../../Charts/UserChart.cpp" line="834"/>
         <source>Background</source>
         <translation>Hintergrund</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="836"/>
+        <location filename="../../Charts/UserChart.cpp" line="837"/>
         <source>Animate</source>
         <translation>Animieren</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="838"/>
+        <location filename="../../Charts/UserChart.cpp" line="839"/>
         <source>Single series per plot</source>
         <translation>Datenreihen einzeln plotten</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="841"/>
+        <location filename="../../Charts/UserChart.cpp" line="842"/>
         <source>Refresh for intervals</source>
         <translation>Aktualisieren für Intervalle</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="848"/>
+        <location filename="../../Charts/UserChart.cpp" line="849"/>
         <source>Series</source>
         <translation>Datenreihe</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Group</source>
         <translation>Gruppe</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Y Formula</source>
         <translation>Y-Formel</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="870"/>
-        <location filename="../../Charts/UserChart.cpp" line="932"/>
         <source>Edit</source>
-        <translation>Bearbeiten</translation>
+        <translation type="vanished">Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="889"/>
         <source>Up</source>
-        <translation>Hoch</translation>
+        <translation type="vanished">Hoch</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="890"/>
         <source>Down</source>
-        <translation>Runter</translation>
+        <translation type="vanished">Runter</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="911"/>
+        <location filename="../../Charts/UserChart.cpp" line="885"/>
         <source>Axes</source>
         <translation>Achsen</translation>
     </message>
@@ -34706,72 +34679,72 @@ F3 drücken, wenn fertig.</translation>
 <context>
     <name>VideoWindow</name>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> kph</source>
         <translation> km/h</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="119"/>
+        <location filename="../../Train/VideoWindow.cpp" line="144"/>
         <source>Meters layout</source>
         <translation>Zählerlayout</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="127"/>
+        <location filename="../../Train/VideoWindow.cpp" line="152"/>
         <source>Reset Meters layout to default</source>
         <translation>Zählerlayout auf Standard zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> mph</source>
         <translation> mph</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> m</source>
         <translation> m</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> feet</source>
         <translation> feet</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="625"/>
+        <location filename="../../Train/VideoWindow.cpp" line="681"/>
         <source>w</source>
         <translation>w</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="629"/>
+        <location filename="../../Train/VideoWindow.cpp" line="685"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> km</source>
         <translation> km</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> mi</source>
         <translation> mi</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="673"/>
+        <location filename="../../Train/VideoWindow.cpp" line="729"/>
         <source>Calibration required</source>
         <translation>Kalibrierung notwendig</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="678"/>
+        <location filename="../../Train/VideoWindow.cpp" line="734"/>
         <source>Configuration required</source>
         <translation>Konfiguration notwendig</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="683"/>
+        <location filename="../../Train/VideoWindow.cpp" line="739"/>
         <source>brake fault</source>
         <translation>Bremsenfehler</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="688"/>
+        <location filename="../../Train/VideoWindow.cpp" line="744"/>
         <source>Ready</source>
         <translation>Fertig</translation>
     </message>
@@ -35206,27 +35179,27 @@ F3 drücken, wenn fertig.</translation>
 <context>
     <name>WheelSizeCalculator</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="202"/>
+        <location filename="../../Gui/AthletePages.cpp" line="187"/>
         <source>Wheel Size Calculator</source>
         <translation>Laufradgrößenrechner</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="221"/>
+        <location filename="../../Gui/AthletePages.cpp" line="206"/>
         <source>Rim Size</source>
         <translation>Felgengröße</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="222"/>
+        <location filename="../../Gui/AthletePages.cpp" line="207"/>
         <source>Tire Size</source>
         <translation>Reifengröße</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="223"/>
+        <location filename="../../Gui/AthletePages.cpp" line="208"/>
         <source>Wheel Size</source>
         <translation>Laufradgröße</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="227"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
@@ -35338,12 +35311,12 @@ F3 drücken, wenn fertig.</translation>
 <context>
     <name>WorkoutFilterBox</name>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="34"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="44"/>
         <source>Filter...</source>
         <translation type="unfinished">Filtern...</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="64"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="95"/>
         <source>ERROR: %1</source>
         <translation type="unfinished">Fehler: %1</translation>
     </message>
@@ -35351,12 +35324,12 @@ F3 drücken, wenn fertig.</translation>
 <context>
     <name>WorkoutImportDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="820"/>
+        <location filename="../../Train/Library.cpp" line="809"/>
         <source>Import to Library</source>
         <translation>In Bibliothek importieren</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="854"/>
+        <location filename="../../Train/Library.cpp" line="843"/>
         <source>Please note, that when importing or drag and dropping videos into the library we DO NOT copy the file into the GoldenCheetah library, instead we add a REFERENCE to it. We DO copy workout and videoSync files, since they are smaller.
 
 You can remove references when managing the library via the context menu options</source>
@@ -35365,24 +35338,107 @@ You can remove references when managing the library via the context menu options
 Sie können die Referenzen in der Bibliothek über die Optionen im Kontektmenu löschen</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="868"/>
+        <location filename="../../Train/Library.cpp" line="857"/>
         <source>Files</source>
         <translation>Dateien</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="878"/>
+        <location filename="../../Train/Library.cpp" line="867"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="880"/>
+        <location filename="../../Train/Library.cpp" line="869"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="884"/>
+        <location filename="../../Train/Library.cpp" line="873"/>
         <source>Overwite existing files</source>
         <translation>Bestehende Dateien überschreiben</translation>
+    </message>
+</context>
+<context>
+    <name>WorkoutMenuProvider</name>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="271"/>
+        <source>Select Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="274"/>
+        <source>Manage Filters</source>
+        <translation type="unfinished">Filter verwalten</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="275"/>
+        <source>Add Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="289"/>
+        <source>Add Tag to Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="292"/>
+        <source>Filter Tags...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="310"/>
+        <source>Match all selected tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="353"/>
+        <source>Manage Workout Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="360"/>
+        <source>Name</source>
+        <translation type="unfinished">Name</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="361"/>
+        <source>Filter</source>
+        <translation type="unfinished">Filter</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="362"/>
+        <source>_index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="370"/>
+        <source>Execute</source>
+        <translation type="unfinished">Ausführen</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="371"/>
+        <source>Update</source>
+        <translation type="unfinished">Aktualisieren</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="423"/>
+        <source>Add Workout Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="426"/>
+        <source>Name of the Filter...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="467"/>
+        <source>New</source>
+        <translation type="unfinished">Neu</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="469"/>
+        <source>New (%1)</source>
+        <translation type="unfinished">Neu (%1)</translation>
     </message>
 </context>
 <context>
@@ -35397,41 +35453,41 @@ Sie können die Referenzen in der Bibliothek über die Optionen im Kontektmenu l
     <name>WorkoutPlotWindow</name>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="40"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="104"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
         <source>Ergmode specific settings</source>
         <translation>Ergmode-spezifische Einstellungen</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="46"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
         <source>Color power zones</source>
         <translation>Farbige Leistungszonen anzeigen</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="48"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="56"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
         <source>Never</source>
         <translation>Nie</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="49"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
         <source>Always</source>
         <translation>Immer</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="50"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="57"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="109"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="113"/>
         <source>When stopped</source>
         <translation>Wenn angehalten</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="54"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="110"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
         <source>Show tooltip</source>
         <translation>Tooltip anzeigen</translation>
     </message>
@@ -35525,12 +35581,12 @@ Sie können die Referenzen in der Bibliothek über die Optionen im Kontektmenu l
 <context>
     <name>WorkoutWidget</name>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="1531"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="1532"/>
         <source>File save failed.</source>
         <translation>Speichern der Datei fehlgeschlagen.</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="2367"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="2368"/>
         <source>Intensity</source>
         <translation>Intensität</translation>
     </message>
@@ -35684,26 +35740,22 @@ Sie können die Referenzen in der Bibliothek über die Optionen im Kontektmenu l
 <context>
     <name>XDataDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="44"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="45"/>
         <source>xData</source>
         <translation>xData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="58"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="59"/>
         <source>Data Series</source>
         <translation>Datenreihe</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="78"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="80"/>
         <source>Add</source>
-        <translation>Hinzufügen</translation>
+        <translation type="vanished">Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="79"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="81"/>
         <source>Delete</source>
-        <translation>Löschen</translation>
+        <translation type="vanished">Löschen</translation>
     </message>
 </context>
 <context>
@@ -35780,32 +35832,32 @@ Sie können die Referenzen in der Bibliothek über die Optionen im Kontektmenu l
 <context>
     <name>XDataSeriesSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="333"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="315"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="338"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="320"/>
         <source>Units</source>
         <translation>Maßeinheiten</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="346"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="328"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="347"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="329"/>
         <source>OK</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Name is blank</source>
         <translation>Name ist leer</translation>
     </message>
@@ -35813,48 +35865,48 @@ Sie können die Referenzen in der Bibliothek über die Optionen im Kontektmenu l
 <context>
     <name>XDataSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="262"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="244"/>
         <source>xData</source>
         <translation>xData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="269"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="251"/>
         <source>Data Series</source>
         <translation>Datenreihe</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="270"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="252"/>
         <source>Units</source>
         <translation>Maßeinheiten</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="274"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="256"/>
         <source>Series %1</source>
         <translation>Datenreihe %1</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="281"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="263"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="282"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="264"/>
         <source>OK</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
         <source>XData name is blank</source>
         <translation>XData-Name ist leer</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Must have at least one data series.</source>
         <translation>Es muss mind. eine Datenserie geben.</translation>
     </message>
@@ -36175,17 +36227,17 @@ Sie können die Referenzen in der Bibliothek über die Optionen im Kontektmenu l
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="915"/>
+        <location filename="../../Gui/AthletePages.cpp" line="886"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="962"/>
+        <location filename="../../Gui/AthletePages.cpp" line="933"/>
         <source>Critical Power</source>
         <translation>Critical Power</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="963"/>
+        <location filename="../../Gui/AthletePages.cpp" line="934"/>
         <source>Default</source>
         <translation>Standardeinstellung</translation>
     </message>

--- a/src/Resources/translations/gc_es.ts
+++ b/src/Resources/translations/gc_es.ts
@@ -107,38 +107,38 @@ Puede que sea necesario deshabilitarlo de forma manual.</translation>
         <translation type="vanished">Constante de tiempo para LTS (estrés a largo plazo), en días</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="504"/>
+        <location filename="../../Gui/AthletePages.cpp" line="489"/>
         <source>s</source>
         <translation>s</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="517"/>
-        <location filename="../../Gui/AthletePages.cpp" line="522"/>
+        <location filename="../../Gui/AthletePages.cpp" line="502"/>
+        <location filename="../../Gui/AthletePages.cpp" line="507"/>
         <source>days</source>
         <translation>días</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="525"/>
+        <location filename="../../Gui/AthletePages.cpp" line="510"/>
         <source>PMC Stress Balance Today</source>
         <translation>Balance de estrés hoy (PMC)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="528"/>
+        <location filename="../../Gui/AthletePages.cpp" line="513"/>
         <source>Restore Defaults</source>
         <translation>Restaurar valores por defecto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="517"/>
         <source>W&apos;bal tau</source>
         <translation>Tau para W&apos;bal</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="518"/>
         <source>Short Term Stress (STS) average</source>
         <translation>Constante de tiempo para STS (estrés a corto plazo)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="534"/>
+        <location filename="../../Gui/AthletePages.cpp" line="519"/>
         <source>Long Term Stress (LTS) average</source>
         <translation>Constante de tiempo para LTS (estrés a largo plazo)</translation>
     </message>
@@ -154,96 +154,96 @@ Puede que sea necesario deshabilitarlo de forma manual.</translation>
 <context>
     <name>AboutRiderPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="372"/>
+        <location filename="../../Gui/AthletePages.cpp" line="357"/>
         <source>Nickname</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="373"/>
+        <location filename="../../Gui/AthletePages.cpp" line="358"/>
         <source>Date of Birth</source>
         <translation>Fecha de nacimiento</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="374"/>
+        <location filename="../../Gui/AthletePages.cpp" line="359"/>
         <source>Sex</source>
         <translation>Sexo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="376"/>
+        <location filename="../../Gui/AthletePages.cpp" line="361"/>
         <source>Weight</source>
         <translation>Peso</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="375"/>
+        <location filename="../../Gui/AthletePages.cpp" line="360"/>
         <source>Height</source>
         <translation>Altura</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="279"/>
+        <location filename="../../Gui/AthletePages.cpp" line="264"/>
         <source>Male</source>
         <translation>Masculino</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="280"/>
+        <location filename="../../Gui/AthletePages.cpp" line="265"/>
         <source>Female</source>
         <translation>Femenino</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> kg</source>
         <translation> kg</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> lb</source>
         <translation> lb</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> cm</source>
         <translation> cm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> in</source>
         <translation> &quot;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="359"/>
+        <location filename="../../Gui/AthletePages.cpp" line="344"/>
         <source>Calculate...</source>
         <translation>Calcular...</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="378"/>
+        <location filename="../../Gui/AthletePages.cpp" line="363"/>
         <source>Bike</source>
         <translation>Bicicleta</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="379"/>
+        <location filename="../../Gui/AthletePages.cpp" line="364"/>
         <source>Crank Length</source>
         <translation>Longitud de palancas/bielas (mm)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="380"/>
+        <location filename="../../Gui/AthletePages.cpp" line="365"/>
         <source>Wheelsize</source>
         <translation>Tamaño de rueda</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="356"/>
+        <location filename="../../Gui/AthletePages.cpp" line="341"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="437"/>
+        <location filename="../../Gui/AthletePages.cpp" line="422"/>
         <source>Choose Picture</source>
         <translation>Seleccionar foto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="438"/>
+        <location filename="../../Gui/AthletePages.cpp" line="423"/>
         <source>Images</source>
         <translation>Imágenes</translation>
     </message>
@@ -2277,397 +2277,394 @@ Presione siguiente para continuar
 <context>
     <name>AllPlotWindow</name>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="190"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="444"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="165"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
         <source>Smooth</source>
         <translation>Suavizado</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="198"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="173"/>
         <source>Stacked</source>
         <translation>Apilado</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="199"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="174"/>
         <source>by series</source>
         <translation>por serie</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="200"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="175"/>
         <source>Fullplot</source>
         <translation>Gráfico completo</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="201"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="176"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="239"/>
         <source>Overlay</source>
         <translation>Superposición</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="229"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="204"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="206"/>
         <source>Stack</source>
         <translation>Apilar</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="210"/>
         <source>By Series</source>
         <translation>Por serie</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="246"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="221"/>
         <source>Stack Zoom</source>
         <translation>Ampliar apilado</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="248"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="223"/>
         <source>Full plot</source>
         <translation>Gráfico completo</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="227"/>
         <source>Show Interval Markers</source>
         <translation>Mostrar marcadores de intervalos</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="256"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
         <source>Interval Navigator</source>
         <translation>Navegador de intervalos</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="260"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
         <source>Hover intervals</source>
         <translation>Sobrevolar intervalos</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="268"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="243"/>
         <source>Fill Curves</source>
         <translation>Rellenar curvas</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="247"/>
         <source>Grid</source>
         <translation>Cuadrícula</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="277"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
         <source>Acceleration</source>
         <translation>Aceleración</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="279"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="254"/>
         <source>Delta Series</source>
         <translation>Serie delta</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="280"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="255"/>
         <source>Power %1</source>
         <translation>Potencia %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="283"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="258"/>
         <source>Cadence %1</source>
         <translation>Cadencia %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="261"/>
         <source>Torque %1</source>
         <translation>Par %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="289"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
         <source>Heartrate %1</source>
         <translation>Frec. cardíaca %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="295"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="270"/>
         <source>Balance</source>
         <translation>Balance</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
         <source>Left/Right</source>
         <translation>Izquierda/derecha</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="274"/>
         <source>Torque Effectiveness</source>
         <translation>Efectividad del par</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="303"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="278"/>
         <source>Smoothness</source>
         <translation>Fluidez</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="282"/>
         <source>Pedal Center Offset</source>
         <translation>Desplazamiento del centro del pedal (PCO)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="311"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
         <source>Power Phase</source>
         <translation>Ángulo barrido en la pedalada</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="290"/>
         <source>Peak Power Phase</source>
         <translation>Ángulo barrido en el pico de potencia de la pedalada</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="322"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
         <source>Vertical Oscillation</source>
         <translation>Oscilación vertical</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="324"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
         <source>Running</source>
         <translation>Carrera</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="326"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="301"/>
         <source>Ground Contact Time</source>
         <translation>Tiempo de contacto con el suelo</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
         <source>Cadence </source>
         <translation>Cadencia </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="313"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="340"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
         <source>Moxy</source>
         <translation>Moxy</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="317"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="321"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="325"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="355"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="330"/>
         <source>Heart Rate</source>
         <translation>Frecuencia cardíaca</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="357"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
         <source>Data series</source>
         <translation>Series de datos</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="359"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="334"/>
         <source>Core Temperature</source>
         <translation>Temperatura corporal</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="363"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
         <source>Speed</source>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="367"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
         <source>Cadence</source>
         <translation>Cadencia</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="94"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="95"/>
         <source>Basic</source>
         <translation>Configuración básica</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="109"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="110"/>
         <source>Curves</source>
         <translation>Curvas</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="116"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="117"/>
         <source>User Data</source>
         <translation>Datos de usuario</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="132"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="134"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Formula</source>
         <translation>Fórmula</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="144"/>
         <source>Edit</source>
-        <translation>Editar</translation>
+        <translation type="vanished">Editar</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="163"/>
         <source>Up</source>
-        <translation>Arriba</translation>
+        <translation type="vanished">Arriba</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="164"/>
         <source>Down</source>
-        <translation>Abajo</translation>
+        <translation type="vanished">Abajo</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="371"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
         <source>Altitude</source>
         <translation>Altitud</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
         <source>Temperature</source>
         <translation>Temperatura</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="379"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="354"/>
         <source>Headwind</source>
         <translation>Viento en contra</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="383"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="358"/>
         <source>Torque</source>
         <translation>Par</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="387"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="362"/>
         <source>Gear Ratio</source>
         <translation>Desarrollo</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="391"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="366"/>
         <source>Slope</source>
         <translation>Pendiente</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="373"/>
         <source>No Alt/Slope</source>
         <translation>Sin altitud/pendiente</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="399"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="374"/>
         <source>0.1km|mi -  1min</source>
         <translation>0.1km|mi - 1min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="400"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
         <source>0.5km|mi -  5min</source>
         <translation>0.5km|mi - 5min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="401"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="376"/>
         <source>1.0km|mi - 10min</source>
         <translation>1.0km|mi - 10min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1528"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="377"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="1503"/>
         <source>Alt/Slope</source>
         <translation>Altitud/pendiente</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="382"/>
         <source>Anaerobic TISS</source>
         <translation>TISS anaeróbico</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="384"/>
         <source>Metrics</source>
         <translation>Métricas</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="411"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="386"/>
         <source>Aerobic TISS</source>
         <translation>TISS aeróbico</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="390"/>
         <source>Iso Power</source>
         <translation>Potencia normalizada</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="394"/>
         <source>Skiba xPower</source>
         <translation>Potencia normalizada de Skiba (xPower)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="423"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
         <source>Altitude Power</source>
         <translation>Potencia corregida de altitud (aPower)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="427"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
         <source>W&apos; balance</source>
         <translation>Balance de W&apos;(J)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="441"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="416"/>
         <source>Time of day</source>
         <translation>Hora del día</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="742"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="717"/>
         <source>Intervals</source>
         <translation>Intervalos</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="2253"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="2228"/>
         <source>Selection #%1 </source>
         <translation>Selección #%1 </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="432"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
         <source>Power + shade</source>
         <translation>Potencia + sombreado</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="433"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="408"/>
         <source>Power - shade</source>
         <translation>Potencia - sombreado</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="434"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
         <source>No Power</source>
         <translation>Sin potencia</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="435"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="410"/>
         <source>Shading</source>
         <translation>Sombreado</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="439"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="414"/>
         <source>Time</source>
         <translation>Tiempo</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="440"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
         <source>Distance</source>
         <translation>Distancia</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="442"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="417"/>
         <source>X Axis</source>
         <translation>Eje X</translation>
     </message>
@@ -3478,51 +3475,45 @@ Presione siguiente para continuar
 <context>
     <name>AutoImportPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4028"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4029"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
         <source>Browse</source>
         <translation type="vanished">Buscar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4040"/>
         <source>Add</source>
-        <translation>Agregar</translation>
+        <translation type="vanished">Agregar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4041"/>
         <source>Delete</source>
-        <translation>Eliminar</translation>
+        <translation type="vanished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4042"/>
         <source>Up</source>
-        <translation>Arriba</translation>
+        <translation type="vanished">Arriba</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4043"/>
         <source>Down</source>
-        <translation>Abajo</translation>
+        <translation type="vanished">Abajo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4054"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3779"/>
         <source>Enter a directory</source>
         <translation>Ingrese carpeta</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4059"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3784"/>
         <source>Directory</source>
         <translation>Carpeta</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4060"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3785"/>
         <source>Import Rule</source>
         <translation>Regla de importación</translation>
     </message>
@@ -4340,37 +4331,37 @@ Presione siguiente para continuar
 <context>
     <name>BackupPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="608"/>
+        <location filename="../../Gui/AthletePages.cpp" line="593"/>
         <source>Enter a directory</source>
         <translation>Elegir carpeta</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="601"/>
         <source>every</source>
         <translation>siempre</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="617"/>
+        <location filename="../../Gui/AthletePages.cpp" line="602"/>
         <source>times</source>
         <translation>veces</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="603"/>
         <source>never</source>
         <translation>nunca</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="605"/>
         <source>Backup now</source>
         <translation>Guardar ahora</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="623"/>
+        <location filename="../../Gui/AthletePages.cpp" line="608"/>
         <source>Auto Backup Folder</source>
         <translation>Carpeta de autoresguardo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="624"/>
+        <location filename="../../Gui/AthletePages.cpp" line="609"/>
         <source>Auto Backup after closing the athlete</source>
         <translation>Autoguardado después de cerrar el atleta</translation>
     </message>
@@ -5200,41 +5191,33 @@ Comencemos la configuración.</translation>
         <translation type="vanished">Modificar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1202"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1203"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1204"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1150"/>
         <source>Review...</source>
         <translation>Revisar...</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1206"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1152"/>
         <source>Changed power estimates are available</source>
         <translation>Estimaciones de potencia disponibles</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1213"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1225"/>
         <source>Add</source>
-        <translation>Agregar</translation>
+        <translation type="vanished">Agregar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1214"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1226"/>
         <source>Delete</source>
-        <translation>Eliminar</translation>
+        <translation type="vanished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1216"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1158"/>
         <source>Def</source>
         <translation>Def</translation>
     </message>
@@ -5243,27 +5226,27 @@ Comencemos la configuración.</translation>
         <translation type="vanished">Fecha desde</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1218"/>
         <source>Critical Power</source>
         <translation>Potencia crítica</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1305"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>AeTP</source>
         <translation>AeTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1306"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>FTP</source>
         <translation>FTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1307"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1221"/>
         <source>W&apos;</source>
         <translation>W&apos;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1308"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1222"/>
         <source>Pmax</source>
         <translation>Pmáx</translation>
     </message>
@@ -5272,207 +5255,207 @@ Comencemos la configuración.</translation>
         <translation type="vanished">La potencia crítica debe ser &gt; 0</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1347"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1261"/>
         <source>Short</source>
         <translation>Código</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1247"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1169"/>
         <source>Use CP for all metrics</source>
         <translation>Usar potencia crítica para todas las métricas</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1240"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1162"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1241"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1163"/>
         <source>Semi-Automatic (CP2)</source>
         <translation>Semiautomático (modelo de 2 parámetros)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1164"/>
         <source>Semi-Automatic (CP3)</source>
         <translation>Semiautomático (modelo de 3 parámetros)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1243"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1165"/>
         <source>Semi-Automatic (Extended)</source>
         <translation>Semiautomático (modelo extendido)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1170"/>
         <source>Use FTP for Coggan metrics</source>
         <translation>Usar FTP para las métricas de Coggan</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1273"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1279"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1285"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1342"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1618"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1631"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2283"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2289"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2310"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1187"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1193"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1199"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1211"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1537"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1545"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2180"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2186"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2194"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2207"/>
         <source>W</source>
         <translation>W</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1205"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1547"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2201"/>
         <source>J</source>
         <translation>J</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1303"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1217"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2145"/>
         <source>Start Date</source>
         <translation>Fecha de inicio</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1309"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1223"/>
         <source>Model Fit</source>
         <translation>Ajuste de modelo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1262"/>
         <source>Long</source>
         <translation>Nombre descriptivo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1349"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1263"/>
         <source>From Watts</source>
         <translation>Potencia de inicio</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1598"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1512"/>
         <source>Review range starting on %1</source>
         <translation>Comprobación del intervalo que comienza el %1</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1614"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1528"/>
         <source>Current</source>
         <translation>Actual</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1615"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1529"/>
         <source>Estimate</source>
         <translation>Estimación</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1530"/>
         <source>Accept</source>
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1788"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1691"/>
         <source>🗹</source>
         <translation>🗹</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1692"/>
         <source>Estimate and settings &lt;b&gt;match&lt;/b&gt;</source>
         <translation>Estimación y configuración &lt;b&gt;coinciden&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1695"/>
         <source>☐</source>
         <translation>☐</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1696"/>
         <source>Estimate and settings &lt;b&gt;differ&lt;/b&gt;</source>
         <translation>Estimación y configuración &lt;b&gt;no coinciden&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1797"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1700"/>
         <source>⏲</source>
         <translation>⏲</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1800"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1703"/>
         <source>Range is %1 days older than closest estimate</source>
         <translation>El intervalo es %1 día(s) más antiguo que la estimación más cercana</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1802"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1705"/>
         <source>Range is %1 days younger than closest estimate</source>
         <translation>El intervalo es %1 día(s) más moderno que la estimación más cercana</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1808"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1711"/>
         <source>∅</source>
         <translation>∅</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1712"/>
         <source>No estimate available</source>
         <translation>No hay estimación disponible</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1902"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1805"/>
         <source>New range from estimate</source>
         <translation>Nuevo intervalo a partir de la estimación</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2237"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2134"/>
         <source>The proposed value for AeTP is a very rough estimate, assuming %1 % of CP. Usually it is determined by a&lt;ul&gt;&lt;li&gt;Metabolic test&lt;/li&gt;&lt;li&gt;Lactate ramp test&lt;/li&gt;&lt;li&gt;Run / Cycling ‘conversational’ test&lt;/li&gt;&lt;li&gt;Run Decoupling test&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>El valor propuesto para umbral aeróbico de potencia (AeTP) es una estimación grosera calculado como el %1 % de la potencia crítica (CP). Normalmente se estima con un&lt;ul&gt;&lt;li&gt;Test metabólico (metabolic test)&lt;/li&gt;&lt;li&gt;Test de lactato en rampa (lactate ramp test)&lt;/li&gt;&lt;li&gt;Test de carrera/ciclismo &apos;conversacional&apos; (run/cycling ‘conversational’ test)&lt;/li&gt;&lt;li&gt;Test de desacople en carrera (run decoupling test)&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2239"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2136"/>
         <source>Updating FTP internally to match CP</source>
         <translation>Se actualiza internamente el valor de FTP para que coincida con el de potencia crítica (CP)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2139"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>El modelo selecionado no proporciona valores de &lt;ul&gt;&lt;li&gt;FTP (se usa la potencia crítica -CP- en su lugar)&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2244"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2141"/>
         <source>Your selected model does not deliver values for PMax, using default value of %1 W instead</source>
         <translation>El modelo selecionado no proporciona valores de Pmáx (se usa el valor %1 W)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2246"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2143"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;li&gt;PMax, assuming a default of %1 W&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>El modelo selecionado no proporciona valores de &lt;ul&gt;&lt;li&gt;FTP (se usa la potencia crítica -CP- en su lugar)&lt;/li&gt;&lt;li&gt;Pmáx (se usa el valor %1 W)&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2250"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2147"/>
         <source>Critical Power (CP)</source>
         <translation>Potencia crítica (CP)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2252"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2149"/>
         <source>Aerobic Threshold Power (AeTP)</source>
         <translation>Umbral aeróbico de potencia (AeTP)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2254"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2151"/>
         <source>Functional Threshold Power (FTP)</source>
         <translation>Potencia al umbral funcional (FTP)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2153"/>
         <source>Anaerobic Work Capacity (W&apos;)</source>
         <translation>Capacidad de trabajo anaeróbico (W&apos;)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2258"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2155"/>
         <source>Maximum Power (PMax)</source>
         <translation>Potencia máxima (Pmáx)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2270"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2167"/>
         <source>Manual range</source>
         <translation>Intervalo manual</translation>
     </message>
@@ -5481,14 +5464,14 @@ Comencemos la configuración.</translation>
         <translation type="vanished">Se alcanzó el máximo de 10 zonas.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2018"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2025"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1917"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1924"/>
         <source>New</source>
         <translation>Nueva</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2020"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1919"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1926"/>
         <source>New (%1)</source>
         <translation>Nueva (%1)</translation>
     </message>
@@ -5942,52 +5925,44 @@ ddd, dd MMM yyyy</source>
         <translation type="vanished">Actualizar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3307"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3319"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3308"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3320"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3313"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3325"/>
         <source>Add</source>
-        <translation>Agregar</translation>
+        <translation type="vanished">Agregar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3314"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3326"/>
         <source>Delete</source>
-        <translation>Eliminar</translation>
+        <translation type="vanished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3316"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3109"/>
         <source>Def</source>
         <translation>Def</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3359"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3506"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3272"/>
         <source>Start Date</source>
         <translation>Fecha de inicio</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3249"/>
         <source>New range</source>
         <translation>Nuevo intervalo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3507"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3273"/>
         <source>Critical Velocity (CV)</source>
         <translation>Velocidad crítica (CV)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3508"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3274"/>
         <source>Aerobic Threshold (AeT)</source>
         <translation>Umbral aeróbico (AeT)</translation>
     </message>
@@ -5996,12 +5971,12 @@ ddd, dd MMM yyyy</source>
         <translation type="vanished">Fecha desde</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3360"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3128"/>
         <source>Critical Velocity</source>
         <translation>Velocidad crítica</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3361"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3129"/>
         <source>Aerobic Threshold</source>
         <translation>Umbral aeróbico</translation>
     </message>
@@ -6010,17 +5985,17 @@ ddd, dd MMM yyyy</source>
         <translation type="vanished">La velocidad crítica debe ser &gt; 0</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3403"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
         <source>Short</source>
         <translation>Corto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3404"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3172"/>
         <source>Long</source>
         <translation>Largo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3405"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3173"/>
         <source>From</source>
         <translation>Desde</translation>
     </message>
@@ -6029,14 +6004,14 @@ ddd, dd MMM yyyy</source>
         <translation type="vanished">Se alcanzó el máximo de 10 zonas.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3679"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3686"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3441"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3448"/>
         <source>New</source>
         <translation>Nueva</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3681"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3688"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3443"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3450"/>
         <source>New (%1)</source>
         <translation>Nueva (%1)</translation>
     </message>
@@ -7576,37 +7551,32 @@ Los datos actuales no estarán más disponibles y es necesario reiniciar GoldenC
 <context>
     <name>CredentialsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="67"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
+    </message>
+    <message>
+        <source>-</source>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="vanished">Editar</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">Agregar</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">Eliminar</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="68"/>
-        <source>-</source>
-        <translation>-</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="69"/>
-        <source>Edit</source>
-        <translation>Editar</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="74"/>
-        <source>Add</source>
-        <translation>Agregar</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="75"/>
-        <source>Delete</source>
-        <translation>Eliminar</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="86"/>
         <source>Service</source>
         <translation>Servicio</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="87"/>
+        <location filename="../../Gui/AthletePages.cpp" line="69"/>
         <source>Description</source>
         <translation>Descripción</translation>
     </message>
@@ -8294,7 +8264,7 @@ Los datos actuales no estarán más disponibles y es necesario reiniciar GoldenC
 <context>
     <name>DataFilterEdit</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2743"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2712"/>
         <source>Warning: sample() is slow -- update code to use samples()</source>
         <translation>Aviso: la función sample() es ineficiente, actualice el código para usar samples()</translation>
     </message>
@@ -8654,7 +8624,7 @@ Los datos actuales no estarán más disponibles y es necesario reiniciar GoldenC
 <context>
     <name>DirectoryPathWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="277"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="308"/>
         <source>Browse</source>
         <translation>Buscar</translation>
     </message>
@@ -8891,28 +8861,28 @@ Puede ser necesario (re)instalar el controlador FTDI o PL2303 antes de descargar
 <context>
     <name>Dropbox</name>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="68"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="77"/>
         <source>Problem accessing Dropbox data</source>
         <translation>Problemas accediendo a datos de Dropbox</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="130"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="139"/>
         <source>You must authorise with Dropbox first</source>
         <translation>Primero tiene que identificarse en Dropbox</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="205"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="214"/>
         <source>Parsing Error: %1</source>
         <translation>Error en el análisis sintáctico: %1</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="293"/>
-        <location filename="../../Cloud/Dropbox.cpp" line="312"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="302"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="321"/>
         <source>Completed.</source>
         <translation>Finalizado.</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="297"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="306"/>
         <source>Network Error - Upload failed.</source>
         <translation>Error de red - Falló la carga.</translation>
     </message>
@@ -9057,136 +9027,136 @@ Puede ser necesario (re)instalar el controlador FTDI o PL2303 antes de descargar
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2064"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2033"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2034"/>
         <source>Axis Label / Units</source>
         <translation>Rótulo del eje/Unidades</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1558"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1527"/>
         <source>Estimate %1 %2 Power</source>
         <translation>Estimar potencia %1 %2</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1562"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1531"/>
         <source>Endurance Index</source>
         <translation>Índice de resistencia</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1532"/>
         <source>Vo2Max Estimate</source>
         <translation>VO2máx estimado</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1597"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1566"/>
         <source>Curve Settings</source>
         <translation>Configuración de la curva</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1605"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1574"/>
         <source>Metric</source>
         <translation>Métrica</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1606"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1575"/>
         <source>Best</source>
         <translation>Mejor</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1607"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1576"/>
         <source>Estimate</source>
         <translation>Estimar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1577"/>
         <source>PMC</source>
         <translation>PMC</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1609"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1578"/>
         <source>Formula</source>
         <translation>Fórmula</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1610"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1579"/>
         <source>Measure</source>
         <translation>Medición</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1611"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1580"/>
         <source>Performance</source>
         <translation>Rendimiento</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1612"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1581"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1684"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1767"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1653"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1736"/>
         <source>seconds</source>
         <translation>segundos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1685"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1768"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1737"/>
         <source>minutes</source>
         <translation>minutos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1769"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1655"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1738"/>
         <source>hours</source>
         <translation>horas</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1723"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1816"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1692"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1785"/>
         <source>Peak</source>
         <translation>Pico</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1781"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1750"/>
         <source>Absolute</source>
         <translation>Absoluto</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1751"/>
         <source>Per Kilogram</source>
         <translation>Por kilogramo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1813"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
         <source>Total</source>
         <translation>Total</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1814"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1783"/>
         <source>Running Total</source>
         <translation>Total acumulado</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1815"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1784"/>
         <source>Average</source>
         <translation>Promedio</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1817"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1786"/>
         <source>Low</source>
         <translation>Mínimo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1820"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1789"/>
         <source>Aggregate:</source>
         <translation>Combinar:</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1828"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1797"/>
         <source># type in a formula to use
 # for e.g. BikeStress / Duration
 # as you type the available metrics
@@ -9200,292 +9170,292 @@ le sugerirá los posibles nombres
 </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1839"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1808"/>
         <source>Weekly Best Performances</source>
         <translation>Mejores rendimientos semanales</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1840"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1809"/>
         <source>Submaximal Weekly Best</source>
         <translation>Mejores submáximos semanales</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1841"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1810"/>
         <source>Performance Tests</source>
         <translation>Pruebas de rendimiento</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1933"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1902"/>
         <source>Short Term Stress (STS/ATL)</source>
         <translation>Estrés a corto plazo (ECP/ATL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1934"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1903"/>
         <source>Long Term Stress  (LTS/CTL)</source>
         <translation>Estrés a largo plazo (ELP/CTL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1935"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1904"/>
         <source>Stress Balance    (SB/TSB)</source>
         <translation>Balance de estrés (BE/TSB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1936"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1905"/>
         <source>Stress Ramp Rate  (RR)</source>
         <translation>Rampa de estrés (RE/RR)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1944"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1913"/>
         <source>Stress Type</source>
         <translation>Tipo de estrés</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1949"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1918"/>
         <source>Negative Training Effect (NTE)</source>
         <translation>Efecto negativo del entrenamiento (NTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1950"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1919"/>
         <source>Positive Training Effect (PTE)</source>
         <translation>Efecto positivo del entrenamiento (PTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1951"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1920"/>
         <source>Performance (Power Index)</source>
         <translation>Rendimiento (Power index)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1952"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1921"/>
         <source>Predicted CP (Watts)</source>
         <translation>PC prevista (W)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1969"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1938"/>
         <source>Curve Type</source>
         <translation>Tipo de curva</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1945"/>
         <source>Perf. Metric</source>
         <translation>Métrica de rendimiento</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2006"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1975"/>
         <source>Metadata Field</source>
         <translation>Campo de metadatos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2007"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
         <source>PMC metric</source>
         <translation>Métrica PMC</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2032"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2001"/>
         <source>Measure Group</source>
         <translation>Grupo de medidas</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2009"/>
         <source>Measure Field</source>
         <translation>Campo de medidas</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2029"/>
         <source>Filter</source>
         <translation>Filtro</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2071"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
         <source>Style</source>
         <translation>Estilo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2042"/>
         <source>Bar</source>
         <translation>Barra</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2074"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2043"/>
         <source>Line</source>
         <translation>Línea</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2075"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2044"/>
         <source>Sticks</source>
         <translation>Palos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2076"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2045"/>
         <source>Dots</source>
         <translation>Puntos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2048"/>
         <source>Stack</source>
         <translation>Apilar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2053"/>
         <source>Symbol</source>
         <translation>Símbolo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2086"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2055"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2087"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2056"/>
         <source>Circle</source>
         <translation>Círculo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2057"/>
         <source>Square</source>
         <translation>Cuadrado</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2089"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2058"/>
         <source>Diamond</source>
         <translation>Rombo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2090"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2059"/>
         <source>Triangle</source>
         <translation>Triángulo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2091"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
         <source>Cross</source>
         <translation>Cruz</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2092"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2061"/>
         <source>Hexagon</source>
         <translation>Hexágono</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2062"/>
         <source>Star</source>
         <translation>Estrella</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2100"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2069"/>
         <source>Fill curve</source>
         <translation>Rellenar curva</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
         <source>Data labels</source>
         <translation>Etiquetas de datos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2080"/>
         <source>Highlight Highest</source>
         <translation>Resaltar los más altos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
         <source>Highlight Lowest</source>
         <translation>Resaltar los más bajos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2127"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
         <source>Highlight Outliers</source>
         <translation>Resaltar atípicos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2135"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
         <source>Baseline</source>
         <translation>Línea base</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2143"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2112"/>
         <source>Smooth Curve</source>
         <translation>Suavizar curva</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2147"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2116"/>
         <source>No trend Line</source>
         <translation>Sin tendencia</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2148"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2117"/>
         <source>Linear Trend</source>
         <translation>Tendencia lineal</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2149"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2118"/>
         <source>Quadratic Trend</source>
         <translation>Tendencia cuadrática</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2150"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
         <source>Moving Average</source>
         <translation>Promedio móvil</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2151"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2120"/>
         <source>Simple Average</source>
         <translation>Promedio simple</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2123"/>
         <source>Ignore Zeros</source>
         <translation>Ignorar ceros</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2168"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2201"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2170"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2431"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2400"/>
         <source>Peak %1</source>
         <translation>Pico %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2402"/>
         <source> second </source>
         <translation> segundo </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2434"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2403"/>
         <source> minute </source>
         <translation> minuto </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2436"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2405"/>
         <source> hour </source>
         <translation> hora </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2456"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2425"/>
         <source>%1 - %2</source>
         <translation>%1 - %2</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2470"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2439"/>
         <source>Performances</source>
         <translation>Rendimientos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2471"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2440"/>
         <source>Power Index</source>
         <translation>Power index</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2588"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2557"/>
         <source>Performances_%1_%2_%3</source>
         <translation>Rendimientos_%1_%2_%3</translation>
     </message>
@@ -9815,93 +9785,93 @@ le sugerirá los posibles nombres
 <context>
     <name>EditUserAxisDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1731"/>
+        <location filename="../../Charts/UserChart.cpp" line="1689"/>
         <source>Edit Axis</source>
         <translation>Editar eje</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1741"/>
+        <location filename="../../Charts/UserChart.cpp" line="1699"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1742"/>
+        <location filename="../../Charts/UserChart.cpp" line="1700"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1750"/>
+        <location filename="../../Charts/UserChart.cpp" line="1708"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1760"/>
+        <location filename="../../Charts/UserChart.cpp" line="1718"/>
         <source>Logarithmic Scale</source>
         <translation>Escala logarítmica</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1757"/>
+        <location filename="../../Charts/UserChart.cpp" line="1715"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1761"/>
-        <location filename="../../Charts/UserChart.cpp" line="1780"/>
+        <location filename="../../Charts/UserChart.cpp" line="1719"/>
+        <location filename="../../Charts/UserChart.cpp" line="1738"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1763"/>
+        <location filename="../../Charts/UserChart.cpp" line="1721"/>
         <source>Fixed</source>
         <translation>Fijo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1774"/>
+        <location filename="../../Charts/UserChart.cpp" line="1732"/>
         <source> from </source>
         <translation> desde </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1776"/>
+        <location filename="../../Charts/UserChart.cpp" line="1734"/>
         <source> to </source>
         <translation> hasta </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1779"/>
+        <location filename="../../Charts/UserChart.cpp" line="1737"/>
         <source>Range</source>
         <translation>Rango</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1787"/>
+        <location filename="../../Charts/UserChart.cpp" line="1745"/>
         <source>Smoothing</source>
         <translation>Suavizado</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1792"/>
+        <location filename="../../Charts/UserChart.cpp" line="1750"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1793"/>
+        <location filename="../../Charts/UserChart.cpp" line="1751"/>
         <source>Day</source>
         <translation>Día</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1794"/>
+        <location filename="../../Charts/UserChart.cpp" line="1752"/>
         <source>Week</source>
         <translation>Semana</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1795"/>
+        <location filename="../../Charts/UserChart.cpp" line="1753"/>
         <source>Month</source>
         <translation>Mes</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1796"/>
+        <location filename="../../Charts/UserChart.cpp" line="1754"/>
         <source>Year</source>
         <translation>Año</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1798"/>
+        <location filename="../../Charts/UserChart.cpp" line="1756"/>
         <source>Group By</source>
         <translation>Agrupar por</translation>
     </message>
@@ -10099,158 +10069,158 @@ le sugerirá los posibles nombres
 <context>
     <name>EditUserSeriesDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1398"/>
+        <location filename="../../Charts/UserChart.cpp" line="1356"/>
         <source>Edit Data Series</source>
         <translation>Editar serie de datos</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1414"/>
+        <location filename="../../Charts/UserChart.cpp" line="1372"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1415"/>
+        <location filename="../../Charts/UserChart.cpp" line="1373"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1422"/>
+        <location filename="../../Charts/UserChart.cpp" line="1380"/>
         <source>Group</source>
         <translation>Grupo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1430"/>
+        <location filename="../../Charts/UserChart.cpp" line="1388"/>
         <source>Series Name</source>
         <translation>Nombre de la serie</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1519"/>
+        <location filename="../../Charts/UserChart.cpp" line="1477"/>
         <source>Y units</source>
         <translation>Unidades Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1524"/>
+        <location filename="../../Charts/UserChart.cpp" line="1482"/>
         <source>X units</source>
         <translation>Unidades X</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1528"/>
+        <location filename="../../Charts/UserChart.cpp" line="1486"/>
         <source>Sum</source>
         <translation>Suma</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1529"/>
+        <location filename="../../Charts/UserChart.cpp" line="1487"/>
         <source>Average</source>
         <translation>Promedio</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1530"/>
+        <location filename="../../Charts/UserChart.cpp" line="1488"/>
         <source>Peak</source>
         <translation>Máximo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1531"/>
+        <location filename="../../Charts/UserChart.cpp" line="1489"/>
         <source>Low</source>
         <translation>Mínimo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1532"/>
+        <location filename="../../Charts/UserChart.cpp" line="1490"/>
         <source>Running Total</source>
         <translation>Total acumulado</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1533"/>
+        <location filename="../../Charts/UserChart.cpp" line="1491"/>
         <source>Mean Square Root</source>
         <translation>Raíz de la media cuadrática</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1534"/>
+        <location filename="../../Charts/UserChart.cpp" line="1492"/>
         <source>Std Deviation</source>
         <translation>Desviación estándar</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1537"/>
+        <location filename="../../Charts/UserChart.cpp" line="1495"/>
         <source>Aggregate</source>
         <translation>Agregar</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1541"/>
-        <location filename="../../Charts/UserChart.cpp" line="1557"/>
+        <location filename="../../Charts/UserChart.cpp" line="1499"/>
+        <location filename="../../Charts/UserChart.cpp" line="1515"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1542"/>
+        <location filename="../../Charts/UserChart.cpp" line="1500"/>
         <source>Solid</source>
         <translation>Sólido</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1543"/>
+        <location filename="../../Charts/UserChart.cpp" line="1501"/>
         <source>Dashed</source>
         <translation>Guiones</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1544"/>
+        <location filename="../../Charts/UserChart.cpp" line="1502"/>
         <source>Dot</source>
         <translation>Punto</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1545"/>
+        <location filename="../../Charts/UserChart.cpp" line="1503"/>
         <source>Dash Dot</source>
         <translation>Punto-guion</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1546"/>
+        <location filename="../../Charts/UserChart.cpp" line="1504"/>
         <source>Fast Graphics</source>
         <translation>Aceleración gráfica</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1547"/>
+        <location filename="../../Charts/UserChart.cpp" line="1505"/>
         <source>Show on Legend</source>
         <translation>Mostrar en leyenda</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1548"/>
+        <location filename="../../Charts/UserChart.cpp" line="1506"/>
         <source>Show Data Labels</source>
         <translation>Mostrar etiquetas de datos</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1554"/>
+        <location filename="../../Charts/UserChart.cpp" line="1512"/>
         <source>Line Style</source>
         <translation>Estilo de línea</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1558"/>
+        <location filename="../../Charts/UserChart.cpp" line="1516"/>
         <source>Circle</source>
         <translation>Círculo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1559"/>
+        <location filename="../../Charts/UserChart.cpp" line="1517"/>
         <source>Rectangle</source>
         <translation>Rectángulo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1564"/>
+        <location filename="../../Charts/UserChart.cpp" line="1522"/>
         <source>Symbol</source>
         <translation>Símbolo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1572"/>
+        <location filename="../../Charts/UserChart.cpp" line="1530"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1575"/>
+        <location filename="../../Charts/UserChart.cpp" line="1533"/>
         <source>Fill curve</source>
         <translation>Rellenar curva</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1583"/>
+        <location filename="../../Charts/UserChart.cpp" line="1541"/>
         <source>Opacity (%)</source>
         <translation>Opacidad (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1589"/>
+        <location filename="../../Charts/UserChart.cpp" line="1547"/>
         <source>Size/Width</source>
         <translation>Tamaño/ancho</translation>
     </message>
@@ -10297,6 +10267,24 @@ le sugerirá los posibles nombres
         <location filename="../../Metrics/BasicRideMetrics.cpp" line="144"/>
         <source>Only useful for intervals, time the interval started</source>
         <translation>Tiempo de comienzo en segundos, útil para intervalos</translation>
+    </message>
+</context>
+<context>
+    <name>ElevationChartWindow</name>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="221"/>
+        <source>Profile Distance (m)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="229"/>
+        <source>Seconds for delta slope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="237"/>
+        <source>Elevation window size (%) relative to current altitude</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10735,7 +10723,7 @@ le sugerirá los posibles nombres
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ExhaustionDialog.cpp" line="160"/>
+        <location filename="../../Charts/ExhaustionDialog.cpp" line="162"/>
         <source>Time</source>
         <translation>Tiempo</translation>
     </message>
@@ -13412,42 +13400,42 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GcCrashDialog</name>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="78"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="74"/>
         <source>%1 Crash Recovery</source>
         <translation>%1 Recuperación de fallo</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="116"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="112"/>
         <source>&lt;b&gt;GoldenCheetah appears to have PREVIOUSLY crashed for this athlete. &lt;/b&gt;&lt;br&gt;&lt;br&gt;The report below gives some diagnostic information that will be useful to the developers. Feel free to post this with a short description of what was occurring when the crash happened to the &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah forums&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;We respect privacy - this log does NOT contain ids, passwords or personal information.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;When this dialog is closed the athlete will be opened.&lt;/b&gt;</source>
         <translation>&lt;b&gt;GoldenCheetah parece haber sufrido una falla en la sesión ANTERIOR de este atleta. &lt;/b&gt;&lt;br&gt;&lt;br&gt;El siguiente reporte brinda alguna información de diagnóstico que será útil para que los desarrolladores puedan corregir el problema. Puede publicar esta información, junto con una pequeña descripción del escenario en el que la misma ocurrió, en el &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;foro de GoldenCheetah&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;Respetamos su privacidad. Este registro NO contiene identificaciones, claves o información personal.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;Cuando este diálogo se cierre se abrirá la vista del atleta.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="141"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="137"/>
         <source>Save Crash Report...</source>
         <translation>Guardar reporte de falla...</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="143"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="139"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="225"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="221"/>
         <source>&lt;p&gt;Build date: %1 %2&lt;br&gt;Build id: %3&lt;br&gt;Version: %4&lt;br&gt;DB Schema: %5&lt;br&gt;Metrics: %7&lt;br&gt;OS: %6&lt;br&gt;OpenGL: %10&lt;br&gt;UI: dpi scale (%8) font size (%9)&lt;br&gt;</source>
         <translation>&lt;p&gt;Fecha de compilación: %1 %2&lt;br&gt;ID de la compilación: %3&lt;br&gt;Versión: %4&lt;br&gt;Esquema de la base de datos: %5&lt;br&gt;Métricas: %7&lt;br&gt;Sistema operativo: %6&lt;br&gt;OpenGL: %10&lt;br&gt;Interfaz de usuario: escala ppp (%8) tamaño de fuente (%9)&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="255"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="251"/>
         <source>&lt;table&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QT&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QWT&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;%3&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SRMIO&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;D2XX&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;ICAL&lt;/td&gt;&lt;td&gt;%9&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;USBXPRESS&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LIBUSB&lt;/td&gt;&lt;td&gt;%11&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VLC&lt;/td&gt;&lt;td&gt;%12&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VIDEO&lt;/td&gt;&lt;td&gt;%13&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SAMPLERATE&lt;/td&gt;&lt;td&gt;%14&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SSL&lt;/td&gt;&lt;td&gt;%15&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;R&lt;/td&gt;&lt;td&gt;%16&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;Python&lt;/td&gt;&lt;td&gt;%18&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LMFIT&lt;/td&gt;&lt;td&gt;7.0&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;GSL&lt;/td&gt;&lt;td&gt;%19&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</source>
         <translation>&lt;table&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QT&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QWT&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;%3&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SRMIO&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;D2XX&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;ICAL&lt;/td&gt;&lt;td&gt;%9&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;USBXPRESS&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LIBUSB&lt;/td&gt;&lt;td&gt;%11&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VLC&lt;/td&gt;&lt;td&gt;%12&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VIDEO&lt;/td&gt;&lt;td&gt;%13&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SAMPLERATE&lt;/td&gt;&lt;td&gt;%14&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SSL&lt;/td&gt;&lt;td&gt;%15&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;R&lt;/td&gt;&lt;td&gt;%16&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;Python&lt;/td&gt;&lt;td&gt;%18&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LMFIT&lt;/td&gt;&lt;td&gt;7.0&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;GSL&lt;/td&gt;&lt;td&gt;%19&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Save Diagnostics</source>
         <translation>Guardar diagnósticos</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Text File (*.txt)</source>
         <translation>Archivo de texto (*.txt)</translation>
     </message>
@@ -13783,167 +13771,172 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GcWindowRegistry</name>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
         <source>Performance</source>
         <translation>Gráfico de curvas</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="89"/>
         <source>Histogram</source>
         <translation>Histograma</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
         <source>Distribution</source>
         <translation>Distribución</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
         <source>Pedal Force vs Velocity</source>
         <translation>Fuerza vs velocidad</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
         <source>Heartrate vs Power</source>
         <translation>FC vs potencia</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
         <source>Python Chart</source>
         <translation>Gráfico Python</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
         <source>Python Chart </source>
         <translation>Gráfico Python </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
         <source>Workout Editor</source>
         <translation>Editor de entrenamientos</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="113"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
         <source>Live Map</source>
         <translation>Mapa en vivo</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="114"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <source>Elevation Chart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
         <source>Web page</source>
         <translation>Página web</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="101"/>
         <source>Calendar</source>
         <translation>Calendario</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
         <source>Navigator</source>
         <translation>Registro de actividades</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="76"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="73"/>
         <source>User Chart</source>
         <translation>Gráfico de usuario</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
         <source>Trends</source>
         <translation>Tendencias</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="78"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
         <source>TreeMap</source>
         <translation>Diagrama arborescente</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
         <source>Power Duration </source>
         <translation>Potencia-duración </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="83"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
         <source>Activity Overview</source>
         <translation>Resumen de actividad</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="81"/>
         <source>Blank Overview</source>
         <translation>Gráfico de resumen vacío</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="85"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="82"/>
         <source>User Chart </source>
         <translation>Gráfico de usuario </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
         <source>Data</source>
         <translation>Datos</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="88"/>
         <source>Power Duration</source>
         <translation>Potencia-duración</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
         <source>Scatter</source>
         <translation>Dispersión</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="103"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
         <source>Aerolab</source>
         <translation>Aerolab</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
         <source>Telemetry</source>
         <translation>Telemetría</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
         <source>Workout</source>
         <translation>Entrenamiento</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="106"/>
         <source>Realtime</source>
         <translation>Tiempo real</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
         <source>Pedal Stroke</source>
         <translation>Pedalada</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
         <source>Map</source>
         <translation>Mapa</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="71"/>
         <source>Season Overview</source>
         <translation>Resumen de temporada</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="72"/>
         <source>Blank Overview </source>
         <translation>Gráfico de resumen vacío </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
         <source>R Chart</source>
         <translation>Gráfico R</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="98"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
         <source>R Chart </source>
         <translation>Gráfico R </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
         <source>Video Player</source>
         <translation>Reproductor de vídeo</translation>
     </message>
@@ -15047,142 +15040,147 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation>Visualización en tiempo real de la ruta simulada en un mapa OSM</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="296"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="294"/>
+        <source>Show elevation profile of instant position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
         <source>Predefined and configurable set of data ranges for selection of activities to be analysed</source>
         <translation>Conjuntos de rangos de fechas predefinidos y configurables para la selección de las actividades a ser analizadas</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
         <source>Powerful filter and search engine to determine the activities which are considered in diagram</source>
         <translation>Potente mecanismo de búsqueda y filtrado para determinar qué actividades se consideran en un diagrama</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
         <source>Configurable list of activities</source>
         <translation>Lista configurable de actividades</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="317"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
         <source>Configurable list of training devices</source>
         <translation>Lista configurable de dispositivos</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
         <source>Configurable list of workout files</source>
         <translation>Lista configurable de entrenamientos</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
         <source>Configurable list of video files</source>
         <translation>Lista configurable de vídeos</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="325"/>
         <source>Configurable list of video sync files</source>
         <translation>Lista configurable de sincronizaciones de vídeo</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="327"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
         <source>Entry field for sophisticated Searching and Filtering of activities</source>
         <translation>Campo de ingreso para la búsqueda y filtrado de actividades</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
         <source>Adding intervals to an activity using simple query methods</source>
         <translation>Incorporación de intervalos a una actividad utilizando métodos de búsqueda</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
         <source>To compare Activities/Intervals in Activity View and Date Ranges in Trends View</source>
         <translation>Comparar actividades/intervalos en la vista de actividades y rangos de datos en la vista de tendencias</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="335"/>
         <source>Workout Control, Intensity Adjustments and Notifications Display</source>
         <translation>Control del entrenamiento, ajustes de intensidad y visualización de notificaciones</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
         <source>Athlete Model</source>
         <translation>Atleta modelo</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
         <source>Athlete Measures</source>
         <translation>Medidas del atleta</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
         <source>Auto Import</source>
         <translation>Importación automática</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
         <source>Backup</source>
         <translation>Resguardo</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="355"/>
         <source>Cloud Accounts</source>
         <translation>Cuentas de serivicos de red</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <source>Automatic Interval Detection</source>
         <translation>Detección automática de intervalos</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
         <source>Definition of coloring rules for activities</source>
         <translation>Definición de reglas de coloreado para las actividades</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
         <source>Metrics shown in &apos;Intervals&apos; and &apos;Summary&apos;</source>
         <translation>Métricas mostradas en &quot;Intervalos&quot; y &quot;Resumen&quot;</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
         <source>User/Custom Metrics</source>
         <translation>Métricas de usuario personalizadas</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
         <source>Create or Edit a User Metric</source>
         <translation>Crear o editar métrica personalizada</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
         <source>Measures</source>
         <translation>Medidas</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
         <source>Train View devices configuration and preferences</source>
         <translation>Configuración y preferencias de dispositivos de entrenamiento</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
         <source>Train View Preferences</source>
         <translation>Preferencias de la vista de entrenamiento</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
         <source>Remote Controls Configuration</source>
         <translation>Configuración del control remoto</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
         <source>Add/Remove Train Devices</source>
         <translation>Agregar/eliminar dispositivos de entrenamiento</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
         <source>Add Train Devices</source>
         <translation>Agregar dispositivos de entrenamiento</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="394"/>
         <source>Virtual Bicycle configuration for simulation rides</source>
         <translation>Configuración de la bicicleta virtual para entrenamientos de simulación</translation>
     </message>
@@ -15216,8 +15214,8 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
     </message>
     <message>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="219"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
         <source>Calendar</source>
         <translation>Calendario</translation>
     </message>
@@ -15252,74 +15250,74 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation>Configuración de filtro/búsqueda y rango de fechas específico para el gráfico</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
         <source>Definition of points in time &apos;Events&apos; which are marked explicitely on time related diagrams</source>
         <translation>Definición de eventos que se pueden mostrar como referencias temporales en los diagramas de tiempo</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="316"/>
         <source>Simple summary view</source>
         <translation>Vista resumida sencilla</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
         <source>Alternative access to the charts created for the main view</source>
         <translation>Acceso alternativo a los diagramas creados para la vista principal</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
         <source>Display the available and add new intervals using simple query methods</source>
         <translation>Muestra los intervalos disponibles y permite la creación de nuevos mediante métodos simples de búsqueda</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="356"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="337"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
         <source>Athlete</source>
         <translation>Atleta</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
         <source>Training Zone definition for power</source>
         <translation>Definición de zonas de entrenamiento por potencia</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
         <source>Training Zone definition for heartrate</source>
         <translation>Definición de zonas de entrenamiento por frecuencia cardíaca</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
         <source>Training Zone definition for Swim and Run</source>
         <translation>Definición de zonas de entrenamiento por ritmo para natación y carrrera</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
         <source>Appearance</source>
         <translation>Aspecto</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="364"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
         <source>Data Fields</source>
         <translation>Campos de datos</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
         <source>Definition of default value(s) for data fields</source>
         <translation>Definición de valores por omisión para campos de datos</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
         <source>Definition of processing default parameters for the fix, adjust,... tools</source>
         <translation>Definición de parámetros por omisión para las herramientas de corrección y ajuste de archivos de actividad</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
         <source>Metrics</source>
         <translation>Métricas</translation>
     </message>
@@ -15519,47 +15517,43 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2437"/>
         <source>Add</source>
-        <translation>Agregar</translation>
+        <translation type="vanished">Agregar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2438"/>
         <source>Delete</source>
-        <translation>Eliminar</translation>
+        <translation type="vanished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2431"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2432"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2447"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2332"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2458"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2343"/>
         <source>Short</source>
         <translation>Abreviatura</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2459"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2344"/>
         <source>Long</source>
         <translation>Descripción</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2460"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2345"/>
         <source>Percent of LT</source>
         <translation>Porcentaje del umbral de lactato</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2461"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2346"/>
         <source>Trimp k</source>
         <translation>Trimp k</translation>
     </message>
@@ -15568,14 +15562,14 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">Se alcanzó el máximo de 10 zonas.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2506"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2513"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2390"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2397"/>
         <source>New</source>
         <translation>Nueva</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2508"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2515"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2392"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2399"/>
         <source>New (%1)</source>
         <translation>Nueva (%1)</translation>
     </message>
@@ -15765,17 +15759,17 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2245"/>
         <source>Sport</source>
         <translation>Deporte</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2395"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2292"/>
         <source>Lactate Threshold</source>
         <translation>Umbral de lactado</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2396"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2293"/>
         <source>Default</source>
         <translation>Por omisión</translation>
     </message>
@@ -17933,545 +17927,542 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTMTool</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1303"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1272"/>
         <source>Metric</source>
         <translation>Métrica</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="351"/>
+        <location filename="../../Charts/LTMTool.cpp" line="325"/>
         <source>Skiba Long Term Stress</source>
         <translation>Estrés a largo plazo (Skiba)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="89"/>
+        <location filename="../../Charts/LTMTool.cpp" line="90"/>
         <source>All</source>
         <translation>Todos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="94"/>
+        <location filename="../../Charts/LTMTool.cpp" line="95"/>
         <source>Data Table</source>
         <translation>Cuadro de datos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="98"/>
+        <location filename="../../Charts/LTMTool.cpp" line="99"/>
         <source>Show Stack</source>
         <translation>Mostrar apilado</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="121"/>
+        <location filename="../../Charts/LTMTool.cpp" line="122"/>
         <source>Stack Zoom</source>
         <translation>Ampliar apilado</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="155"/>
+        <location filename="../../Charts/LTMTool.cpp" line="156"/>
         <source>Add Current</source>
         <translation>Agregar actual</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="146"/>
+        <location filename="../../Charts/LTMTool.cpp" line="147"/>
         <source>Charts</source>
         <translation>Gráficos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="112"/>
         <source>Show Banister Helper</source>
         <translation>Mostar asistente Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="155"/>
         <source>Apply</source>
         <translation>Aplicar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Up</source>
-        <translation>Arriba</translation>
+        <translation type="vanished">Arriba</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Down</source>
-        <translation>Abajo</translation>
+        <translation type="vanished">Abajo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="353"/>
-        <location filename="../../Charts/LTMTool.cpp" line="368"/>
-        <location filename="../../Charts/LTMTool.cpp" line="429"/>
-        <location filename="../../Charts/LTMTool.cpp" line="444"/>
-        <location filename="../../Charts/LTMTool.cpp" line="505"/>
-        <location filename="../../Charts/LTMTool.cpp" line="520"/>
-        <location filename="../../Charts/LTMTool.cpp" line="580"/>
-        <location filename="../../Charts/LTMTool.cpp" line="595"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1080"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1095"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1156"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1171"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1309"/>
+        <location filename="../../Charts/LTMTool.cpp" line="327"/>
+        <location filename="../../Charts/LTMTool.cpp" line="342"/>
+        <location filename="../../Charts/LTMTool.cpp" line="403"/>
+        <location filename="../../Charts/LTMTool.cpp" line="418"/>
+        <location filename="../../Charts/LTMTool.cpp" line="479"/>
+        <location filename="../../Charts/LTMTool.cpp" line="494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="554"/>
+        <location filename="../../Charts/LTMTool.cpp" line="569"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1054"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1069"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1130"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1145"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1278"/>
         <source>Stress</source>
         <translation>Estrés</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="366"/>
+        <location filename="../../Charts/LTMTool.cpp" line="340"/>
         <source>Skiba Short Term Stress</source>
         <translation>Estrés a corto plazo (Skiba)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="381"/>
+        <location filename="../../Charts/LTMTool.cpp" line="355"/>
         <source>Skiba Stress Balance</source>
         <translation>Balance de estrés (Skiba)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="383"/>
-        <location filename="../../Charts/LTMTool.cpp" line="459"/>
-        <location filename="../../Charts/LTMTool.cpp" line="535"/>
-        <location filename="../../Charts/LTMTool.cpp" line="610"/>
-        <location filename="../../Charts/LTMTool.cpp" line="686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="762"/>
-        <location filename="../../Charts/LTMTool.cpp" line="838"/>
-        <location filename="../../Charts/LTMTool.cpp" line="914"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1110"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1186"/>
+        <location filename="../../Charts/LTMTool.cpp" line="357"/>
+        <location filename="../../Charts/LTMTool.cpp" line="433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="509"/>
+        <location filename="../../Charts/LTMTool.cpp" line="584"/>
+        <location filename="../../Charts/LTMTool.cpp" line="660"/>
+        <location filename="../../Charts/LTMTool.cpp" line="736"/>
+        <location filename="../../Charts/LTMTool.cpp" line="812"/>
+        <location filename="../../Charts/LTMTool.cpp" line="888"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1160"/>
         <source>Stress Balance</source>
         <translation>Balance de estrés</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="396"/>
+        <location filename="../../Charts/LTMTool.cpp" line="370"/>
         <source>Skiba STS Ramp</source>
         <translation>Rampa ECP/STS (Skiba)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="398"/>
-        <location filename="../../Charts/LTMTool.cpp" line="413"/>
-        <location filename="../../Charts/LTMTool.cpp" line="474"/>
-        <location filename="../../Charts/LTMTool.cpp" line="489"/>
-        <location filename="../../Charts/LTMTool.cpp" line="550"/>
-        <location filename="../../Charts/LTMTool.cpp" line="565"/>
-        <location filename="../../Charts/LTMTool.cpp" line="625"/>
-        <location filename="../../Charts/LTMTool.cpp" line="640"/>
-        <location filename="../../Charts/LTMTool.cpp" line="701"/>
-        <location filename="../../Charts/LTMTool.cpp" line="716"/>
-        <location filename="../../Charts/LTMTool.cpp" line="777"/>
-        <location filename="../../Charts/LTMTool.cpp" line="792"/>
-        <location filename="../../Charts/LTMTool.cpp" line="853"/>
-        <location filename="../../Charts/LTMTool.cpp" line="868"/>
-        <location filename="../../Charts/LTMTool.cpp" line="929"/>
-        <location filename="../../Charts/LTMTool.cpp" line="944"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1005"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1020"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1125"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1140"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1201"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1216"/>
+        <location filename="../../Charts/LTMTool.cpp" line="372"/>
+        <location filename="../../Charts/LTMTool.cpp" line="387"/>
+        <location filename="../../Charts/LTMTool.cpp" line="448"/>
+        <location filename="../../Charts/LTMTool.cpp" line="463"/>
+        <location filename="../../Charts/LTMTool.cpp" line="524"/>
+        <location filename="../../Charts/LTMTool.cpp" line="539"/>
+        <location filename="../../Charts/LTMTool.cpp" line="599"/>
+        <location filename="../../Charts/LTMTool.cpp" line="614"/>
+        <location filename="../../Charts/LTMTool.cpp" line="675"/>
+        <location filename="../../Charts/LTMTool.cpp" line="690"/>
+        <location filename="../../Charts/LTMTool.cpp" line="751"/>
+        <location filename="../../Charts/LTMTool.cpp" line="766"/>
+        <location filename="../../Charts/LTMTool.cpp" line="827"/>
+        <location filename="../../Charts/LTMTool.cpp" line="842"/>
+        <location filename="../../Charts/LTMTool.cpp" line="903"/>
+        <location filename="../../Charts/LTMTool.cpp" line="918"/>
+        <location filename="../../Charts/LTMTool.cpp" line="979"/>
+        <location filename="../../Charts/LTMTool.cpp" line="994"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1099"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1114"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1175"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1190"/>
         <source>Ramp</source>
         <translation>Rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="411"/>
+        <location filename="../../Charts/LTMTool.cpp" line="385"/>
         <source>Skiba LTS Ramp</source>
         <translation>Rampa ELP/LTS (Skiba)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="427"/>
+        <location filename="../../Charts/LTMTool.cpp" line="401"/>
         <source>Aerobic TISS Long Term Stress</source>
         <translation>Estrés a largo plazo (TISS aeróbico)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="442"/>
+        <location filename="../../Charts/LTMTool.cpp" line="416"/>
         <source>Aerobic TISS Short Term Stress</source>
         <translation>Estrés a corto plazo (TISS aeróbico)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="457"/>
+        <location filename="../../Charts/LTMTool.cpp" line="431"/>
         <source>Aerobic TISS Stress Balance</source>
         <translation>Balance de estrés (TISS aeróbico)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="472"/>
+        <location filename="../../Charts/LTMTool.cpp" line="446"/>
         <source>Aerobic TISS STS Ramp</source>
         <translation>Rampa de ECP/STS (TISS aeróbico)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="487"/>
+        <location filename="../../Charts/LTMTool.cpp" line="461"/>
         <source>Aerobic TISS LTS Ramp</source>
         <translation>Rampa de ELP/LTS (TISS aeróbico)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="503"/>
+        <location filename="../../Charts/LTMTool.cpp" line="477"/>
         <source>Anaerobic TISS Long Term Stress</source>
         <translation>Estrés a largo plazo (TISS anaeróbico)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="518"/>
+        <location filename="../../Charts/LTMTool.cpp" line="492"/>
         <source>Anaerobic TISS Short Term Stress</source>
         <translation>Estrés a corto plazo (TISS anaeróbico)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="533"/>
+        <location filename="../../Charts/LTMTool.cpp" line="507"/>
         <source>Anaerobic TISS Stress Balance</source>
         <translation>Balance de estrés (TISS anaeróbico)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="548"/>
+        <location filename="../../Charts/LTMTool.cpp" line="522"/>
         <source>Anaerobic TISS STS Ramp</source>
         <translation>Rampa de ECP/STS (TISS anaeróbico)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="537"/>
         <source>Anaerobic TISS LTS Ramp</source>
         <translation>Rampa de ELP/LTS (TISS anaeróbico)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="578"/>
+        <location filename="../../Charts/LTMTool.cpp" line="552"/>
         <source>Daniels Long Term Stress</source>
         <translation>Estrés a largo plazo (Daniels)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="593"/>
+        <location filename="../../Charts/LTMTool.cpp" line="567"/>
         <source>Daniels Short Term Stress</source>
         <translation>Estrés a corto plazo (Daniels)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="582"/>
         <source>Daniels Stress Balance</source>
         <translation>Balance de estrés (Daniels)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="623"/>
+        <location filename="../../Charts/LTMTool.cpp" line="597"/>
         <source>Daniels STS Ramp</source>
         <translation>Rampa ECP/STS (Daniels)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="638"/>
+        <location filename="../../Charts/LTMTool.cpp" line="612"/>
         <source>Daniels LTS Ramp</source>
         <translation>Rampa ELP/LTS (Daniels)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="730"/>
+        <location filename="../../Charts/LTMTool.cpp" line="704"/>
         <source>W&apos; Work (Kj) Long Term Stress</source>
         <translation>Estrés a largo plazo como trabajo W&apos; (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="745"/>
+        <location filename="../../Charts/LTMTool.cpp" line="719"/>
         <source>W&apos; Work (Kj) Short Term Stress</source>
         <translation>Estrés a corto plazo como trabajo W&apos; (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="760"/>
+        <location filename="../../Charts/LTMTool.cpp" line="734"/>
         <source>W&apos; Work (Kj) Stress Balance</source>
         <translation>Balance de estrés como trabajo W&apos; (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="775"/>
+        <location filename="../../Charts/LTMTool.cpp" line="749"/>
         <source>W&apos; Work (Kj) STS Ramp</source>
         <translation>Rampa ECP/STS como trabajo W&apos; (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="790"/>
+        <location filename="../../Charts/LTMTool.cpp" line="764"/>
         <source>W&apos; Work (Kj) LTS Ramp</source>
         <translation>Rampa ELP/LTS como trabajo W&apos; (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="806"/>
+        <location filename="../../Charts/LTMTool.cpp" line="780"/>
         <source>Below CP Work (Kj) Long Term Stress</source>
         <translation>Estrés a largo plazo. Trabajo sub PC/CP (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="821"/>
+        <location filename="../../Charts/LTMTool.cpp" line="795"/>
         <source>Below CP Work (Kj) Short Term Stress</source>
         <translation>Estrés a corto plazo. Trabajo sub PC/CP (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="836"/>
+        <location filename="../../Charts/LTMTool.cpp" line="810"/>
         <source>Below CP Work (Kj) Stress Balance</source>
         <translation>Balance de estrés. Trabajo sub PC/CP (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="851"/>
+        <location filename="../../Charts/LTMTool.cpp" line="825"/>
         <source>Below CP Work (Kj) STS Ramp</source>
         <translation>Rampa ECP/STS. Trabajo sub PC/CP (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="866"/>
+        <location filename="../../Charts/LTMTool.cpp" line="840"/>
         <source>Below CP Work (Kj) LTS Ramp</source>
         <translation>Rampa ELP/LTS. Trabajo sub PC/CP (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="958"/>
+        <location filename="../../Charts/LTMTool.cpp" line="932"/>
         <source>Coggan Chronic Training Load</source>
         <translation>Carga crónica de trabajo, CTL (Coggan)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="973"/>
+        <location filename="../../Charts/LTMTool.cpp" line="947"/>
         <source>Coggan Acute Training Load</source>
         <translation>Carga aguda de trabajo, ATL (Coggan)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="988"/>
+        <location filename="../../Charts/LTMTool.cpp" line="962"/>
         <source>Coggan Training Stress Balance</source>
         <translation>Balance de estrés, TSB (Coggan)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1003"/>
+        <location filename="../../Charts/LTMTool.cpp" line="977"/>
         <source>Coggan STS Ramp</source>
         <translation>Rampa de estrés a corto plazo, STS (Coggan)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1018"/>
+        <location filename="../../Charts/LTMTool.cpp" line="992"/>
         <source>Coggan LTS Ramp</source>
         <translation>Rampa de estrés a latgo plazo, LTS (Coggan)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1033"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1007"/>
         <source>Coggan Expected Chronic Training Load</source>
         <translation>Carga crónica de trabajo esperada (Coggan)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1048"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1022"/>
         <source>Coggan Expected Acute Training Load</source>
         <translation>Carga aguda de trabajo esperada (Coggan)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1063"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1037"/>
         <source>Coggan Expected Training Stress Balance</source>
         <translation>Balance de estrés esperado (Coggan)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1053"/>
         <source>TRIMP Long Term Stress</source>
         <translation>Estrés a largo plazo (TRIMP)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1067"/>
         <source>TRIMP Short Term Stress</source>
         <translation>Estrés a corto plazo (TRIMP)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1082"/>
         <source>TRIMP Stress Balance</source>
         <translation>Balance de estrés (TRIMP)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1123"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1097"/>
         <source>TRIMP STS Ramp</source>
         <translation>Rampa ECP/STS (TRIMP)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1138"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1112"/>
         <source>TRIMP LTS Ramp</source>
         <translation>Rampa ELP/LTS (TRIMP)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="124"/>
+        <location filename="../../Charts/LTMTool.cpp" line="125"/>
         <source>Use sidebar chart settings</source>
         <translation>Usar configuración de gráficos/barra lateral</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1307"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1276"/>
         <source>Estimate</source>
         <translation>Estimar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1311"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1280"/>
         <source>Formula</source>
         <translation>Fórmula</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1282"/>
         <source>Measure</source>
         <translation>Medición</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1284"/>
         <source>Performance</source>
         <translation>Rendimiento</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1317"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1286"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1463"/>
         <source>Chart %1</source>
         <translation>Gráfico %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="74"/>
+        <location filename="../../Charts/LTMTool.cpp" line="75"/>
         <source>Filter</source>
         <translation>Filtro</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="80"/>
+        <location filename="../../Charts/LTMTool.cpp" line="81"/>
         <source>Date range</source>
         <translation>Rango de fechas</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="84"/>
+        <location filename="../../Charts/LTMTool.cpp" line="85"/>
         <source>Days</source>
         <translation>Días</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="85"/>
+        <location filename="../../Charts/LTMTool.cpp" line="86"/>
         <source>Weeks</source>
         <translation>Semanas</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="86"/>
+        <location filename="../../Charts/LTMTool.cpp" line="87"/>
         <source>Months</source>
         <translation>Meses</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="87"/>
+        <location filename="../../Charts/LTMTool.cpp" line="88"/>
         <source>Years</source>
         <translation>Años</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="88"/>
+        <location filename="../../Charts/LTMTool.cpp" line="89"/>
         <source>Time Of Day</source>
         <translation>Hora del día</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="91"/>
+        <location filename="../../Charts/LTMTool.cpp" line="92"/>
         <source>Group by</source>
         <translation>Agrupar por</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="102"/>
+        <location filename="../../Charts/LTMTool.cpp" line="103"/>
         <source>Shade Zones</source>
         <translation>Sombrear zonas</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="105"/>
+        <location filename="../../Charts/LTMTool.cpp" line="106"/>
         <source>Show Legend</source>
         <translation>Mostrar leyenda</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="109"/>
         <source>Show Events</source>
         <translation>Mostrar eventos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="628"/>
         <source>Work (Kj) Long Term Stress</source>
         <translation>Estrés a largo plazo como trabajo (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="656"/>
-        <location filename="../../Charts/LTMTool.cpp" line="671"/>
-        <location filename="../../Charts/LTMTool.cpp" line="732"/>
-        <location filename="../../Charts/LTMTool.cpp" line="747"/>
-        <location filename="../../Charts/LTMTool.cpp" line="808"/>
-        <location filename="../../Charts/LTMTool.cpp" line="823"/>
+        <location filename="../../Charts/LTMTool.cpp" line="630"/>
+        <location filename="../../Charts/LTMTool.cpp" line="645"/>
+        <location filename="../../Charts/LTMTool.cpp" line="706"/>
+        <location filename="../../Charts/LTMTool.cpp" line="721"/>
+        <location filename="../../Charts/LTMTool.cpp" line="782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="797"/>
         <source>Stress (Kj)</source>
         <translation>Estrés (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="669"/>
+        <location filename="../../Charts/LTMTool.cpp" line="643"/>
         <source>Work (Kj) Short Term Stress</source>
         <translation>Estrés a corto plazo como trabajo (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="684"/>
+        <location filename="../../Charts/LTMTool.cpp" line="658"/>
         <source>Work (Kj) Stress Balance</source>
         <translation>Balance de estrés como trabajo (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="699"/>
+        <location filename="../../Charts/LTMTool.cpp" line="673"/>
         <source>Work (Kj) STS Ramp</source>
         <translation>Rampa ECP/STS como trabajo (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="714"/>
+        <location filename="../../Charts/LTMTool.cpp" line="688"/>
         <source>Work (Kj) LTS Ramp</source>
         <translation>Rampa ELP/LTS como trabajo (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="882"/>
+        <location filename="../../Charts/LTMTool.cpp" line="856"/>
         <source>Distance (km|mi) Long Term Stress</source>
         <translation>Estrés a largo plazo como distancia (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="884"/>
-        <location filename="../../Charts/LTMTool.cpp" line="899"/>
+        <location filename="../../Charts/LTMTool.cpp" line="858"/>
+        <location filename="../../Charts/LTMTool.cpp" line="873"/>
         <source>Stress (km|mi)</source>
         <translation>Estrés (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="897"/>
+        <location filename="../../Charts/LTMTool.cpp" line="871"/>
         <source>Distance (km|mi) Short Term Stress</source>
         <translation>Estrés a corto plazo como distancia (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="912"/>
+        <location filename="../../Charts/LTMTool.cpp" line="886"/>
         <source>Distance (km|mi) Stress Balance</source>
         <translation>Balance de estrés como distancia (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="927"/>
+        <location filename="../../Charts/LTMTool.cpp" line="901"/>
         <source>Distance (km|mi) STS Ramp</source>
         <translation>Rampa ECP/STS como distancia (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="942"/>
+        <location filename="../../Charts/LTMTool.cpp" line="916"/>
         <source>Distance (km|mi) LTS Ramp</source>
         <translation>Rampa ELP/LTS como distancia (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="268"/>
         <source>Edit</source>
-        <translation>Editar</translation>
+        <translation type="vanished">Editar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Basic</source>
         <translation>Configuración básica</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="314"/>
+        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Preset</source>
         <translation>Gráficos predefinidos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="289"/>
         <source>Curves</source>
         <translation>Curvas</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1128"/>
         <source>TriScore Long Term Stress</source>
         <translation>Estrés a largo plazo (TriScore)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1169"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1143"/>
         <source>TriScore Short Term Stress</source>
         <translation>Estrés a corto plazo (TriScore)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1184"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1158"/>
         <source>TriScore Stress Balance</source>
         <translation>Balance de estrés (TriScore)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1173"/>
         <source>TriScore STS Ramp</source>
         <translation>Rampa ECP/STS (TriScore)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1214"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1188"/>
         <source>TriScore LTS Ramp</source>
         <translation>Rampa ELP/LTS (TriScore)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Details</source>
         <translation>Detalles</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1305"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1274"/>
         <source>Peak</source>
         <translation>Pico</translation>
     </message>
@@ -18674,31 +18665,23 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">Actualizar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2590"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2602"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2591"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2603"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2596"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2608"/>
         <source>Add</source>
-        <translation>Agregar</translation>
+        <translation type="vanished">Agregar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2597"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2609"/>
         <source>Delete</source>
-        <translation>Eliminar</translation>
+        <translation type="vanished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2599"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2467"/>
         <source>Def</source>
         <translation>Def</translation>
     </message>
@@ -18707,14 +18690,14 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">Fecha desde</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2651"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2790"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2494"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2631"/>
         <source>Lactate Threshold</source>
         <translation>Umbral de lactado</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2652"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2791"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2495"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2632"/>
         <source>Aerobic Threshold</source>
         <translation>Umbral aeróbico</translation>
     </message>
@@ -18727,65 +18710,65 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">Se alcanzó el máximo de 10 zonas.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2967"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2974"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2804"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2811"/>
         <source>New</source>
         <translation>Nueva</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2969"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2976"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2806"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2813"/>
         <source>New (%1)</source>
         <translation>Nueva (%1)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2653"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2496"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
         <source>Rest HR</source>
         <translation>FC en reposo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2628"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2690"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2770"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2775"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2780"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2785"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2473"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2478"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2488"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2611"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2621"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2626"/>
         <source>bpm</source>
         <translation>ppm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2650"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2493"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2630"/>
         <source>Start Date</source>
         <translation>Fecha de inicio</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2654"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2497"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2634"/>
         <source>Max HR</source>
         <translation>FC máxima</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2701"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2544"/>
         <source>Short</source>
         <translation>Abreviatura</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2702"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2545"/>
         <source>Long</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2703"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2546"/>
         <source>From BPM</source>
         <translation>Desde (ppm)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2704"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2547"/>
         <source>Trimp k</source>
         <translation>Trimp k</translation>
     </message>
@@ -19527,62 +19510,62 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>Library</name>
     <message>
+        <location filename="../../Train/Library.cpp" line="126"/>
         <location filename="../../Train/Library.cpp" line="130"/>
-        <location filename="../../Train/Library.cpp" line="134"/>
         <source>Import Videos, VideoSyncs and Workouts</source>
         <translation>Importar vídeos, VideoSyncs y entrenamientos</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="127"/>
         <location filename="../../Train/Library.cpp" line="131"/>
-        <location filename="../../Train/Library.cpp" line="135"/>
         <source>No supported videos, videoSyncs or workouts were found to import</source>
         <translation>No se encontraron vídeos, VideoSyncs o entrenamientos para importar</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="189"/>
         <location filename="../../Train/Library.cpp" line="193"/>
-        <location filename="../../Train/Library.cpp" line="197"/>
+        <location filename="../../Train/Library.cpp" line="198"/>
         <location filename="../../Train/Library.cpp" line="202"/>
-        <location filename="../../Train/Library.cpp" line="206"/>
         <source>Copy VideoSync Failed</source>
         <translation>Falló la copia de VideoSync</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="190"/>
         <location filename="../../Train/Library.cpp" line="194"/>
-        <location filename="../../Train/Library.cpp" line="198"/>
         <source>%1 already exists in videoSync library: %2</source>
         <translation>%1 ya existe en la biblioteca de VideoSync: %2</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="203"/>
+        <location filename="../../Train/Library.cpp" line="199"/>
         <source>%1 cannot be written to videoSync library %2. Check library path, permissions and free space</source>
         <translation>%1 no se puede escribir en la biblioteca de VideoSync %2. Compruebe la ruta, los permisos y si hay espacio libre</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="207"/>
+        <location filename="../../Train/Library.cpp" line="203"/>
         <source>%1 cannot be written to videoSync library %2, check permissions and free space</source>
         <translation>%1 no se pudieron escribir en la biblioteca de vídeos Sync %2, compruebe los permisos y el espacio libre</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="253"/>
+        <location filename="../../Train/Library.cpp" line="249"/>
         <source>%1 cannot be written to workout library %2. Check library path, permissions and free space</source>
         <translation>%1 no se puede escribir en la biblioteca de actividades %2. Compruebe la ruta, los permisos y si hay espacio libre</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="257"/>
+        <location filename="../../Train/Library.cpp" line="253"/>
         <source>%1 cannot be written to workout library %2, check permissions and free space</source>
         <translation>%1 no se pudieron escribir en la biblioteca de entrenamientos %2, compruebe los permisos y el espacio libre</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="239"/>
         <location filename="../../Train/Library.cpp" line="243"/>
-        <location filename="../../Train/Library.cpp" line="247"/>
+        <location filename="../../Train/Library.cpp" line="248"/>
         <location filename="../../Train/Library.cpp" line="252"/>
-        <location filename="../../Train/Library.cpp" line="256"/>
         <source>Copy Workout Failed</source>
         <translation>Falló la copia de entrenamiento</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="240"/>
         <location filename="../../Train/Library.cpp" line="244"/>
-        <location filename="../../Train/Library.cpp" line="248"/>
         <source>%1 already exists in workout library: %2</source>
         <translation>%1 ya existe en la biblioteca de actividades: %2</translation>
     </message>
@@ -19590,89 +19573,89 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LibrarySearchDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="330"/>
+        <location filename="../../Train/Library.cpp" line="326"/>
         <source>Search for Workouts, Syncs and Media</source>
         <translation>Buscar entrenamientos, sincronizaciones de vídeo y medios</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="337"/>
+        <location filename="../../Train/Library.cpp" line="333"/>
         <source>Workout files (.erg, .mrc, .zwo etc)</source>
         <translation>Archivos de entrenamientos (.erg, .mrc, .zwo, etc.)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="339"/>
+        <location filename="../../Train/Library.cpp" line="335"/>
         <source>Video files (.mp4, .avi etc)</source>
         <translation>Archivos de vídeo (.mpr, .avi, etc.)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="341"/>
+        <location filename="../../Train/Library.cpp" line="337"/>
         <source>VideoSync files (.rlv, .tts etc)</source>
         <translation>Archivos VideoSync (.rlv, .tts, .json)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="359"/>
+        <location filename="../../Train/Library.cpp" line="353"/>
         <source>Search Path</source>
         <translation>Ruta de búsqueda</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="379"/>
+        <location filename="../../Train/Library.cpp" line="373"/>
         <source>Video references</source>
         <translation>Referencias vídeo</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="391"/>
+        <location filename="../../Train/Library.cpp" line="385"/>
         <source>Searching...</source>
         <translation>Buscando...</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="394"/>
+        <location filename="../../Train/Library.cpp" line="388"/>
         <source>Videos</source>
         <translation>Vídeos</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="396"/>
+        <location filename="../../Train/Library.cpp" line="390"/>
         <source>Workouts</source>
         <translation>Entrenamientos</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="398"/>
+        <location filename="../../Train/Library.cpp" line="392"/>
         <source>VideoSyncs</source>
         <translation>VideoSyncs</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="407"/>
-        <location filename="../../Train/Library.cpp" line="494"/>
+        <location filename="../../Train/Library.cpp" line="401"/>
+        <location filename="../../Train/Library.cpp" line="484"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="409"/>
+        <location filename="../../Train/Library.cpp" line="403"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="412"/>
+        <location filename="../../Train/Library.cpp" line="406"/>
         <source>Files to search for:</source>
         <translation>Archivos a buscar:</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="475"/>
+        <location filename="../../Train/Library.cpp" line="466"/>
         <source>Abort Search</source>
         <translation>Cancelar búsqueda</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="515"/>
-        <location filename="../../Train/Library.cpp" line="559"/>
+        <location filename="../../Train/Library.cpp" line="504"/>
+        <location filename="../../Train/Library.cpp" line="548"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="557"/>
+        <location filename="../../Train/Library.cpp" line="546"/>
         <source>Search completed.</source>
         <translation>Búsqueda finalizada.</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="645"/>
+        <location filename="../../Train/Library.cpp" line="634"/>
         <source>Select Directory</source>
         <translation>Seleccionar directorio</translation>
     </message>
@@ -19680,12 +19663,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>ListEditWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="623"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="654"/>
         <source>New</source>
         <translation>Nuevo</translation>
     </message>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="625"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="656"/>
         <source>New (%1)</source>
         <translation>Nuevo (%1)</translation>
     </message>
@@ -19698,7 +19681,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation>URL base OSM</translation>
     </message>
     <message>
-        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="90"/>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="85"/>
+        <source>Initial Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="98"/>
         <source>Apply changes</source>
         <translation>Aplicar los cambios</translation>
     </message>
@@ -20109,34 +20097,34 @@ encendido y muestra &quot;PC-Link&quot;</translation>
         <translation type="vanished">&amp;Editar actividad</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
         <source>Select Activity</source>
         <translation>Elegir actividad</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>No activity selected!</source>
         <translation>¡No hay actividad seleccionada!</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1724"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1734"/>
         <source>Export Activity</source>
         <translation>Exportar actividad</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1777"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1787"/>
         <source>Export Failed</source>
         <translation>Falló la exportación</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
         <source>No activity selected</source>
         <translation>No hay actividad seleccionada</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
         <source>Current activity contains no data to split</source>
         <translation>La actividad seleccionada no tiene datos para dividir</translation>
     </message>
@@ -20390,42 +20378,42 @@ encendido y muestra &quot;PC-Link&quot;</translation>
         <translation>¿Desea continuar?</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Chart Import</source>
         <translation>Importar gráfico</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>Import Images Failed</source>
         <translation>Fallo en la importación de imágenes</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>You can only import images on the activities view with an activity selected.</source>
         <translation>Hay que seleccionar una actividad para poder importar imágenes.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>Import Images to Activity</source>
         <translation>Importar imágenes a la actividad</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>%1 images imported.</source>
         <translation>%1 imagen/imágenes importada(s).</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Current activity contains no data to merge</source>
         <translation>La actividad seleccionada no tiene datos para combinar</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2165"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2175"/>
         <source>&amp;New Athlete...</source>
         <translation>&amp;Nuevo atleta...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2342"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2352"/>
         <source>Refresh in Progress</source>
         <translation>Actualización en curso</translation>
     </message>
@@ -20450,7 +20438,7 @@ encendido y muestra &quot;PC-Link&quot;</translation>
         <translation>&amp;Acerca de GoldenCheetah</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>Delete Activity</source>
         <translation>Eliminar actividad</translation>
     </message>
@@ -20511,44 +20499,44 @@ encendido y muestra &quot;PC-Link&quot;</translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Activity Import</source>
         <translation>Importar actividad</translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Closing of athlete window not possible while background activity import is in progress...</source>
         <translation>No es posible cerrar la ventana del atleta mientras se está realizando una importación de actividades en segundo plano...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Imported %1 metric charts</source>
         <translation>%1 gráficos importados</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1778"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1788"/>
         <source>Failed to export activity, please check permissions</source>
         <translation>Error al exportar actividad, verifique los permisos</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1815"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1825"/>
         <source>There is no currently selected activity to save.</source>
         <translation>No hay actividad seleccionada para guardar.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
         <location filename="../../Gui/MainWindow.cpp" line="1886"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Split Activity</source>
         <translation>Dividir actividad</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2400"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2421"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2410"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2431"/>
         <source>The workout directory is not configured, or the directory selected no longer exists.
 
 Please check your preference settings.</source>
@@ -20557,7 +20545,7 @@ Please check your preference settings.</source>
 Por favor, verifique la configuración de preferencias.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2611"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2621"/>
         <source>Loading activities: %1%</source>
         <translation>Cargando actividades: %1%</translation>
     </message>
@@ -20570,51 +20558,51 @@ Por favor, verifique la configuración de preferencias.</translation>
         <translation type="vanished">Administrar procesadores Python...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>CloudDB</source>
         <translation>CloudDB</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>Current athlete is not registered as curator - please contact the GoldenCheetah team</source>
         <translation>Este atleta no está registrado como curador. Por favor, contacte con el equipo de GoldenCheetah</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1799"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2369"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1809"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2379"/>
         <source>Import from File</source>
         <translation>Importar de archivo</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1814"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1824"/>
         <source>No Activity To Save</source>
         <translation>No hay actividad para guardar</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1904"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1914"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation>¿Confirma que quiere eliminar la actividad:</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Export Metrics</source>
         <translation>Exportar métricas</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation>Variables separada por comas (*.csv)</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2399"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2420"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2409"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2430"/>
         <source>Workout Directory Invalid</source>
         <translation>Directorio de entrenamientos inválido</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1906"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1916"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
@@ -21570,24 +21558,24 @@ Por favor, verifique la configuración de preferencias.</translation>
         <translation type="vanished">Medidas %1 diarias</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="656"/>
+        <location filename="../../Gui/AthletePages.cpp" line="641"/>
         <source>From Date - Time</source>
         <translation>Fecha y hora</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="780"/>
+        <location filename="../../Gui/AthletePages.cpp" line="751"/>
         <source>Start Date</source>
         <translation>Fecha de inicio</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="893"/>
+        <location filename="../../Gui/AthletePages.cpp" line="864"/>
         <source>MMM d, yyyy - hh:mm:ss</source>
         <translatorcomment>No traducir esta cadena, pues ha de ser interpretada</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="659"/>
-        <location filename="../../Gui/AthletePages.cpp" line="807"/>
+        <location filename="../../Gui/AthletePages.cpp" line="644"/>
+        <location filename="../../Gui/AthletePages.cpp" line="778"/>
         <source>Comment</source>
         <translation>Comentario</translation>
     </message>
@@ -21596,32 +21584,28 @@ Por favor, verifique la configuración de preferencias.</translation>
         <translation type="vanished">Modificar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="662"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="663"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">Agregar</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">Eliminar</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="668"/>
-        <source>Add</source>
-        <translation>Agregar</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="669"/>
-        <source>Delete</source>
-        <translation>Eliminar</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="698"/>
         <source>Source</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="699"/>
+        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Original Source</source>
         <translation>Fuente original</translation>
     </message>
@@ -22324,17 +22308,17 @@ No se han encontrado actividades para importar.
 <context>
     <name>MultiDeviceDialog</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3048"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3060"/>
         <source>Multiple Device Configuration</source>
         <translation>Configuración de múltiples dispositivos</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3103"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3115"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3106"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3118"/>
         <source>Apply</source>
         <translation>Aplicar</translation>
     </message>
@@ -23369,42 +23353,38 @@ No se han encontrado actividades para importar.
 <context>
     <name>PaceSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3154"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3155"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3160"/>
         <source>Add</source>
-        <translation>Agregar</translation>
+        <translation type="vanished">Agregar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3161"/>
         <source>Delete</source>
-        <translation>Eliminar</translation>
+        <translation type="vanished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2982"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3176"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2987"/>
         <source>Short</source>
         <translation>Abreviatura</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3177"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2988"/>
         <source>Long</source>
         <translation>Descripción</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3178"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2989"/>
         <source>Percent of CV</source>
         <translation>Porcentaje de la velocidad crítica</translation>
     </message>
@@ -23413,14 +23393,14 @@ No se han encontrado actividades para importar.
         <translation type="vanished">Se alcanzó el máximo de 10 zonas.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3220"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3227"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3037"/>
         <source>New</source>
         <translation>Nueva</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3222"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3229"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3032"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3039"/>
         <source>New (%1)</source>
         <translation>Nueva (%1)</translation>
     </message>
@@ -23620,27 +23600,27 @@ No se han encontrado actividades para importar.
 <context>
     <name>PaceZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3082"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2905"/>
         <source>Sport</source>
         <translation>Deporte</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3084"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2907"/>
         <source>Run</source>
         <translation>Carrera</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3085"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2908"/>
         <source>Swim</source>
         <translation>Natación</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3126"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2949"/>
         <source>Critical Velocity</source>
         <translation>Velocidad crítica</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2950"/>
         <source>Default</source>
         <translation>Por omisión</translation>
     </message>
@@ -25788,78 +25768,79 @@ Do you want to continue?</source>
 <context>
     <name>PerspectiveDialog</name>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="34"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="35"/>
         <source>Manage Perspectives</source>
         <translation>Administrar perspectivas</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="43"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="44"/>
         <source>Perspectives</source>
         <translation>Perspectivas</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="60"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="61"/>
         <source>Charts</source>
         <translation>Gráficos</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Edit</source>
-        <translation>Editar</translation>
+        <translation type="vanished">Editar</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="83"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="78"/>
         <source>Import</source>
         <translation>Importar</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="84"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="77"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="90"/>
         <source>Add</source>
-        <translation>Agregar</translation>
+        <translation type="vanished">Agregar</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="91"/>
         <source>Delete</source>
-        <translation>Eliminar</translation>
+        <translation type="vanished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="98"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Drag charts to move to a perspective</source>
         <translation>Arrastrar gráficos para cambiarlos de perspectiva</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="287"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="256"/>
         <source>Export Persepctive</source>
         <translation>Exportar perspectiva</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
         <source>Export Perspective</source>
         <translation>Exportar perspectiva</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>No perspective file selected!</source>
         <translation>¡No hay archivo de perspectiva seleccionado!</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
         <source>Select Perspective file to export</source>
-        <translation>Elegir archivo de perspectiva para exportar</translation>
+        <translation type="vanished">Elegir archivo de perspectiva para exportar</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
         <source>GoldenCheetah Perspective Files (*.gchartset)</source>
         <translation>Archivos de perspectivas de GoldenCheetah (*.gchartset)</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
+        <source>Select Perspective file to import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>Import Perspective</source>
         <translation>Importar perspectiva</translation>
     </message>
@@ -27022,307 +27003,307 @@ Python deshabilitado en preferencias.</translation>
 <context>
     <name>RealtimeData</name>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="621"/>
+        <location filename="../../Train/RealtimeData.cpp" line="623"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="624"/>
+        <location filename="../../Train/RealtimeData.cpp" line="626"/>
         <source>Time</source>
         <translation>Tiempo</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="627"/>
+        <location filename="../../Train/RealtimeData.cpp" line="629"/>
         <source>Lap</source>
         <translation>Intervalo</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="630"/>
+        <location filename="../../Train/RealtimeData.cpp" line="632"/>
         <source>Lap Time</source>
         <translation>Tiempo del intervalo</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="633"/>
+        <location filename="../../Train/RealtimeData.cpp" line="635"/>
         <source>Lap Time Remaining</source>
         <translation>Tiempo de intervalo restante</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="636"/>
+        <location filename="../../Train/RealtimeData.cpp" line="638"/>
         <source>Section Time Remaining</source>
         <translation>Tiempor restante en la sección</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="639"/>
+        <location filename="../../Train/RealtimeData.cpp" line="641"/>
         <source>BikeStress</source>
         <translation>BikeStress</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="645"/>
+        <location filename="../../Train/RealtimeData.cpp" line="647"/>
         <source>kJoules</source>
         <translation>kJ</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="648"/>
+        <location filename="../../Train/RealtimeData.cpp" line="650"/>
         <source>W&apos; bal</source>
         <translation>W&apos;bal</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="651"/>
+        <location filename="../../Train/RealtimeData.cpp" line="653"/>
         <source>XPower</source>
         <translation>xPower</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="654"/>
+        <location filename="../../Train/RealtimeData.cpp" line="656"/>
         <source>Iso Power</source>
         <translation>Potencia normalizada</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="657"/>
+        <location filename="../../Train/RealtimeData.cpp" line="659"/>
         <source>Intensity Factor</source>
         <translation>Factor de intensidad</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="660"/>
+        <location filename="../../Train/RealtimeData.cpp" line="662"/>
         <source>Relative Intensity</source>
         <translation>Intensidad relativa</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="663"/>
+        <location filename="../../Train/RealtimeData.cpp" line="665"/>
         <source>Skiba Variability Index</source>
         <translation>Índice de variabilidad de Skiba</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="666"/>
+        <location filename="../../Train/RealtimeData.cpp" line="668"/>
         <source>Variability Index</source>
         <translation>Índice de variabilidad</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="669"/>
+        <location filename="../../Train/RealtimeData.cpp" line="671"/>
         <source>Distance</source>
         <translation>Distancia</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="672"/>
+        <location filename="../../Train/RealtimeData.cpp" line="674"/>
         <source>Route Distance</source>
         <translation>Distancia de la ruta</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="675"/>
+        <location filename="../../Train/RealtimeData.cpp" line="677"/>
         <source>Distance Remaining</source>
         <translation>Distancia restante</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="678"/>
+        <location filename="../../Train/RealtimeData.cpp" line="680"/>
         <source>Alternate Power</source>
         <translation>Potencia alternativa</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="681"/>
+        <location filename="../../Train/RealtimeData.cpp" line="683"/>
         <source>Power</source>
         <translation>Potencia</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="684"/>
+        <location filename="../../Train/RealtimeData.cpp" line="686"/>
         <source>Speed</source>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="687"/>
+        <location filename="../../Train/RealtimeData.cpp" line="689"/>
         <source>Virtual Speed</source>
         <translation>Velocidad virtual</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="690"/>
+        <location filename="../../Train/RealtimeData.cpp" line="692"/>
         <source>Cadence</source>
         <translation>Cadencia</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="693"/>
+        <location filename="../../Train/RealtimeData.cpp" line="695"/>
         <source>Heart Rate</source>
         <translation>Frec. cardíaca</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="696"/>
+        <location filename="../../Train/RealtimeData.cpp" line="698"/>
         <source>Target Power</source>
         <translation>Potencia objetivo</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="699"/>
+        <location filename="../../Train/RealtimeData.cpp" line="701"/>
         <source>Average Power</source>
         <translation>Potencia media</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="702"/>
+        <location filename="../../Train/RealtimeData.cpp" line="704"/>
         <source>Average Speed</source>
         <translation>Velocidad media</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="705"/>
+        <location filename="../../Train/RealtimeData.cpp" line="707"/>
         <source>Average Heartrate</source>
         <translation>Fec. cardíaca media</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="708"/>
+        <location filename="../../Train/RealtimeData.cpp" line="710"/>
         <source>Average Cadence</source>
         <translation>Cadencia media</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="711"/>
+        <location filename="../../Train/RealtimeData.cpp" line="713"/>
         <source>Lap Power</source>
         <translation>Potencia del intervalo</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="714"/>
+        <location filename="../../Train/RealtimeData.cpp" line="716"/>
         <source>Lap Speed</source>
         <translation>Velocidad del intervalo</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="717"/>
+        <location filename="../../Train/RealtimeData.cpp" line="719"/>
         <source>Lap Heartrate</source>
         <translation>FC del intervalo</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="720"/>
+        <location filename="../../Train/RealtimeData.cpp" line="722"/>
         <source>Lap Cadence</source>
         <translation>Cadencia del intervalo</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="723"/>
+        <location filename="../../Train/RealtimeData.cpp" line="725"/>
         <source>Left/Right Balance</source>
         <translation>Balance izq/der</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="726"/>
+        <location filename="../../Train/RealtimeData.cpp" line="728"/>
         <source>Total Hb Mass</source>
         <translation>Masa Hb total</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="729"/>
+        <location filename="../../Train/RealtimeData.cpp" line="731"/>
         <source>Hb O2 Saturation</source>
         <translation>Saturación Hb O2</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="732"/>
+        <location filename="../../Train/RealtimeData.cpp" line="734"/>
         <source>Deoxy Hb</source>
         <translation>Deoxy Hb</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="735"/>
+        <location filename="../../Train/RealtimeData.cpp" line="737"/>
         <source>Oxy Hb</source>
         <translation>Oxy Hb</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="738"/>
+        <location filename="../../Train/RealtimeData.cpp" line="740"/>
         <source>Left Torque Effectiveness</source>
         <translation>Eficiencia de la pedalada izquierda</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="741"/>
+        <location filename="../../Train/RealtimeData.cpp" line="743"/>
         <source>Right Torque Effectiveness</source>
         <translation>Efectividad de la pedalada derecha</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="744"/>
+        <location filename="../../Train/RealtimeData.cpp" line="746"/>
         <source>Left Pedal Smoothness</source>
         <translation>Fluidez de la pedalada izquierda</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="747"/>
+        <location filename="../../Train/RealtimeData.cpp" line="749"/>
         <source>Right Pedal Smoothness</source>
         <translation>Fluidez de la pedalada derecha</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="750"/>
+        <location filename="../../Train/RealtimeData.cpp" line="752"/>
         <source>Right Power Phase Start</source>
         <translation>Ángulo de inicio de la pedalada derecha</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="753"/>
+        <location filename="../../Train/RealtimeData.cpp" line="755"/>
         <source>Right Power Phase End</source>
         <translation>Ángulo de fin de la pedalada derecha</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="756"/>
+        <location filename="../../Train/RealtimeData.cpp" line="758"/>
         <source>Right Power Phase Peak Start</source>
         <translation>Ángulo de inicio del pico de potencia de la pedalada derecha</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="759"/>
+        <location filename="../../Train/RealtimeData.cpp" line="761"/>
         <source>Right Power Phase Peak End</source>
         <translation>Ángulo de fin del pico de potencia de la pedalada derecha</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="762"/>
+        <location filename="../../Train/RealtimeData.cpp" line="764"/>
         <source>Slope</source>
         <translation>Pendiente</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="765"/>
+        <location filename="../../Train/RealtimeData.cpp" line="767"/>
         <source>Lap Distance</source>
         <translation>Distancia del intervalo</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="768"/>
+        <location filename="../../Train/RealtimeData.cpp" line="770"/>
         <source>Lap Distance Remaining</source>
         <translation>Distancia del intervalo restante</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="771"/>
+        <location filename="../../Train/RealtimeData.cpp" line="773"/>
         <source>Latitude</source>
         <translation>Latitud</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="774"/>
+        <location filename="../../Train/RealtimeData.cpp" line="776"/>
         <source>Longitude</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="777"/>
+        <location filename="../../Train/RealtimeData.cpp" line="779"/>
         <source>Altitude</source>
         <translation>Altitud</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="780"/>
+        <location filename="../../Train/RealtimeData.cpp" line="782"/>
         <source>Respiratory Frequency</source>
         <translation>Frecuencia respiratoria</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="783"/>
+        <location filename="../../Train/RealtimeData.cpp" line="785"/>
         <source>Ventilation</source>
         <translation>Ventilación</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="786"/>
+        <location filename="../../Train/RealtimeData.cpp" line="788"/>
         <source>VO2</source>
         <translation>VO2</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="789"/>
+        <location filename="../../Train/RealtimeData.cpp" line="791"/>
         <source>VCO2</source>
         <translation>VCO2</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="792"/>
+        <location filename="../../Train/RealtimeData.cpp" line="794"/>
         <source>Respiratory Exchange Ratio</source>
         <translation>Relación de intercambio respiratorio (RER)</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="795"/>
+        <location filename="../../Train/RealtimeData.cpp" line="797"/>
         <source>Tidal Volume</source>
         <translation>Volúmen corriente</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="798"/>
+        <location filename="../../Train/RealtimeData.cpp" line="800"/>
         <source>Fraction O2 Expired</source>
         <translation>Fracción de O2 expirado</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="801"/>
+        <location filename="../../Train/RealtimeData.cpp" line="803"/>
         <source>Temperature</source>
         <translation type="unfinished">Temperatura</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="804"/>
+        <location filename="../../Train/RealtimeData.cpp" line="806"/>
         <source>CoreTemp</source>
         <translation type="unfinished"></translation>
     </message>
@@ -27418,22 +27399,22 @@ Python deshabilitado en preferencias.</translation>
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Series</source>
         <translation>Serie</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="172"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
         <source>Power</source>
         <translation>Potencia</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="176"/>
         <source>Heart Rate</source>
         <translation>Frec. cardíaca</translation>
     </message>
@@ -29733,317 +29714,317 @@ formato GoldenCheetah. ¿Quiere hacerlo?
 <context>
     <name>ScatterPlot</name>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="113"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
         <source>Power (watts)</source>
         <translation>Potencia (W)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
         <source>Cadence (rpm)</source>
         <translation>Cadencia (rpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="116"/>
         <source>Heartrate (bpm)</source>
         <translation>Frec. cardíaca (ppm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="118"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="119"/>
         <source>Speed (kph)</source>
         <translation>Velocidad (km/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="120"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="121"/>
         <source>Speed (mph)</source>
         <translation>Velocidad (mi/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="124"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="125"/>
         <source>Altitude (meters)</source>
         <translation>Altitud (metros)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="126"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="127"/>
         <source>Altitude (feet)</source>
         <translation>Altitud (pies)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="128"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
         <source>Torque (N)</source>
         <translation>Par (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="130"/>
         <source>Elapsed Time (secs)</source>
         <translation>Tiempo transcurrido (s)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="132"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="133"/>
         <source>Elapsed Distance (km)</source>
         <translation>Distancia recorrida (km)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="134"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="135"/>
         <source>Elapsed Distance (mi)</source>
         <translation>Distancia recorrida (mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="136"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
         <source>Interval Number</source>
         <translation>Número del intervalo</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
         <source>Latitude (degree offset)</source>
         <translation>Latitud (grados)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
         <source>Longitude (degree offset)</source>
         <translation>Longitud (grados)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
         <source>Circumferential Pedal Velocity (m/s)</source>
         <translation>Velocidad lineal de los pedales (m/s)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="141"/>
         <source>Average Effective Pedal Force (N)</source>
         <translation>Fuerza efectiva media en los pedales (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="144"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
         <source>Time at X/Y (%)</source>
         <translation>Tiempo en X/Y (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
         <source>Power Zone</source>
         <translation>Zona de potencia</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
         <source>Headwind (kph)</source>
         <translation>Viento en contra (km/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
         <source>Slope (gradient)</source>
         <translation>Pendiente</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
         <source>Temperature (C)</source>
         <translation>Temperatura (ºC)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
         <source>L/R Balance</source>
         <translation>Balance izq/der</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
         <source>Torque Efficiency</source>
         <translation>Eficiencia del par</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
         <source>Pedal Smoothness</source>
         <translation>Fluidez del pedaleo</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
         <source>Running Vertical Oscillation</source>
         <translation>Oscilación vertical</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
         <source>Running Ground Contact Time</source>
         <translation>Tiempo de contacto con el suelo</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
         <source>Running Cadence</source>
         <translation>Frecuencia de paso</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
         <source>Gear Ratio</source>
         <translation>Multiplicación/desarrollo</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
         <source>Muscle Oxygen</source>
         <translation>Oxigenación muscular</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
         <source>Haemoglobin Mass</source>
         <translation>Masa de hemoglobina</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
         <source>Deoxygenated Haemoglobin</source>
         <translation>Hemoglobina reducida</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="160"/>
         <source>Oxygenated Haemoglobin</source>
         <translation>Hemoglobina oxigenada</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="161"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="162"/>
         <source>Unknown</source>
         <translation>Desconocido</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="165"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
         <source>Power</source>
         <translation>Potencia</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
         <source>Cadence</source>
         <translation>Cadencia</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
         <source>Heartrate</source>
         <translation>Frec. cardíaca</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
         <source>Speed</source>
         <translation>Velocidad</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
         <source>Altitude</source>
         <translation>Altitud</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
         <source>Pedal Force</source>
         <translation>Fuerza en los pedales</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
         <source>Time</source>
         <translation>Tiempo</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
         <source>Distance</source>
         <translation>Distancia</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
         <source>Interval</source>
         <translation>Intervalo</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
         <source>Latitude</source>
         <translation>Latitud</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
         <source>Longitude</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
         <source>Time at X/Y</source>
         <translation>Tiempo en X/Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
         <source>Zone</source>
         <translation>Zona</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
         <source>CPV</source>
         <translation>VCP/CPV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
         <source>AEPF</source>
         <translation>FEMP (AEPF)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
         <source>Headwind</source>
         <translation>Viento en contra</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
         <source>Slope</source>
         <translation>Pendiente</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
         <source>Temp</source>
         <translation>Temperatura</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
         <source>Balance</source>
         <translation>Balance</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
         <source>TE</source>
         <translation>EP/TE</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
         <source>PS</source>
         <translation>FP/PS</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
         <source>RV</source>
         <translation>RV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
         <source>GCT</source>
         <translation>GCT</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
         <source>Run Cad</source>
         <translation>Frec. de paso</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
         <source>Gear</source>
         <translation>Multiplicación/desarrollo</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="194"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="195"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="196"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
@@ -30281,42 +30262,38 @@ formato GoldenCheetah. ¿Quiere hacerlo?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1012"/>
         <source>Add</source>
-        <translation>Agregar</translation>
+        <translation type="vanished">Agregar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1013"/>
         <source>Delete</source>
-        <translation>Eliminar</translation>
+        <translation type="vanished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1006"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1007"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1023"/>
+        <location filename="../../Gui/AthletePages.cpp" line="982"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="988"/>
         <source>Short</source>
         <translation>Abreviatura</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="989"/>
         <source>Long</source>
         <translation>Descripción</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1031"/>
+        <location filename="../../Gui/AthletePages.cpp" line="990"/>
         <source>Percent of CP</source>
         <translation>Porcentaje de la potencia crítica</translation>
     </message>
@@ -30325,14 +30302,14 @@ formato GoldenCheetah. ¿Quiere hacerlo?
         <translation type="vanished">Se alcanzó el máximo de 10 zonas.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1069"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1076"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1034"/>
         <source>New</source>
         <translation>Nueva</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1071"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1078"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1036"/>
         <source>New (%1)</source>
         <translation>Nueva (%1)</translation>
     </message>
@@ -30505,65 +30482,65 @@ formato GoldenCheetah. ¿Quiere hacerlo?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3821"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3569"/>
         <source>Add</source>
         <translation>Agregar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3822"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3570"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3823"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3571"/>
         <source>Up</source>
         <translation>Arriba</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3824"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3572"/>
         <source>Down</source>
         <translation>Abajo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3870"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3872"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3963"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3965"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3711"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3713"/>
         <source>ddd MMM d, yyyy</source>
         <translatorcomment>No traducir esta cadena, pues ha de ser interpretada</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3557"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3810"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3558"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3804"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3835"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3583"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3805"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3836"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3553"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3584"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3806"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3837"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3554"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3585"/>
         <source>From</source>
         <translation>Desde</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3807"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3838"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3555"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3586"/>
         <source>To</source>
         <translation>Hasta</translation>
     </message>
@@ -33025,25 +33002,25 @@ de acuerdo a la altitud y la configuración.</translation>
 <context>
     <name>TrainSidebar</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="253"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="257"/>
         <source>Save workout data</source>
         <translation>Guardar datos de entrenamiento</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="259"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="263"/>
         <source>Devices</source>
         <translation>Dispositivos</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="262"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="267"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="311"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="321"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="271"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="315"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="325"/>
         <source>Menu</source>
         <translation>Menú</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="270"/>
         <source>Workouts</source>
         <translation>Entrenamientos</translation>
     </message>
@@ -33052,114 +33029,114 @@ de acuerdo a la altitud y la configuración.</translation>
         <translation type="vanished">Filtrar...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="303"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="307"/>
         <source>Workout Info</source>
         <translation>Información de la actividad</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="310"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="314"/>
         <source>Media</source>
         <translation>Medios</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="320"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="324"/>
         <source>VideoSync</source>
         <translation>VideoSync</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="506"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
         <source>Import Workout from File</source>
         <translation>Importar de archivo</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="507"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="511"/>
         <source>Get Workouts from TrainerDay</source>
         <translation>Obtener entrenamiento de TrainerDay</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="509"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="513"/>
         <source>Create Workout via Wizard</source>
         <translation>Crear entrenamiento con el asistente</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="514"/>
         <source>Scan for Workouts</source>
         <translation>Buscar entrenamientos</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="534"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="538"/>
         <source>Delete selected Workout</source>
         <translation>Borrar entrenamiento seleccionado</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="541"/>
         <source>Delete %1 selected Workouts</source>
         <translation>Borrar %1 entrenamientos seleccionados</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Train mode active</source>
         <translation>Modo entrenar activo</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Please stop the train mode before closing the window or application.</source>
         <translation>Por favor, detenga el modo entrenamiento antes de cerrar la ventana o la aplicación.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="635"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="639"/>
         <source>Remove reference to selected video</source>
         <translation>Eliminar la referencia al vídeo seleccionado</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="650"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="654"/>
         <source>Import VideoSync from File</source>
         <translation>Importar VideoSync desde archivo</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="651"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="655"/>
         <source>Scan for VideoSyncs</source>
         <translation>Buscar VideoSyncs</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="668"/>
         <source>Delete selected VideoSync</source>
         <translation>Eliminar las VideoSync seleccionadas</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1064"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1068"/>
         <source>Are you sure you want to remove the reference to this video?</source>
         <translation>¿Está seguro de eliminar la referencia a este vídeo?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1066"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1128"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1204"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1070"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1132"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1208"/>
         <source>Remove</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1099"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1103"/>
         <source>Are you sure you want to delete this VideoSync?</source>
         <translation>¿Está seguro de eliminar esta VideoSync?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1126"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1130"/>
         <source>The VideoSync file is either not valid or not existing and will be removed from the library.</source>
         <translation>La VideoSync no es válida o no existe y será eliminada de la biblioteca.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1160"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1164"/>
         <source>Are you sure you want to delete this Workout?</source>
         <translation>¿Está seguro de eliminar este entrenamiento?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1163"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1167"/>
         <source>Are you sure you want to delete this %1 workouts?</source>
         <translation>¿Está seguro de eliminar estos %1 entrenamientos?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1202"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1206"/>
         <source>The Workout file is either not valid or not existing and will be removed from the library.</source>
         <translation>El archivo de entrenamiento no es válido o no existe y será eliminado de la biblioteca.</translation>
     </message>
@@ -33168,31 +33145,31 @@ de acuerdo a la altitud y la configuración.</translation>
         <translation type="vanished">ERROR: %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1347"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1351"/>
         <source>Starting in %1</source>
         <translation>Comenzando en %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2225"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2237"/>
         <source>Recalibrating steering..</source>
         <translation>Recalibrando la dirección..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2521"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2525"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2594"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2645"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2649"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2533"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2606"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2657"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2661"/>
         <source>Requesting calibration..</source>
         <translation>Solicitando calibración..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2532"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2544"/>
         <source>Calibrating...</source>
         <translation>Calibrando...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2536"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2548"/>
         <source>Calibrating...
 Current speed %1 kph
 Increase speed to %2 kph</source>
@@ -33201,14 +33178,14 @@ Velocidad actual %1 km/h
 Aumente la velocidad a %2 km/h</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2540"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2552"/>
         <source>Calibrating...
 Stop pedalling until speed drops to 0</source>
         <translation>Calibrando...
 Pare de pedalear hasta que la velocidad caiga a 0</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2545"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2557"/>
         <source>Calibration completed successfully!
 Spindown %1 ms
 Zero Offset %2</source>
@@ -33217,30 +33194,30 @@ Reducción velocidad de rotación %1 ms
 Compensación cero %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2553"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2620"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2672"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2565"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2632"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2684"/>
         <source>Calibration failed!</source>
         <translation>¡Falló la calibración!</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2573"/>
         <source>Calibration Failed: Loosen Roller</source>
         <translation>Falló la calibración. Afloje la tensión del rodillo</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2569"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2581"/>
         <source>Calibration Failed: Tighten Roller</source>
         <translation>Falló la calibración. Ajuste la tensión del rodillo</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2588"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2639"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2600"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2651"/>
         <source>Unclip or stop pedalling to begin calibration..</source>
         <translation>Deje de pedalear para comenzar la calibración..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2607"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2619"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Torque %1</source>
@@ -33249,7 +33226,7 @@ Deje de pedalear hasta que se complete el proceso..
 Par %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2612"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2624"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Torque %2</source>
@@ -33258,7 +33235,7 @@ Compensación cero %1
 Par %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2659"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2671"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Zero Offset %1</source>
@@ -33267,7 +33244,7 @@ Deje de pedalear hasta que se complete el proceso..
 Compensación cero %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2676"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Slope %2</source>
@@ -33276,175 +33253,175 @@ Compensación cero %1
 Pendiente %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2693"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2705"/>
         <source>Give the pedal a kick to start calibration...
 The motor will run until calibration is complete.</source>
         <translation>Pisar un pedal para comenzar la calibración...
 El motor se activará hasta que se complete la calibración.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2695"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
         <source>Allow wheel speed to settle, DO NOT PEDAL...
 The motor will run until calibration is complete.</source>
         <translation>Espere SIN PEDALEAR a que la velocidad se estabilice...
 El motor continurará activo hasta que se complete la calibración.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2700"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2712"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Gathering enough samples to calculate average: %1</source>
         <translation>Calibrando... NO PEDALEE, permanezca sentado...
 Obteniendo muestras para calcular el promedio: %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2719"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Waiting for value to stabilize (max %1s): %2 (%3W @ %4kph)</source>
         <translation>Calibrando... NO PEDALEE, permanezca sentado...
 Esperando a que los valores se estabilicen (máx %1s): %2 (%3 W @ %4 km/h)</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2722"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
         <source>Calibration completed successfully!
 Final calibration value %1 (%2W @ %3kph)</source>
         <translation>Calibración completada satisfactoriamente
 Valor final de calibración %1 (%2 W @ %3 km/h)</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2746"/>
         <source>Calibration failed! Do not pedal while calibration is taking place.
 Allow wheel to run freely.</source>
         <translation>¡Falló la calibración! No hay que pedalear mietras se calibra.
 Permita que la rueda gire libremente.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2780"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2792"/>
         <source>Fast forward..</source>
         <translation>Avance rápido...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2813"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2825"/>
         <source>Rewind..</source>
         <translation>Rebobinar...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2843"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2855"/>
         <source>Next Lap..</source>
         <translation>Intervalo siguiente...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2876"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2888"/>
         <source>Back Lap..</source>
         <translation>Intervalo anterior...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2902"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2914"/>
         <source>Increasing intensity..</source>
         <translation>Incrementando intensidad...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2928"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2940"/>
         <source>Decreasing intensity..</source>
         <translation>Disminuyendo intensidad...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="621"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="625"/>
         <source>Import Video from File</source>
         <translation>Importar vídeo desde archivo</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="508"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="512"/>
         <source>Get Workouts from Strava Routes</source>
         <translation>Obtener entrenamientos de rutas de Strava</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="622"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="626"/>
         <source>Scan for Videos</source>
         <translation>Buscar vídeos</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1101"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1173"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3183"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1105"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1177"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3195"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1309"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1313"/>
         <source>Resuming..</source>
         <translation>Retomando...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1336"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1340"/>
         <source>Paused..</source>
         <translation>En pausa...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1465"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1469"/>
         <source>Starting..</source>
         <translation>Iniciando...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1673"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1677"/>
         <source>Stopped..</source>
         <translation>En parada...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1763"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1769"/>
         <source>Connected..</source>
         <translation>Conectado...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1787"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1793"/>
         <source>Disconnected..</source>
         <translation>Desconectado...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2198"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2210"/>
         <source>New lap..</source>
         <translation>Nuevo intervalo...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>No Devices Configured</source>
         <translation>Sin dispositivo configurado</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>Please configure a device in Preferences.</source>
         <translation>Por favor, configure un dispositivo en Preferencias/Opciones.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2483"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2495"/>
         <source>Exiting calibration..</source>
         <translation>Saliendo de calibración...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2498"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2510"/>
         <source>Calibration not supported for this device.</source>
         <translation>Calibración no soportada para este dispositivo.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2505"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2517"/>
         <source>Calibrating...
 Press F3 on Controller when done.</source>
         <translation>Calibrando...
 Presionar F3 en el controlador al finalizar.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3135"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3153"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3147"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3165"/>
         <source>Add Device</source>
         <translation>Agregar dispositivo</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3140"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3158"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3152"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3170"/>
         <source>Delete Device</source>
         <translation>Eliminar dispositivo</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3181"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3193"/>
         <source>Are you sure you want to delete this device?</source>
         <translation>¿Está seguro de querer eliminar este dispositivo?</translation>
     </message>
@@ -33762,7 +33739,7 @@ Presionar F3 en el controlador al finalizar.</translation>
 <context>
     <name>UniqueLabelEditDelegate</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="77"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="108"/>
         <source>The given value &quot;%1&quot; is not unique</source>
         <translation>El valor &quot;%1&quot; no es único</translation>
     </message>
@@ -33778,171 +33755,167 @@ Presionar F3 en el controlador al finalizar.</translation>
 <context>
     <name>UserChartSettings</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="772"/>
+        <location filename="../../Charts/UserChart.cpp" line="773"/>
         <source>Chart</source>
         <translation>Gráfico</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="782"/>
+        <location filename="../../Charts/UserChart.cpp" line="783"/>
         <source>Sub-title</source>
         <translation>Subtítulo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="785"/>
+        <location filename="../../Charts/UserChart.cpp" line="786"/>
         <source>Description</source>
         <translation>Descripción</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="791"/>
+        <location filename="../../Charts/UserChart.cpp" line="792"/>
         <source>Line Chart</source>
         <translation>Gráfico de líneas</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="792"/>
+        <location filename="../../Charts/UserChart.cpp" line="793"/>
         <source>Scatter Chart</source>
         <translation>Gráfico de dispersión</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="793"/>
+        <location filename="../../Charts/UserChart.cpp" line="794"/>
         <source>Bar Chart</source>
         <translation>Gráfico de barras</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="794"/>
+        <location filename="../../Charts/UserChart.cpp" line="795"/>
         <source>Stacked Bar Chart</source>
         <translation>Gráfico de barras apiladas</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="795"/>
+        <location filename="../../Charts/UserChart.cpp" line="796"/>
         <source>Stacked Percent Chart</source>
         <translation>Gráfico porcentual apilado</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="796"/>
+        <location filename="../../Charts/UserChart.cpp" line="797"/>
         <source>Pie Chart</source>
         <translation>Gráfico de tarta</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="800"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="801"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="804"/>
+        <location filename="../../Charts/UserChart.cpp" line="805"/>
         <source>Vertical</source>
         <translation>Vertical</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="805"/>
+        <location filename="../../Charts/UserChart.cpp" line="806"/>
         <source>Horizontal</source>
         <translation>Horizontal</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="808"/>
+        <location filename="../../Charts/UserChart.cpp" line="809"/>
         <source>Layout</source>
         <translation>Diseño</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="812"/>
+        <location filename="../../Charts/UserChart.cpp" line="813"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="813"/>
+        <location filename="../../Charts/UserChart.cpp" line="814"/>
         <source>Top</source>
         <translation>Superior</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="814"/>
+        <location filename="../../Charts/UserChart.cpp" line="815"/>
         <source>Left</source>
         <translation>Izquierda</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="815"/>
+        <location filename="../../Charts/UserChart.cpp" line="816"/>
         <source>Right</source>
         <translation>Derecha</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="816"/>
+        <location filename="../../Charts/UserChart.cpp" line="817"/>
         <source>Bottom</source>
         <translation>Inferior</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="820"/>
+        <location filename="../../Charts/UserChart.cpp" line="821"/>
         <source>Legend</source>
         <translation>Leyenda</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="829"/>
+        <location filename="../../Charts/UserChart.cpp" line="830"/>
         <source>Font scaling</source>
         <translation>Escalar tipografía</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="831"/>
-        <location filename="../../Charts/UserChart.cpp" line="833"/>
+        <location filename="../../Charts/UserChart.cpp" line="832"/>
+        <location filename="../../Charts/UserChart.cpp" line="834"/>
         <source>Background</source>
         <translation>Fondo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="836"/>
+        <location filename="../../Charts/UserChart.cpp" line="837"/>
         <source>Animate</source>
         <translation>Animación</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="838"/>
+        <location filename="../../Charts/UserChart.cpp" line="839"/>
         <source>Single series per plot</source>
         <translation>Una sola serie por gráfico</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="841"/>
+        <location filename="../../Charts/UserChart.cpp" line="842"/>
         <source>Refresh for intervals</source>
         <translation>Refrescar intervalos</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="848"/>
+        <location filename="../../Charts/UserChart.cpp" line="849"/>
         <source>Series</source>
         <translation>Serie</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Group</source>
         <translation>Grupo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Y Formula</source>
         <translation>Formula Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="870"/>
-        <location filename="../../Charts/UserChart.cpp" line="932"/>
         <source>Edit</source>
-        <translation>Editar</translation>
+        <translation type="vanished">Editar</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="889"/>
         <source>Up</source>
-        <translation>Arriba</translation>
+        <translation type="vanished">Arriba</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="890"/>
         <source>Down</source>
-        <translation>Abajo</translation>
+        <translation type="vanished">Abajo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="911"/>
+        <location filename="../../Charts/UserChart.cpp" line="885"/>
         <source>Axes</source>
         <translation>Ejes</translation>
     </message>
@@ -34616,72 +34589,72 @@ Aguante la respiración durante 5 segundos.</translation>
 <context>
     <name>VideoWindow</name>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> kph</source>
         <translation> km/h</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="119"/>
+        <location filename="../../Train/VideoWindow.cpp" line="144"/>
         <source>Meters layout</source>
         <translation>Diseño</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="127"/>
+        <location filename="../../Train/VideoWindow.cpp" line="152"/>
         <source>Reset Meters layout to default</source>
         <translation>Restablecer diseño a valores originales</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> mph</source>
         <translation> mi/h</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> m</source>
         <translation> m</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> feet</source>
         <translation> pies</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="625"/>
+        <location filename="../../Train/VideoWindow.cpp" line="681"/>
         <source>w</source>
         <translation>W</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="629"/>
+        <location filename="../../Train/VideoWindow.cpp" line="685"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> km</source>
         <translation> km</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> mi</source>
         <translation> mi</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="673"/>
+        <location filename="../../Train/VideoWindow.cpp" line="729"/>
         <source>Calibration required</source>
         <translation>Requiere calibración</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="678"/>
+        <location filename="../../Train/VideoWindow.cpp" line="734"/>
         <source>Configuration required</source>
         <translation>Requiere configuración</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="683"/>
+        <location filename="../../Train/VideoWindow.cpp" line="739"/>
         <source>brake fault</source>
         <translation>falla en el freno</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="688"/>
+        <location filename="../../Train/VideoWindow.cpp" line="744"/>
         <source>Ready</source>
         <translation>Listo</translation>
     </message>
@@ -35116,27 +35089,27 @@ Aguante la respiración durante 5 segundos.</translation>
 <context>
     <name>WheelSizeCalculator</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="202"/>
+        <location filename="../../Gui/AthletePages.cpp" line="187"/>
         <source>Wheel Size Calculator</source>
         <translation>Calculadora de tamaño de rueda</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="221"/>
+        <location filename="../../Gui/AthletePages.cpp" line="206"/>
         <source>Rim Size</source>
         <translation>Tamaño de la llanta (aro)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="222"/>
+        <location filename="../../Gui/AthletePages.cpp" line="207"/>
         <source>Tire Size</source>
         <translation>Tamaño del neumático</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="223"/>
+        <location filename="../../Gui/AthletePages.cpp" line="208"/>
         <source>Wheel Size</source>
         <translation>Tamaño de rueda</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="227"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
@@ -35248,12 +35221,12 @@ Aguante la respiración durante 5 segundos.</translation>
 <context>
     <name>WorkoutFilterBox</name>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="34"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="44"/>
         <source>Filter...</source>
         <translation type="unfinished">Filtrar...</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="64"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="95"/>
         <source>ERROR: %1</source>
         <translation type="unfinished">ERROR: %1</translation>
     </message>
@@ -35261,12 +35234,12 @@ Aguante la respiración durante 5 segundos.</translation>
 <context>
     <name>WorkoutImportDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="820"/>
+        <location filename="../../Train/Library.cpp" line="809"/>
         <source>Import to Library</source>
         <translation>Importar a la biblioteca</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="854"/>
+        <location filename="../../Train/Library.cpp" line="843"/>
         <source>Please note, that when importing or drag and dropping videos into the library we DO NOT copy the file into the GoldenCheetah library, instead we add a REFERENCE to it. We DO copy workout and videoSync files, since they are smaller.
 
 You can remove references when managing the library via the context menu options</source>
@@ -35275,24 +35248,107 @@ You can remove references when managing the library via the context menu options
 Puede eliminar las referencias cuando administra la biblioteca usando el menú de contexto</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="868"/>
+        <location filename="../../Train/Library.cpp" line="857"/>
         <source>Files</source>
         <translation>Archivos</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="878"/>
+        <location filename="../../Train/Library.cpp" line="867"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="880"/>
+        <location filename="../../Train/Library.cpp" line="869"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="884"/>
+        <location filename="../../Train/Library.cpp" line="873"/>
         <source>Overwite existing files</source>
         <translation>Reemplazar archivos existentes</translation>
+    </message>
+</context>
+<context>
+    <name>WorkoutMenuProvider</name>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="271"/>
+        <source>Select Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="274"/>
+        <source>Manage Filters</source>
+        <translation type="unfinished">Administrar filtros</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="275"/>
+        <source>Add Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="289"/>
+        <source>Add Tag to Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="292"/>
+        <source>Filter Tags...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="310"/>
+        <source>Match all selected tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="353"/>
+        <source>Manage Workout Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="360"/>
+        <source>Name</source>
+        <translation type="unfinished">Nombre</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="361"/>
+        <source>Filter</source>
+        <translation type="unfinished">Filtro</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="362"/>
+        <source>_index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="370"/>
+        <source>Execute</source>
+        <translation type="unfinished">Ejecutar</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="371"/>
+        <source>Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="423"/>
+        <source>Add Workout Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="426"/>
+        <source>Name of the Filter...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="467"/>
+        <source>New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="469"/>
+        <source>New (%1)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -35307,41 +35363,41 @@ Puede eliminar las referencias cuando administra la biblioteca usando el menú d
     <name>WorkoutPlotWindow</name>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="40"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="104"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
         <source>Ergmode specific settings</source>
         <translation>Configuración específica de Ergmode</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="46"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
         <source>Color power zones</source>
         <translation>Color de las zonas de potencia</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="48"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="56"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
         <source>Never</source>
         <translation>Nunca</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="49"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
         <source>Always</source>
         <translation>Siempre</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="50"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="57"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="109"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="113"/>
         <source>When stopped</source>
         <translation>Cuando se detenga</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="54"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="110"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
         <source>Show tooltip</source>
         <translation>Mostrar ayuda emergente</translation>
     </message>
@@ -35435,12 +35491,12 @@ Puede eliminar las referencias cuando administra la biblioteca usando el menú d
 <context>
     <name>WorkoutWidget</name>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="1531"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="1532"/>
         <source>File save failed.</source>
         <translation>Fallo al guardar el archivo.</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="2367"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="2368"/>
         <source>Intensity</source>
         <translation>Intensidad</translation>
     </message>
@@ -35594,26 +35650,22 @@ Puede eliminar las referencias cuando administra la biblioteca usando el menú d
 <context>
     <name>XDataDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="44"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="45"/>
         <source>xData</source>
         <translation>xData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="58"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="59"/>
         <source>Data Series</source>
         <translation>Serie de datos</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="78"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="80"/>
         <source>Add</source>
-        <translation>Agregar</translation>
+        <translation type="vanished">Agregar</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="79"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="81"/>
         <source>Delete</source>
-        <translation>Eliminar</translation>
+        <translation type="vanished">Eliminar</translation>
     </message>
 </context>
 <context>
@@ -35690,32 +35742,32 @@ Puede eliminar las referencias cuando administra la biblioteca usando el menú d
 <context>
     <name>XDataSeriesSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="333"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="315"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="338"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="320"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="346"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="328"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="347"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="329"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Name is blank</source>
         <translation>Nombre en blanco</translation>
     </message>
@@ -35723,48 +35775,48 @@ Puede eliminar las referencias cuando administra la biblioteca usando el menú d
 <context>
     <name>XDataSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="262"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="244"/>
         <source>xData</source>
         <translation>xData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="269"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="251"/>
         <source>Data Series</source>
         <translation>Serie de datos</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="270"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="252"/>
         <source>Units</source>
         <translation>Unidades</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="274"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="256"/>
         <source>Series %1</source>
         <translation>Serie %1</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="281"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="263"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="282"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="264"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
         <source>XData name is blank</source>
         <translation>Nombre de XData en blanco</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Must have at least one data series.</source>
         <translation>Debe tener al menos una serie de datos.</translation>
     </message>
@@ -36085,17 +36137,17 @@ Puede eliminar las referencias cuando administra la biblioteca usando el menú d
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="915"/>
+        <location filename="../../Gui/AthletePages.cpp" line="886"/>
         <source>Sport</source>
         <translation>Deporte</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="962"/>
+        <location filename="../../Gui/AthletePages.cpp" line="933"/>
         <source>Critical Power</source>
         <translation>Potencia crítica</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="963"/>
+        <location filename="../../Gui/AthletePages.cpp" line="934"/>
         <source>Default</source>
         <translation>Por omisión</translation>
     </message>

--- a/src/Resources/translations/gc_fr.ts
+++ b/src/Resources/translations/gc_fr.ts
@@ -107,40 +107,40 @@ Il peut être nécessaire de le désactiver manuellement.</translation>
         <translation type="vanished">LTS, Stress à long terme moyen (jour)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="504"/>
+        <location filename="../../Gui/AthletePages.cpp" line="489"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="517"/>
-        <location filename="../../Gui/AthletePages.cpp" line="522"/>
+        <location filename="../../Gui/AthletePages.cpp" line="502"/>
+        <location filename="../../Gui/AthletePages.cpp" line="507"/>
         <source>days</source>
         <translation type="unfinished">jours</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="525"/>
+        <location filename="../../Gui/AthletePages.cpp" line="510"/>
         <source>PMC Stress Balance Today</source>
         <translation>PMC Stress Balance &quot;Today&quot;
 Si cochée, le stress de l&apos;entraînement d&apos;un jour donné sera pris en compte ce même jour.
 Si non cochée, le stress de l&apos;entraînement d&apos;un jour donné sera pris en compte le lendemain</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="528"/>
+        <location filename="../../Gui/AthletePages.cpp" line="513"/>
         <source>Restore Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="517"/>
         <source>W&apos;bal tau</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="518"/>
         <source>Short Term Stress (STS) average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="534"/>
+        <location filename="../../Gui/AthletePages.cpp" line="519"/>
         <source>Long Term Stress (LTS) average</source>
         <translation type="unfinished"></translation>
     </message>
@@ -156,96 +156,96 @@ Si non cochée, le stress de l&apos;entraînement d&apos;un jour donné sera pri
 <context>
     <name>AboutRiderPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="372"/>
+        <location filename="../../Gui/AthletePages.cpp" line="357"/>
         <source>Nickname</source>
         <translation>Surnom</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="373"/>
+        <location filename="../../Gui/AthletePages.cpp" line="358"/>
         <source>Date of Birth</source>
         <translation>Date de naissance</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="374"/>
+        <location filename="../../Gui/AthletePages.cpp" line="359"/>
         <source>Sex</source>
         <translation>Sexe</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="376"/>
+        <location filename="../../Gui/AthletePages.cpp" line="361"/>
         <source>Weight</source>
         <translation>Poids</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="375"/>
+        <location filename="../../Gui/AthletePages.cpp" line="360"/>
         <source>Height</source>
         <translation>Taille</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="279"/>
+        <location filename="../../Gui/AthletePages.cpp" line="264"/>
         <source>Male</source>
         <translation>Homme</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="280"/>
+        <location filename="../../Gui/AthletePages.cpp" line="265"/>
         <source>Female</source>
         <translation>Femme</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> kg</source>
         <translation> kg</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> lb</source>
         <translation> lb</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> cm</source>
         <translation> cm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> in</source>
         <translation> in</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="359"/>
+        <location filename="../../Gui/AthletePages.cpp" line="344"/>
         <source>Calculate...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="378"/>
+        <location filename="../../Gui/AthletePages.cpp" line="363"/>
         <source>Bike</source>
         <translation type="unfinished">Vélo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="379"/>
+        <location filename="../../Gui/AthletePages.cpp" line="364"/>
         <source>Crank Length</source>
         <translation>Longueur des manivelles</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="380"/>
+        <location filename="../../Gui/AthletePages.cpp" line="365"/>
         <source>Wheelsize</source>
         <translation>Taille de la roue</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="438"/>
+        <location filename="../../Gui/AthletePages.cpp" line="423"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="356"/>
+        <location filename="../../Gui/AthletePages.cpp" line="341"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="437"/>
+        <location filename="../../Gui/AthletePages.cpp" line="422"/>
         <source>Choose Picture</source>
         <translation>Choisir une photo</translation>
     </message>
@@ -2283,403 +2283,400 @@ Choisir &apos;Suivant&apos; pour continuer
 <context>
     <name>AllPlotWindow</name>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="190"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="444"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="165"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
         <source>Smooth</source>
         <translation>Lisser</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="198"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="173"/>
         <source>Stacked</source>
         <translation>Empilé</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="199"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="174"/>
         <source>by series</source>
         <translation>par série</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="200"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="175"/>
         <source>Fullplot</source>
         <translation>Graphique plein écran</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="201"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="176"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="239"/>
         <source>Overlay</source>
         <translatorcomment>Based on observed action in GUI</translatorcomment>
         <translation>Afficher la fenêtre des intervalles</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="229"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="204"/>
         <source>View</source>
         <translation>Vue</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="206"/>
         <source>Stack</source>
         <translatorcomment>Based on observed action in GUI</translatorcomment>
         <translation>Diagrammes empilés (surperposés sinon)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="210"/>
         <source>By Series</source>
         <translatorcomment>Based on observed action in GUI</translatorcomment>
         <translation>Diagrammes par série de données (si empilés)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="246"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="221"/>
         <source>Stack Zoom</source>
         <translatorcomment>Based on observed action in GUI</translatorcomment>
         <translation>Taille diagrammes empilés</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="248"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="223"/>
         <source>Full plot</source>
         <translatorcomment>Based on observed action in GUI and wiki info</translatorcomment>
         <translation>Afficher le graphique de l&apos;activité complète (zoomable)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="227"/>
         <source>Show Interval Markers</source>
         <translation>Afficher les repères d&apos;intervalle</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="256"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
         <source>Interval Navigator</source>
         <translation>Navigateur d&apos;intervalles</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="260"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
         <source>Hover intervals</source>
         <translatorcomment>long but we have space in the GUI</translatorcomment>
         <translation>Auto-sélection d&apos;intervalle au survol des diagrammes</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="268"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="243"/>
         <source>Fill Curves</source>
         <translation>Remplir les courbes</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="247"/>
         <source>Grid</source>
         <translation>Grille</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="277"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
         <source>Acceleration</source>
         <translation>Accélération</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="279"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="254"/>
         <source>Delta Series</source>
         <translation>Séries de différence</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="280"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="255"/>
         <source>Power %1</source>
         <translation>Puissance %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="283"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="258"/>
         <source>Cadence %1</source>
         <translation>Cadence %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="261"/>
         <source>Torque %1</source>
         <translation>Couple %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="289"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
         <source>Heartrate %1</source>
         <translation>FC %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="295"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="270"/>
         <source>Balance</source>
         <translation>Equilibre</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
         <source>Left/Right</source>
         <translation>Gauche/Droit</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="274"/>
         <source>Torque Effectiveness</source>
         <translation>Efficacité du pédalage</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="303"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="278"/>
         <source>Smoothness</source>
         <translation>Lissage</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="282"/>
         <source>Pedal Center Offset</source>
         <translation>Décalage plate-forme pédales</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="311"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
         <source>Power Phase</source>
         <translation>Phase de pédalage</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="290"/>
         <source>Peak Power Phase</source>
         <translation>Phase de pic de pédalage</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="322"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
         <source>Vertical Oscillation</source>
         <translation>Oscillation verticale</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="324"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
         <source>Running</source>
         <translation>Course à pied</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="326"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="301"/>
         <source>Ground Contact Time</source>
         <translation>Temps de contact au sol</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
         <source>Cadence </source>
         <translation>Cadence </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="313"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="340"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
         <source>Moxy</source>
         <translation>Moxy</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="317"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="321"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="325"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="355"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="330"/>
         <source>Heart Rate</source>
         <translation>Fréquence cardiaque</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="357"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
         <source>Data series</source>
         <translation>Séries de données</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="359"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="334"/>
         <source>Core Temperature</source>
         <translation>Température de base</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="363"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
         <source>Speed</source>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="367"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
         <source>Cadence</source>
         <translation>Cadence</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="94"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="95"/>
         <source>Basic</source>
         <translation>Simple</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="109"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="110"/>
         <source>Curves</source>
         <translation>Courbes</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="116"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="117"/>
         <source>User Data</source>
         <translation>Données utilisateur</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="132"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="134"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Formula</source>
         <translation>Formule</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="144"/>
         <source>Edit</source>
-        <translation>Editer</translation>
+        <translation type="vanished">Editer</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="163"/>
         <source>Up</source>
-        <translation>Vers le haut</translation>
+        <translation type="vanished">Vers le haut</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="164"/>
         <source>Down</source>
-        <translation>Vers le bas</translation>
+        <translation type="vanished">Vers le bas</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="371"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
         <source>Altitude</source>
         <translation>Altitude</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
         <source>Temperature</source>
         <translation>Température</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="379"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="354"/>
         <source>Headwind</source>
         <translation>vent contraire</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="383"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="358"/>
         <source>Torque</source>
         <translation>Couple</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="387"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="362"/>
         <source>Gear Ratio</source>
         <translation>Braquet</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="391"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="366"/>
         <source>Slope</source>
         <translation>Pente</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="373"/>
         <source>No Alt/Slope</source>
         <translation>Pas d&apos;alt/Pente</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="399"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="374"/>
         <source>0.1km|mi -  1min</source>
         <translation>0.1km|mi -  1min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="400"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
         <source>0.5km|mi -  5min</source>
         <translation>0.5km|mi -  5min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="401"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="376"/>
         <source>1.0km|mi - 10min</source>
         <translation>1.0km|mi - 10min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1528"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="377"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="1503"/>
         <source>Alt/Slope</source>
         <translation>Alt/Pente</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="382"/>
         <source>Anaerobic TISS</source>
         <translation>Anaérobique TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="384"/>
         <source>Metrics</source>
         <translation>Métriques</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="411"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="386"/>
         <source>Aerobic TISS</source>
         <translation>Aérobique TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="390"/>
         <source>Iso Power</source>
         <translation>Puissance normalisée</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="394"/>
         <source>Skiba xPower</source>
         <translation>Skiba xPower</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="423"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
         <source>Altitude Power</source>
         <translation>Puissance (altitude)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="427"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
         <source>W&apos; balance</source>
         <translation>Equilibre W&apos;</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="441"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="416"/>
         <source>Time of day</source>
         <translation>Heure de la journée</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="742"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="717"/>
         <source>Intervals</source>
         <translation>Intervalles</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="2253"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="2228"/>
         <source>Selection #%1 </source>
         <translation>Sélection #%1 </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="432"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
         <source>Power + shade</source>
         <translation>Puissance + zones</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="433"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="408"/>
         <source>Power - shade</source>
         <translation>Puissance - zones</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="434"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
         <source>No Power</source>
         <translation>Sans puissance</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="435"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="410"/>
         <source>Shading</source>
         <translation>Ombrage</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="439"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="414"/>
         <source>Time</source>
         <translation>Temps</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="440"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
         <source>Distance</source>
         <translation>Distance</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="442"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="417"/>
         <source>X Axis</source>
         <translation>Axe X</translation>
     </message>
@@ -3490,51 +3487,45 @@ Choisir &apos;Suivant&apos; pour continuer
 <context>
     <name>AutoImportPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4028"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4029"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
         <source>Browse</source>
         <translation type="vanished">Parcourir</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4040"/>
         <source>Add</source>
-        <translation>Ajouter</translation>
+        <translation type="vanished">Ajouter</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4041"/>
         <source>Delete</source>
-        <translation>Effacer</translation>
+        <translation type="vanished">Effacer</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4042"/>
         <source>Up</source>
-        <translation>Vers le haut</translation>
+        <translation type="vanished">Vers le haut</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4043"/>
         <source>Down</source>
-        <translation>Vers le bas</translation>
+        <translation type="vanished">Vers le bas</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4054"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3779"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4059"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3784"/>
         <source>Directory</source>
         <translation>Dossier</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4060"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3785"/>
         <source>Import Rule</source>
         <translation>Règle d&apos;importation</translation>
     </message>
@@ -4352,37 +4343,37 @@ Choisir &apos;Suivant&apos; pour continuer
 <context>
     <name>BackupPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="608"/>
+        <location filename="../../Gui/AthletePages.cpp" line="593"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="601"/>
         <source>every</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="617"/>
+        <location filename="../../Gui/AthletePages.cpp" line="602"/>
         <source>times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="603"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="605"/>
         <source>Backup now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="623"/>
+        <location filename="../../Gui/AthletePages.cpp" line="608"/>
         <source>Auto Backup Folder</source>
         <translation>Dossier de sauvegarde automatique</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="624"/>
+        <location filename="../../Gui/AthletePages.cpp" line="609"/>
         <source>Auto Backup after closing the athlete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5213,41 +5204,25 @@ Commençons par la configuration.</translation>
         <translation type="vanished">Mettre à jour</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1202"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
-        <source>+</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1203"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
-        <source>-</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1204"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1150"/>
         <source>Review...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1206"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1152"/>
         <source>Changed power estimates are available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1213"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1225"/>
         <source>Add</source>
-        <translation>Ajouter</translation>
+        <translation type="vanished">Ajouter</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1214"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1226"/>
         <source>Delete</source>
-        <translation>Effacer</translation>
+        <translation type="vanished">Effacer</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1216"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1158"/>
         <source>Def</source>
         <translation>Def</translation>
     </message>
@@ -5256,27 +5231,27 @@ Commençons par la configuration.</translation>
         <translation type="vanished">Depuis une date</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1218"/>
         <source>Critical Power</source>
         <translation>Puissance Critique</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1305"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>AeTP</source>
         <translation>AeTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1306"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>FTP</source>
         <translation>FTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1307"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1221"/>
         <source>W&apos;</source>
         <translation>W&apos;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1308"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1222"/>
         <source>Pmax</source>
         <translation>Pmax</translation>
     </message>
@@ -5289,209 +5264,209 @@ Commençons par la configuration.</translation>
         <translation type="vanished">MMM d, yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1347"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1261"/>
         <source>Short</source>
         <translatorcomment>As observed in GUI</translatorcomment>
         <translation>Zone</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1247"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1169"/>
         <source>Use CP for all metrics</source>
         <translation>Utiliser la CP pour tous les métriques</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1240"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1162"/>
         <source>Manual</source>
         <translation type="unfinished">Manuel</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1241"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1163"/>
         <source>Semi-Automatic (CP2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1164"/>
         <source>Semi-Automatic (CP3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1243"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1165"/>
         <source>Semi-Automatic (Extended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1170"/>
         <source>Use FTP for Coggan metrics</source>
         <translation>Utiliser le FTP pour les métriques Coggan</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1273"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1279"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1285"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1342"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1618"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1631"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2283"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2289"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2310"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1187"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1193"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1199"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1211"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1537"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1545"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2180"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2186"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2194"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2207"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1205"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1547"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2201"/>
         <source>J</source>
         <translation type="unfinished">J</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1303"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1217"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2145"/>
         <source>Start Date</source>
         <translation type="unfinished">Date</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1309"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1223"/>
         <source>Model Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1262"/>
         <source>Long</source>
         <translatorcomment>As observed in GUI</translatorcomment>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1349"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1263"/>
         <source>From Watts</source>
         <translation>Depuis (watts)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1598"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1512"/>
         <source>Review range starting on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1614"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1528"/>
         <source>Current</source>
         <translation type="unfinished">Actuel</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1615"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1529"/>
         <source>Estimate</source>
         <translation type="unfinished">Estimation</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1530"/>
         <source>Accept</source>
         <translation type="unfinished">Accepter</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1788"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1691"/>
         <source>🗹</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1692"/>
         <source>Estimate and settings &lt;b&gt;match&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1695"/>
         <source>☐</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1696"/>
         <source>Estimate and settings &lt;b&gt;differ&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1797"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1700"/>
         <source>⏲</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1800"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1703"/>
         <source>Range is %1 days older than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1802"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1705"/>
         <source>Range is %1 days younger than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1808"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1711"/>
         <source>∅</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1712"/>
         <source>No estimate available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1902"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1805"/>
         <source>New range from estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2237"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2134"/>
         <source>The proposed value for AeTP is a very rough estimate, assuming %1 % of CP. Usually it is determined by a&lt;ul&gt;&lt;li&gt;Metabolic test&lt;/li&gt;&lt;li&gt;Lactate ramp test&lt;/li&gt;&lt;li&gt;Run / Cycling ‘conversational’ test&lt;/li&gt;&lt;li&gt;Run Decoupling test&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2239"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2136"/>
         <source>Updating FTP internally to match CP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2139"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2244"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2141"/>
         <source>Your selected model does not deliver values for PMax, using default value of %1 W instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2246"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2143"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;li&gt;PMax, assuming a default of %1 W&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2250"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2147"/>
         <source>Critical Power (CP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2252"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2149"/>
         <source>Aerobic Threshold Power (AeTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2254"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2151"/>
         <source>Functional Threshold Power (FTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2153"/>
         <source>Anaerobic Work Capacity (W&apos;)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2258"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2155"/>
         <source>Maximum Power (PMax)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2270"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2167"/>
         <source>Manual range</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5500,14 +5475,14 @@ Commençons par la configuration.</translation>
         <translation type="vanished">Maximum de 10 zones atteint.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2018"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2025"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1917"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1924"/>
         <source>New</source>
         <translation>Nouveau</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2020"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1919"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1926"/>
         <source>New (%1)</source>
         <translation>Nouveau (%1)</translation>
     </message>
@@ -5961,52 +5936,44 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">Mettre à jour</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3307"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3319"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3308"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3320"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3313"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3325"/>
         <source>Add</source>
-        <translation>Ajouter</translation>
+        <translation type="vanished">Ajouter</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3314"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3326"/>
         <source>Delete</source>
-        <translation>Effacer</translation>
+        <translation type="vanished">Effacer</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3316"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3109"/>
         <source>Def</source>
         <translation>Def</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3359"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3506"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3272"/>
         <source>Start Date</source>
         <translation type="unfinished">Date</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3249"/>
         <source>New range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3507"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3273"/>
         <source>Critical Velocity (CV)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3508"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3274"/>
         <source>Aerobic Threshold (AeT)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6015,12 +5982,12 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">Depuis une date</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3360"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3128"/>
         <source>Critical Velocity</source>
         <translation>Vitesse Critique</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3361"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3129"/>
         <source>Aerobic Threshold</source>
         <translation>Seuil aérobie</translation>
     </message>
@@ -6033,19 +6000,19 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">d MMM, yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3403"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
         <source>Short</source>
         <translatorcomment>As observed in GUI</translatorcomment>
         <translation>Zone</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3404"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3172"/>
         <source>Long</source>
         <translatorcomment>As observed in GUI</translatorcomment>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3405"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3173"/>
         <source>From</source>
         <translation>De</translation>
     </message>
@@ -6054,14 +6021,14 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">Maximum de 10 zones atteint.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3679"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3686"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3441"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3448"/>
         <source>New</source>
         <translation>Nouveau</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3681"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3688"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3443"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3450"/>
         <source>New (%1)</source>
         <translation>Nouveau (%1)</translation>
     </message>
@@ -7601,39 +7568,34 @@ Voulez-vous appliquer les changements et redémarrer GoldenCheetah?</translation
 <context>
     <name>CredentialsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="67"/>
         <source>+</source>
         <translatorcomment>+</translatorcomment>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
+    </message>
+    <message>
+        <source>-</source>
+        <translatorcomment>-</translatorcomment>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="vanished">Editer</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">Ajouter</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">Effacer</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="68"/>
-        <source>-</source>
-        <translatorcomment>-</translatorcomment>
-        <translation>-</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="69"/>
-        <source>Edit</source>
-        <translation>Editer</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="74"/>
-        <source>Add</source>
-        <translation>Ajouter</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="75"/>
-        <source>Delete</source>
-        <translation>Effacer</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="86"/>
         <source>Service</source>
         <translation>Service</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="87"/>
+        <location filename="../../Gui/AthletePages.cpp" line="69"/>
         <source>Description</source>
         <translation>Description</translation>
     </message>
@@ -8320,7 +8282,7 @@ Voulez-vous appliquer les changements et redémarrer GoldenCheetah?</translation
 <context>
     <name>DataFilterEdit</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2743"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2712"/>
         <source>Warning: sample() is slow -- update code to use samples()</source>
         <translation>Avertissement : sample() est lent -- mettre à jour le code pour utiliser sample()</translation>
     </message>
@@ -8677,7 +8639,7 @@ Voulez-vous appliquer les changements et redémarrer GoldenCheetah?</translation
 <context>
     <name>DirectoryPathWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="277"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="308"/>
         <source>Browse</source>
         <translation type="unfinished">Parcourir</translation>
     </message>
@@ -8915,28 +8877,28 @@ Vous devez peut-être (ré)installer le driver FTDI ou PL2303 avant de télécha
 <context>
     <name>Dropbox</name>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="68"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="77"/>
         <source>Problem accessing Dropbox data</source>
         <translation>Problème d&apos;accès aux données Dropbox</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="130"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="139"/>
         <source>You must authorise with Dropbox first</source>
         <translation>Vous devez d&apos;abord autoriser GC à accéder à Dropbox</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="205"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="214"/>
         <source>Parsing Error: %1</source>
         <translation>Erreur de parsing:%1</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="293"/>
-        <location filename="../../Cloud/Dropbox.cpp" line="312"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="302"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="321"/>
         <source>Completed.</source>
         <translation>Terminé.</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="297"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="306"/>
         <source>Network Error - Upload failed.</source>
         <translation>Problème de connexion - échec de l&apos;envoi.</translation>
     </message>
@@ -9081,136 +9043,136 @@ Vous devez peut-être (ré)installer le driver FTDI ou PL2303 avant de télécha
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2064"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2033"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2034"/>
         <source>Axis Label / Units</source>
         <translation>Etiquette / unité de l&apos;axe</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1558"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1527"/>
         <source>Estimate %1 %2 Power</source>
         <translation>Estimation %1 %2 Puissance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1562"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1531"/>
         <source>Endurance Index</source>
         <translation>Index d&apos;endurance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1532"/>
         <source>Vo2Max Estimate</source>
         <translation>Estimation de VO2Max</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1597"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1566"/>
         <source>Curve Settings</source>
         <translation>Configuration de la courbe</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1605"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1574"/>
         <source>Metric</source>
         <translation>Métriques</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1606"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1575"/>
         <source>Best</source>
         <translation>Records</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1607"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1576"/>
         <source>Estimate</source>
         <translation>Estimation</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1577"/>
         <source>PMC</source>
         <translation>PMC</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1609"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1578"/>
         <source>Formula</source>
         <translation>Formule</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1610"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1579"/>
         <source>Measure</source>
         <translation>Mesure</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1611"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1580"/>
         <source>Performance</source>
         <translation>Performance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1612"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1581"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1684"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1767"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1653"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1736"/>
         <source>seconds</source>
         <translation>secondes</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1685"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1768"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1737"/>
         <source>minutes</source>
         <translation>minutes</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1769"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1655"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1738"/>
         <source>hours</source>
         <translation>heures</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1723"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1816"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1692"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1785"/>
         <source>Peak</source>
         <translation>Pic</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1781"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1750"/>
         <source>Absolute</source>
         <translation>Absolu</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1751"/>
         <source>Per Kilogram</source>
         <translation>Par kilogramme</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1813"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
         <source>Total</source>
         <translation>Total</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1814"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1783"/>
         <source>Running Total</source>
         <translation>Total pour la course</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1815"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1784"/>
         <source>Average</source>
         <translation>Moyenne</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1817"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1786"/>
         <source>Low</source>
         <translation>Minimum</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1820"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1789"/>
         <source>Aggregate:</source>
         <translation>Agrégat:</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1828"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1797"/>
         <source># type in a formula to use
 # for e.g. BikeStress / Duration
 # as you type the available metrics
@@ -9223,295 +9185,295 @@ Vous devez peut-être (ré)installer le driver FTDI ou PL2303 avant de télécha
 </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1839"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1808"/>
         <source>Weekly Best Performances</source>
         <translation>Meilleures performances hebdomadaires</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1840"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1809"/>
         <source>Submaximal Weekly Best</source>
         <translation>Performances hebdomadaires sous maximales</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1841"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1810"/>
         <source>Performance Tests</source>
         <translation>Tests de performance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1933"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1902"/>
         <source>Short Term Stress (STS/ATL)</source>
         <translation>Charge à court terme (STS/ATL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1934"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1903"/>
         <source>Long Term Stress  (LTS/CTL)</source>
         <translation>Charge à long terme (LTS/CTL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1935"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1904"/>
         <source>Stress Balance    (SB/TSB)</source>
         <translation>Equilibre de charge    (SB/TSB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1936"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1905"/>
         <source>Stress Ramp Rate  (RR)</source>
         <translation>Rampe de charge  (RR)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1944"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1913"/>
         <source>Stress Type</source>
         <translation>Type de charge</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1949"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1918"/>
         <source>Negative Training Effect (NTE)</source>
         <translation>Effet d&apos;entraînement négatif (NTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1950"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1919"/>
         <source>Positive Training Effect (PTE)</source>
         <translation>Effet d&apos;entraînement positif (PTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1951"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1920"/>
         <source>Performance (Power Index)</source>
         <translation>Performance (Power Index)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1952"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1921"/>
         <source>Predicted CP (Watts)</source>
         <translation>CP prévue (Watts)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1969"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1938"/>
         <source>Curve Type</source>
         <translation>Type de courbe</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1945"/>
         <source>Perf. Metric</source>
         <translation>Perf. Métrique</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2006"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1975"/>
         <source>Metadata Field</source>
         <translation>Champ de métadonnées</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2007"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
         <source>PMC metric</source>
         <translation>Métrique PMC</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2032"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2001"/>
         <source>Measure Group</source>
         <translation>Groupe de mesure</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2009"/>
         <source>Measure Field</source>
         <translation>Champ de mesure</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2029"/>
         <source>Filter</source>
         <translation>Filtre</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2071"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
         <source>Style</source>
         <translation>Style</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2042"/>
         <source>Bar</source>
         <translation>Barre</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2074"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2043"/>
         <source>Line</source>
         <translation>Ligne</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2075"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2044"/>
         <source>Sticks</source>
         <translation>Barre</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2076"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2045"/>
         <source>Dots</source>
         <translation>Points</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2048"/>
         <source>Stack</source>
         <translation>Empile courbes &quot;Barre&quot;</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2053"/>
         <source>Symbol</source>
         <translation>Symbole</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2086"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2055"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2087"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2056"/>
         <source>Circle</source>
         <translation>Cercle</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2057"/>
         <source>Square</source>
         <translation>Carré</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2089"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2058"/>
         <source>Diamond</source>
         <translation>Diamant</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2090"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2059"/>
         <source>Triangle</source>
         <translation>Triangle</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2091"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
         <source>Cross</source>
         <translation>Croix</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2092"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2061"/>
         <source>Hexagon</source>
         <translation>Hexagone</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2062"/>
         <source>Star</source>
         <translation>Etoile</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
         <source>Color</source>
         <translation>Couleur</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2100"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2069"/>
         <source>Fill curve</source>
         <translation>Remplir les courbes</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
         <source>Data labels</source>
         <translation>Etiquettes</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2080"/>
         <source>Highlight Highest</source>
         <translation>Surligner les maximums</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
         <source>Highlight Lowest</source>
         <translation>Surligner les minimums</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2127"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
         <source>Highlight Outliers</source>
         <translation>Montrer les valeurs aberrantes</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2135"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
         <source>Baseline</source>
         <translatorcomment>useful with fill curve (only?)</translatorcomment>
         <translation>Ligne de base</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2143"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2112"/>
         <source>Smooth Curve</source>
         <translation>Lisser la courbe</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2147"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2116"/>
         <source>No trend Line</source>
         <translation>Pas de ligne de tendance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2148"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2117"/>
         <source>Linear Trend</source>
         <translation>Tendance linéaire</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2149"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2118"/>
         <source>Quadratic Trend</source>
         <translation>Tendance quadratique</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2150"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
         <source>Moving Average</source>
         <translation>Moyenne mobile</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2151"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2120"/>
         <source>Simple Average</source>
         <translation>Moyenne simple</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2123"/>
         <source>Ignore Zeros</source>
         <translation>Ignorer les zéros</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2168"/>
         <source>&amp;OK</source>
         <translatorcomment>Alt accelerator does not seem to work here</translatorcomment>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2201"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2170"/>
         <source>&amp;Cancel</source>
         <translatorcomment>Alt accelerator does not seem to work here</translatorcomment>
         <translation>&amp;Annuler</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2431"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2400"/>
         <source>Peak %1</source>
         <translation>Pic %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2402"/>
         <source> second </source>
         <translation> seconde </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2434"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2403"/>
         <source> minute </source>
         <translation> minute </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2436"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2405"/>
         <source> hour </source>
         <translation> heure </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2456"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2425"/>
         <source>%1 - %2</source>
         <translation>%1 - %2</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2470"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2439"/>
         <source>Performances</source>
         <translation>Performances</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2471"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2440"/>
         <source>Power Index</source>
         <translation>Power Index</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2588"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2557"/>
         <source>Performances_%1_%2_%3</source>
         <translation>Performances_%1_%2_%3</translation>
     </message>
@@ -9841,93 +9803,93 @@ Vous devez peut-être (ré)installer le driver FTDI ou PL2303 avant de télécha
 <context>
     <name>EditUserAxisDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1731"/>
+        <location filename="../../Charts/UserChart.cpp" line="1689"/>
         <source>Edit Axis</source>
         <translation>Modifier l&apos;axe</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1741"/>
+        <location filename="../../Charts/UserChart.cpp" line="1699"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1742"/>
+        <location filename="../../Charts/UserChart.cpp" line="1700"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Annuler</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1750"/>
+        <location filename="../../Charts/UserChart.cpp" line="1708"/>
         <source>Units</source>
         <translation>Unités</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1760"/>
+        <location filename="../../Charts/UserChart.cpp" line="1718"/>
         <source>Logarithmic Scale</source>
         <translation>Échelle logarithmique</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1757"/>
+        <location filename="../../Charts/UserChart.cpp" line="1715"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1761"/>
-        <location filename="../../Charts/UserChart.cpp" line="1780"/>
+        <location filename="../../Charts/UserChart.cpp" line="1719"/>
+        <location filename="../../Charts/UserChart.cpp" line="1738"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1763"/>
+        <location filename="../../Charts/UserChart.cpp" line="1721"/>
         <source>Fixed</source>
         <translation>Fixe</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1774"/>
+        <location filename="../../Charts/UserChart.cpp" line="1732"/>
         <source> from </source>
         <translation> de </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1776"/>
+        <location filename="../../Charts/UserChart.cpp" line="1734"/>
         <source> to </source>
         <translation> à </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1779"/>
+        <location filename="../../Charts/UserChart.cpp" line="1737"/>
         <source>Range</source>
         <translation>Intervalle</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1787"/>
+        <location filename="../../Charts/UserChart.cpp" line="1745"/>
         <source>Smoothing</source>
         <translation>Lissage</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1792"/>
+        <location filename="../../Charts/UserChart.cpp" line="1750"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1793"/>
+        <location filename="../../Charts/UserChart.cpp" line="1751"/>
         <source>Day</source>
         <translation>Jour</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1794"/>
+        <location filename="../../Charts/UserChart.cpp" line="1752"/>
         <source>Week</source>
         <translation>Semaine</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1795"/>
+        <location filename="../../Charts/UserChart.cpp" line="1753"/>
         <source>Month</source>
         <translation>Mois</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1796"/>
+        <location filename="../../Charts/UserChart.cpp" line="1754"/>
         <source>Year</source>
         <translation>Année</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1798"/>
+        <location filename="../../Charts/UserChart.cpp" line="1756"/>
         <source>Group By</source>
         <translation>Grouper par</translation>
     </message>
@@ -10131,160 +10093,160 @@ Vous devez peut-être (ré)installer le driver FTDI ou PL2303 avant de télécha
 <context>
     <name>EditUserSeriesDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1398"/>
+        <location filename="../../Charts/UserChart.cpp" line="1356"/>
         <source>Edit Data Series</source>
         <translation>Modifier la série de données</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1414"/>
+        <location filename="../../Charts/UserChart.cpp" line="1372"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1415"/>
+        <location filename="../../Charts/UserChart.cpp" line="1373"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Annuler</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1422"/>
+        <location filename="../../Charts/UserChart.cpp" line="1380"/>
         <source>Group</source>
         <translation>Groupe</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1430"/>
+        <location filename="../../Charts/UserChart.cpp" line="1388"/>
         <source>Series Name</source>
         <translation>Nom de la série</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1519"/>
+        <location filename="../../Charts/UserChart.cpp" line="1477"/>
         <source>Y units</source>
         <translation>Unités axe Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1524"/>
+        <location filename="../../Charts/UserChart.cpp" line="1482"/>
         <source>X units</source>
         <translation>Unités axe X</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1528"/>
+        <location filename="../../Charts/UserChart.cpp" line="1486"/>
         <source>Sum</source>
         <translation>Somme</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1529"/>
+        <location filename="../../Charts/UserChart.cpp" line="1487"/>
         <source>Average</source>
         <translation>Moyenne</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1530"/>
+        <location filename="../../Charts/UserChart.cpp" line="1488"/>
         <source>Peak</source>
         <translation>Maximum</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1531"/>
+        <location filename="../../Charts/UserChart.cpp" line="1489"/>
         <source>Low</source>
         <translation>Minimum</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1532"/>
+        <location filename="../../Charts/UserChart.cpp" line="1490"/>
         <source>Running Total</source>
         <translation>Total intermédiaire</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1533"/>
+        <location filename="../../Charts/UserChart.cpp" line="1491"/>
         <source>Mean Square Root</source>
         <translatorcomment>Or should it be Root Mean Square ?</translatorcomment>
         <translation>Moyenne quadratique</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1534"/>
+        <location filename="../../Charts/UserChart.cpp" line="1492"/>
         <source>Std Deviation</source>
         <translation>Ecart type</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1537"/>
+        <location filename="../../Charts/UserChart.cpp" line="1495"/>
         <source>Aggregate</source>
         <translatorcomment>have not managed to translate</translatorcomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1541"/>
-        <location filename="../../Charts/UserChart.cpp" line="1557"/>
+        <location filename="../../Charts/UserChart.cpp" line="1499"/>
+        <location filename="../../Charts/UserChart.cpp" line="1515"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1542"/>
+        <location filename="../../Charts/UserChart.cpp" line="1500"/>
         <source>Solid</source>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1543"/>
+        <location filename="../../Charts/UserChart.cpp" line="1501"/>
         <source>Dashed</source>
         <translation>Trait en pointillé</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1544"/>
+        <location filename="../../Charts/UserChart.cpp" line="1502"/>
         <source>Dot</source>
         <translation>Point</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1545"/>
+        <location filename="../../Charts/UserChart.cpp" line="1503"/>
         <source>Dash Dot</source>
         <translation>Trait Point</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1546"/>
+        <location filename="../../Charts/UserChart.cpp" line="1504"/>
         <source>Fast Graphics</source>
         <translation>Graphiques rapides</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1547"/>
+        <location filename="../../Charts/UserChart.cpp" line="1505"/>
         <source>Show on Legend</source>
         <translation>Montrer la légende</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1548"/>
+        <location filename="../../Charts/UserChart.cpp" line="1506"/>
         <source>Show Data Labels</source>
         <translation>Afficher les étiquettes de données</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1554"/>
+        <location filename="../../Charts/UserChart.cpp" line="1512"/>
         <source>Line Style</source>
         <translation>Style de ligne</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1558"/>
+        <location filename="../../Charts/UserChart.cpp" line="1516"/>
         <source>Circle</source>
         <translation>Cercle</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1559"/>
+        <location filename="../../Charts/UserChart.cpp" line="1517"/>
         <source>Rectangle</source>
         <translation>Rectangle</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1564"/>
+        <location filename="../../Charts/UserChart.cpp" line="1522"/>
         <source>Symbol</source>
         <translation>Symbole</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1572"/>
+        <location filename="../../Charts/UserChart.cpp" line="1530"/>
         <source>Color</source>
         <translation>Couleur</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1575"/>
+        <location filename="../../Charts/UserChart.cpp" line="1533"/>
         <source>Fill curve</source>
         <translation>Remplir les courbes</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1583"/>
+        <location filename="../../Charts/UserChart.cpp" line="1541"/>
         <source>Opacity (%)</source>
         <translation>Opacité (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1589"/>
+        <location filename="../../Charts/UserChart.cpp" line="1547"/>
         <source>Size/Width</source>
         <translation>Taille/largeur</translation>
     </message>
@@ -10331,6 +10293,24 @@ Vous devez peut-être (ré)installer le driver FTDI ou PL2303 avant de télécha
         <location filename="../../Metrics/BasicRideMetrics.cpp" line="144"/>
         <source>Only useful for intervals, time the interval started</source>
         <translation>Utile uniquement pour les intervalles, heure à laquelle l&apos;intervalle a commencé</translation>
+    </message>
+</context>
+<context>
+    <name>ElevationChartWindow</name>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="221"/>
+        <source>Profile Distance (m)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="229"/>
+        <source>Seconds for delta slope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="237"/>
+        <source>Elevation window size (%) relative to current altitude</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10856,7 +10836,7 @@ Vous devez peut-être (ré)installer le driver FTDI ou PL2303 avant de télécha
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ExhaustionDialog.cpp" line="160"/>
+        <location filename="../../Charts/ExhaustionDialog.cpp" line="162"/>
         <source>Time</source>
         <translation>Temps</translation>
     </message>
@@ -13532,44 +13512,44 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
 <context>
     <name>GcCrashDialog</name>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="78"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="74"/>
         <source>%1 Crash Recovery</source>
         <translation>%1 Récupération après crash</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="116"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="112"/>
         <source>&lt;b&gt;GoldenCheetah appears to have PREVIOUSLY crashed for this athlete. &lt;/b&gt;&lt;br&gt;&lt;br&gt;The report below gives some diagnostic information that will be useful to the developers. Feel free to post this with a short description of what was occurring when the crash happened to the &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah forums&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;We respect privacy - this log does NOT contain ids, passwords or personal information.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;When this dialog is closed the athlete will be opened.&lt;/b&gt;</source>
         <translation>&lt;b&gt;GoldenCheetah semble ne pas s&apos;être correctement fermé la dernière fois, pour cet athlète. &lt;/b&gt;&lt;br&gt;&lt;br&gt;Le rapport ci-dessous donne quelques informations utiles au développeurs. N&apos;hésitez pas à poster ce rapport avec une courte description de ce qui s&apos;est passé lors du problème sur le &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;forum GoldenCheetah&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;Nous respectons la vie privée - ce log ne contient pas d&apos;identifiant, mot de passe ou d&apos;information personnelle.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;A la fermeture de cette boîte de dialogue, l&apos;athlète sera ouvert.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="141"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="137"/>
         <source>Save Crash Report...</source>
         <translation>Enregistrer le rapport d&apos;erreur...</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="143"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="139"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="225"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="221"/>
         <source>&lt;p&gt;Build date: %1 %2&lt;br&gt;Build id: %3&lt;br&gt;Version: %4&lt;br&gt;DB Schema: %5&lt;br&gt;Metrics: %7&lt;br&gt;OS: %6&lt;br&gt;OpenGL: %10&lt;br&gt;UI: dpi scale (%8) font size (%9)&lt;br&gt;</source>
         <translatorcomment>no need to translate</translatorcomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="255"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="251"/>
         <source>&lt;table&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QT&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QWT&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;%3&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SRMIO&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;D2XX&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;ICAL&lt;/td&gt;&lt;td&gt;%9&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;USBXPRESS&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LIBUSB&lt;/td&gt;&lt;td&gt;%11&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VLC&lt;/td&gt;&lt;td&gt;%12&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VIDEO&lt;/td&gt;&lt;td&gt;%13&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SAMPLERATE&lt;/td&gt;&lt;td&gt;%14&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SSL&lt;/td&gt;&lt;td&gt;%15&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;R&lt;/td&gt;&lt;td&gt;%16&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;Python&lt;/td&gt;&lt;td&gt;%18&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LMFIT&lt;/td&gt;&lt;td&gt;7.0&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;GSL&lt;/td&gt;&lt;td&gt;%19&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</source>
         <translatorcomment>no need to translate</translatorcomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Save Diagnostics</source>
         <translation>Enregistrer les diagnostics</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Text File (*.txt)</source>
         <translation>Fichier texte (*.txt)</translation>
     </message>
@@ -13906,167 +13886,172 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
 <context>
     <name>GcWindowRegistry</name>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
         <source>Performance</source>
         <translation>Performance</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="89"/>
         <source>Histogram</source>
         <translation>Histogramme</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
         <source>Distribution</source>
         <translation>Distribution</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
         <source>Pedal Force vs Velocity</source>
         <translation>Force sur la pédale / vélocité</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
         <source>Heartrate vs Power</source>
         <translation>FC / Puissance</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
         <source>Python Chart</source>
         <translation>Graph Python</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
         <source>Python Chart </source>
         <translation>Graph Python </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="113"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
         <source>Live Map</source>
         <translation>Carte Live</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="114"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <source>Elevation Chart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
         <source>Web page</source>
         <translation>Page Web</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="101"/>
         <source>Calendar</source>
         <translation>Calendrier</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
         <source>Navigator</source>
         <translation>Navigateur</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="71"/>
         <source>Season Overview</source>
         <translation>Aperçu de la saison</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="72"/>
         <source>Blank Overview </source>
         <translation>Aperçu vierge </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="76"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="73"/>
         <source>User Chart</source>
         <translation>Graphique de l&apos;utilisateur</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
         <source>Trends</source>
         <translation>Tendances</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="78"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
         <source>TreeMap</source>
         <translation>Arborescence</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
         <source>Power Duration </source>
         <translation>Durée de puissance </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="83"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
         <source>Activity Overview</source>
         <translation>Aperçu de l&apos;activité</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="81"/>
         <source>Blank Overview</source>
         <translation>Aperçu vierge</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="85"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="82"/>
         <source>User Chart </source>
         <translation>Graphique de l&apos;utilisateur </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
         <source>Data</source>
         <translation>Données</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="88"/>
         <source>Power Duration</source>
         <translation>Durée de puissance</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
         <source>Scatter</source>
         <translation>Dispersion</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="103"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
         <source>Aerolab</source>
         <translation>Aérolab</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
         <source>Telemetry</source>
         <translation>Télémétrie</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
         <source>Workout</source>
         <translation>Entraînement</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="106"/>
         <source>Realtime</source>
         <translation>Temps réel</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
         <source>Pedal Stroke</source>
         <translation>Coup de pédale</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
         <source>Map</source>
         <translation>Carte</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
         <source>R Chart</source>
         <translation>Graphique R</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="98"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
         <source>R Chart </source>
         <translation>Graphique R </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
         <source>Video Player</source>
         <translation>Lecteur vidéo</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
         <source>Workout Editor</source>
         <translation>Editeur d&apos;entraînement</translation>
     </message>
@@ -15008,37 +14993,37 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
         <translation>Graphe 3D configurable pour l&apos;activité courante</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="296"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
         <source>Predefined and configurable set of data ranges for selection of activities to be analysed</source>
         <translation>Plages de données, prédéfinies ou configurable, pour la sélection des activités à analyser</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
         <source>Powerful filter and search engine to determine the activities which are considered in diagram</source>
         <translation>Filtre et moteur de recherche afin de déterminer les activités utilisées dans les diagrammes</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
         <source>Configurable list of activities</source>
         <translation>Listes d&apos;activités configurable</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="327"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
         <source>Entry field for sophisticated Searching and Filtering of activities</source>
         <translation>Champ de saisie pour la recherche et filtrage des activités</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
         <source>Adding intervals to an activity using simple query methods</source>
         <translation>Ajouter des intervalles à une activité par méthode simplifiée</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <source>Automatic Interval Detection</source>
         <translation>Détection automatique d&apos;intervalles</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
         <source>Definition of coloring rules for activities</source>
         <translation>Définir les règles de coloration des activités</translation>
     </message>
@@ -15162,8 +15147,8 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
     </message>
     <message>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="219"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
         <source>Calendar</source>
         <translation>Calendrier</translation>
     </message>
@@ -15268,182 +15253,187 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
         <translation>Affichage en temps réel de l&apos;itinéraire des séances d&apos;entraînement de simulation dans Open Street Map</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="294"/>
+        <source>Show elevation profile of instant position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
         <source>Definition of points in time &apos;Events&apos; which are marked explicitely on time related diagrams</source>
         <translation>Définition de dates d&apos;événements qui seront affichées explicitement sur ​​les diagrammes en rapport avec le temps</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="316"/>
         <source>Simple summary view</source>
         <translation>Vue résumé simple</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
         <source>Alternative access to the charts created for the main view</source>
         <translation>Accès alternatif aux diagrammes créés pour la vue principale</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
         <source>Display the available and add new intervals using simple query methods</source>
         <translation>Afficher la disposition et ajouter de nouveaux intervalles en utilisant des méthodes de requêtes simples</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="317"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
         <source>Configurable list of training devices</source>
         <translation>Liste configurable des appareils d&apos;entraînement</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
         <source>Configurable list of workout files</source>
         <translation>Liste configurable des fichiers d&apos;entraînement</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
         <source>Configurable list of video files</source>
         <translation>Liste configurable des fichiers vidéo</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="325"/>
         <source>Configurable list of video sync files</source>
         <translation>Liste configurable des fichiers de synchronisation vidéo</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
         <source>To compare Activities/Intervals in Activity View and Date Ranges in Trends View</source>
         <translation>Pour comparer les activités/intervalles dans la vue des activités et les plages de dates dans la vue des tendances</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="335"/>
         <source>Workout Control, Intensity Adjustments and Notifications Display</source>
         <translation>Contrôle de l&apos;entraînement, réglages de l&apos;intensité et affichage des notifications</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
         <source>Athlete Model</source>
         <translation>Modèle d&apos;athlète</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
         <source>Athlete Measures</source>
         <translation>Mesures de l&apos;athlète</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
         <source>Auto Import</source>
         <translation>Importation automatique</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
         <source>Backup</source>
         <translation>Sauvegarde</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="355"/>
         <source>Cloud Accounts</source>
         <translation>Comptes Cloud</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="356"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
         <source>General</source>
         <translation>Général</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
         <source>Metrics shown in &apos;Intervals&apos; and &apos;Summary&apos;</source>
         <translatorcomment>Not observed in GUI just translated at &quot;face value&quot;</translatorcomment>
         <translation>Métriques affichées dans &quot;Intervalles&quot; et &quot;Résumé&quot;</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
         <source>User/Custom Metrics</source>
         <translatorcomment>Not observed in GUI just translated at &quot;face value&quot;</translatorcomment>
         <translation>Métriques utilisateur/personnalisées</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
         <source>Create or Edit a User Metric</source>
         <translatorcomment>Not observed in GUI just translated at &quot;face value&quot;</translatorcomment>
         <translation>Créer ou editer une métrique utilisateur</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
         <source>Measures</source>
         <translation>Mesures</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
         <source>Train View devices configuration and preferences</source>
         <translation>Configuration et préférences des appareils de la vue d&apos;entraînement</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
         <source>Train View Preferences</source>
         <translation>Préférences de la vue d&apos;entraînement</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
         <source>Remote Controls Configuration</source>
         <translation>Configuration des commandes</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
         <source>Add/Remove Train Devices</source>
         <translation>Ajouter/supprimer des dispositifs d&apos;entraînement</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
         <source>Add Train Devices</source>
         <translation>Ajouter des appareils d&apos;entraînement</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="394"/>
         <source>Virtual Bicycle configuration for simulation rides</source>
         <translation>Configuration du vélo virtuel pour les tours de simulation</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="337"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
         <source>Athlete</source>
         <translation>Athlète</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
         <source>Training Zone definition for power</source>
         <translation>Définition des zones d&apos;entraînement pour la puissance</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
         <source>Training Zone definition for heartrate</source>
         <translation>Définition des zones d&apos;entraînement pour la fréquence cardiaque</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
         <source>Training Zone definition for Swim and Run</source>
         <translation>Définition des zones d&apos;entraînement pour la natation et la course</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
         <source>Appearance</source>
         <translation>Apparence</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="364"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
         <source>Data Fields</source>
         <translation>Champs de données</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
         <source>Definition of default value(s) for data fields</source>
         <translation>Définition des valeurs par défaut pour les champs de données</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
         <source>Definition of processing default parameters for the fix, adjust,... tools</source>
         <translation>Définition des paramètres pour les processus automatiques des outils d&apos;ajustement et correction</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
         <source>Metrics</source>
         <translation>Métriques</translation>
     </message>
@@ -15643,49 +15633,45 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2437"/>
         <source>Add</source>
-        <translation>Ajouter</translation>
+        <translation type="vanished">Ajouter</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2438"/>
         <source>Delete</source>
-        <translation>Effacer</translation>
+        <translation type="vanished">Effacer</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2431"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2432"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2447"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2332"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2458"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2343"/>
         <source>Short</source>
         <translatorcomment>As observed in GUI</translatorcomment>
         <translation>Zone</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2459"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2344"/>
         <source>Long</source>
         <translatorcomment>As observed in GUI</translatorcomment>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2460"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2345"/>
         <source>Percent of LT</source>
         <translation>Pourcentage du seuil</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2461"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2346"/>
         <source>Trimp k</source>
         <translation>TRIMP k</translation>
     </message>
@@ -15694,14 +15680,14 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
         <translation type="vanished">Maximum de 10 zones atteint.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2506"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2513"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2390"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2397"/>
         <source>New</source>
         <translation>Nouveau</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2508"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2515"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2392"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2399"/>
         <source>New (%1)</source>
         <translation>Nouveau (%1)</translation>
     </message>
@@ -15891,17 +15877,17 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2245"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2395"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2292"/>
         <source>Lactate Threshold</source>
         <translation>Seuil lactique</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2396"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2293"/>
         <source>Default</source>
         <translation>Défaut</translation>
     </message>
@@ -18054,547 +18040,544 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
 <context>
     <name>LTMTool</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1303"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1272"/>
         <source>Metric</source>
         <translation>Métrique</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="74"/>
+        <location filename="../../Charts/LTMTool.cpp" line="75"/>
         <source>Filter</source>
         <translation>Filtre</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="80"/>
+        <location filename="../../Charts/LTMTool.cpp" line="81"/>
         <source>Date range</source>
         <translation>Plage de dates</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="84"/>
+        <location filename="../../Charts/LTMTool.cpp" line="85"/>
         <source>Days</source>
         <translation>Jours</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="85"/>
+        <location filename="../../Charts/LTMTool.cpp" line="86"/>
         <source>Weeks</source>
         <translation>Semaines</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="86"/>
+        <location filename="../../Charts/LTMTool.cpp" line="87"/>
         <source>Months</source>
         <translation>Mois</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="87"/>
+        <location filename="../../Charts/LTMTool.cpp" line="88"/>
         <source>Years</source>
         <translation>Années</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="88"/>
+        <location filename="../../Charts/LTMTool.cpp" line="89"/>
         <source>Time Of Day</source>
         <translation>Heure de la journée</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="89"/>
+        <location filename="../../Charts/LTMTool.cpp" line="90"/>
         <source>All</source>
         <translation>Tous</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="91"/>
+        <location filename="../../Charts/LTMTool.cpp" line="92"/>
         <source>Group by</source>
         <translation>Grouper par</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="94"/>
+        <location filename="../../Charts/LTMTool.cpp" line="95"/>
         <source>Data Table</source>
         <translation>Table de données</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="98"/>
+        <location filename="../../Charts/LTMTool.cpp" line="99"/>
         <source>Show Stack</source>
         <translatorcomment>As observed in GUI</translatorcomment>
         <translation>Diagrammes empilés (superposés sinon)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="102"/>
+        <location filename="../../Charts/LTMTool.cpp" line="103"/>
         <source>Shade Zones</source>
         <translation>Ombrer les zones</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="105"/>
+        <location filename="../../Charts/LTMTool.cpp" line="106"/>
         <source>Show Legend</source>
         <translation>Montrer la légende</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="109"/>
         <source>Show Events</source>
         <translation>Montrer les évènements</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="121"/>
+        <location filename="../../Charts/LTMTool.cpp" line="122"/>
         <source>Stack Zoom</source>
         <translatorcomment>As observed in GUI</translatorcomment>
         <translation>Taille des diagrammes empilés</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="155"/>
+        <location filename="../../Charts/LTMTool.cpp" line="156"/>
         <source>Add Current</source>
         <translation>Ajouter le courant</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="146"/>
+        <location filename="../../Charts/LTMTool.cpp" line="147"/>
         <source>Charts</source>
         <translation>Graphiques</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="112"/>
         <source>Show Banister Helper</source>
         <translation>Montrer l&apos;aide Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="155"/>
         <source>Apply</source>
         <translation>Appliquer</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Up</source>
-        <translation>Vers le haut</translation>
+        <translation type="vanished">Vers le haut</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Down</source>
-        <translation>Vers le bas</translation>
+        <translation type="vanished">Vers le bas</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="351"/>
+        <location filename="../../Charts/LTMTool.cpp" line="325"/>
         <source>Skiba Long Term Stress</source>
         <translation>LTS -charge à long terme selon Skiba</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="353"/>
-        <location filename="../../Charts/LTMTool.cpp" line="368"/>
-        <location filename="../../Charts/LTMTool.cpp" line="429"/>
-        <location filename="../../Charts/LTMTool.cpp" line="444"/>
-        <location filename="../../Charts/LTMTool.cpp" line="505"/>
-        <location filename="../../Charts/LTMTool.cpp" line="520"/>
-        <location filename="../../Charts/LTMTool.cpp" line="580"/>
-        <location filename="../../Charts/LTMTool.cpp" line="595"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1080"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1095"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1156"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1171"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1309"/>
+        <location filename="../../Charts/LTMTool.cpp" line="327"/>
+        <location filename="../../Charts/LTMTool.cpp" line="342"/>
+        <location filename="../../Charts/LTMTool.cpp" line="403"/>
+        <location filename="../../Charts/LTMTool.cpp" line="418"/>
+        <location filename="../../Charts/LTMTool.cpp" line="479"/>
+        <location filename="../../Charts/LTMTool.cpp" line="494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="554"/>
+        <location filename="../../Charts/LTMTool.cpp" line="569"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1054"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1069"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1130"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1145"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1278"/>
         <source>Stress</source>
         <translation>Charge</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="366"/>
+        <location filename="../../Charts/LTMTool.cpp" line="340"/>
         <source>Skiba Short Term Stress</source>
         <translation>Charge à court terme selon Skiba</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="381"/>
+        <location filename="../../Charts/LTMTool.cpp" line="355"/>
         <source>Skiba Stress Balance</source>
         <translation>Equilibre de charge selon Skiba</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="383"/>
-        <location filename="../../Charts/LTMTool.cpp" line="459"/>
-        <location filename="../../Charts/LTMTool.cpp" line="535"/>
-        <location filename="../../Charts/LTMTool.cpp" line="610"/>
-        <location filename="../../Charts/LTMTool.cpp" line="686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="762"/>
-        <location filename="../../Charts/LTMTool.cpp" line="838"/>
-        <location filename="../../Charts/LTMTool.cpp" line="914"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1110"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1186"/>
+        <location filename="../../Charts/LTMTool.cpp" line="357"/>
+        <location filename="../../Charts/LTMTool.cpp" line="433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="509"/>
+        <location filename="../../Charts/LTMTool.cpp" line="584"/>
+        <location filename="../../Charts/LTMTool.cpp" line="660"/>
+        <location filename="../../Charts/LTMTool.cpp" line="736"/>
+        <location filename="../../Charts/LTMTool.cpp" line="812"/>
+        <location filename="../../Charts/LTMTool.cpp" line="888"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1160"/>
         <source>Stress Balance</source>
         <translation>Equilibre de charge</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="396"/>
+        <location filename="../../Charts/LTMTool.cpp" line="370"/>
         <source>Skiba STS Ramp</source>
         <translation>Rampe STS selon Skiba</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="398"/>
-        <location filename="../../Charts/LTMTool.cpp" line="413"/>
-        <location filename="../../Charts/LTMTool.cpp" line="474"/>
-        <location filename="../../Charts/LTMTool.cpp" line="489"/>
-        <location filename="../../Charts/LTMTool.cpp" line="550"/>
-        <location filename="../../Charts/LTMTool.cpp" line="565"/>
-        <location filename="../../Charts/LTMTool.cpp" line="625"/>
-        <location filename="../../Charts/LTMTool.cpp" line="640"/>
-        <location filename="../../Charts/LTMTool.cpp" line="701"/>
-        <location filename="../../Charts/LTMTool.cpp" line="716"/>
-        <location filename="../../Charts/LTMTool.cpp" line="777"/>
-        <location filename="../../Charts/LTMTool.cpp" line="792"/>
-        <location filename="../../Charts/LTMTool.cpp" line="853"/>
-        <location filename="../../Charts/LTMTool.cpp" line="868"/>
-        <location filename="../../Charts/LTMTool.cpp" line="929"/>
-        <location filename="../../Charts/LTMTool.cpp" line="944"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1005"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1020"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1125"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1140"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1201"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1216"/>
+        <location filename="../../Charts/LTMTool.cpp" line="372"/>
+        <location filename="../../Charts/LTMTool.cpp" line="387"/>
+        <location filename="../../Charts/LTMTool.cpp" line="448"/>
+        <location filename="../../Charts/LTMTool.cpp" line="463"/>
+        <location filename="../../Charts/LTMTool.cpp" line="524"/>
+        <location filename="../../Charts/LTMTool.cpp" line="539"/>
+        <location filename="../../Charts/LTMTool.cpp" line="599"/>
+        <location filename="../../Charts/LTMTool.cpp" line="614"/>
+        <location filename="../../Charts/LTMTool.cpp" line="675"/>
+        <location filename="../../Charts/LTMTool.cpp" line="690"/>
+        <location filename="../../Charts/LTMTool.cpp" line="751"/>
+        <location filename="../../Charts/LTMTool.cpp" line="766"/>
+        <location filename="../../Charts/LTMTool.cpp" line="827"/>
+        <location filename="../../Charts/LTMTool.cpp" line="842"/>
+        <location filename="../../Charts/LTMTool.cpp" line="903"/>
+        <location filename="../../Charts/LTMTool.cpp" line="918"/>
+        <location filename="../../Charts/LTMTool.cpp" line="979"/>
+        <location filename="../../Charts/LTMTool.cpp" line="994"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1099"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1114"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1175"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1190"/>
         <source>Ramp</source>
         <translation>Pente</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="411"/>
+        <location filename="../../Charts/LTMTool.cpp" line="385"/>
         <source>Skiba LTS Ramp</source>
         <translation>Rampe LTS selon Skiba</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="427"/>
+        <location filename="../../Charts/LTMTool.cpp" line="401"/>
         <source>Aerobic TISS Long Term Stress</source>
         <translation>LTS Charge à long terme selon aérobic TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="442"/>
+        <location filename="../../Charts/LTMTool.cpp" line="416"/>
         <source>Aerobic TISS Short Term Stress</source>
         <translation>STS Charge à court terme selon aérobic TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="457"/>
+        <location filename="../../Charts/LTMTool.cpp" line="431"/>
         <source>Aerobic TISS Stress Balance</source>
         <translation>TSB Equilibre de charge selon aérobic TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="472"/>
+        <location filename="../../Charts/LTMTool.cpp" line="446"/>
         <source>Aerobic TISS STS Ramp</source>
         <translation>Rampe STS selon aérobic TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="487"/>
+        <location filename="../../Charts/LTMTool.cpp" line="461"/>
         <source>Aerobic TISS LTS Ramp</source>
         <translation>Rampe LTS selon aérobic TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="503"/>
+        <location filename="../../Charts/LTMTool.cpp" line="477"/>
         <source>Anaerobic TISS Long Term Stress</source>
         <translation>LTS Charge à long terme selon anaérobic TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="518"/>
+        <location filename="../../Charts/LTMTool.cpp" line="492"/>
         <source>Anaerobic TISS Short Term Stress</source>
         <translation>STS Charge à court terme selon anaérobic TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="533"/>
+        <location filename="../../Charts/LTMTool.cpp" line="507"/>
         <source>Anaerobic TISS Stress Balance</source>
         <translation>TSB Equilibre de charge selon anaérobic TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="548"/>
+        <location filename="../../Charts/LTMTool.cpp" line="522"/>
         <source>Anaerobic TISS STS Ramp</source>
         <translation>Rampe STS selon anaérobic TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="537"/>
         <source>Anaerobic TISS LTS Ramp</source>
         <translation>Rampe LTS selon anaérobic TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="578"/>
+        <location filename="../../Charts/LTMTool.cpp" line="552"/>
         <source>Daniels Long Term Stress</source>
         <translation>LTS Charge à long terme selon points Daniels</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="593"/>
+        <location filename="../../Charts/LTMTool.cpp" line="567"/>
         <source>Daniels Short Term Stress</source>
         <translation>STS Charge à court terme selon les points Daniels</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="582"/>
         <source>Daniels Stress Balance</source>
         <translation>TSB Equilibre de charge selon les points Daniels</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="623"/>
+        <location filename="../../Charts/LTMTool.cpp" line="597"/>
         <source>Daniels STS Ramp</source>
         <translation>Rampe STS selon les points Daniels</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="638"/>
+        <location filename="../../Charts/LTMTool.cpp" line="612"/>
         <source>Daniels LTS Ramp</source>
         <translation>Rampe LTS selon points Daniels</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="628"/>
         <source>Work (Kj) Long Term Stress</source>
         <translation>LTS Charge à long terme selon le travail (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="656"/>
-        <location filename="../../Charts/LTMTool.cpp" line="671"/>
-        <location filename="../../Charts/LTMTool.cpp" line="732"/>
-        <location filename="../../Charts/LTMTool.cpp" line="747"/>
-        <location filename="../../Charts/LTMTool.cpp" line="808"/>
-        <location filename="../../Charts/LTMTool.cpp" line="823"/>
+        <location filename="../../Charts/LTMTool.cpp" line="630"/>
+        <location filename="../../Charts/LTMTool.cpp" line="645"/>
+        <location filename="../../Charts/LTMTool.cpp" line="706"/>
+        <location filename="../../Charts/LTMTool.cpp" line="721"/>
+        <location filename="../../Charts/LTMTool.cpp" line="782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="797"/>
         <source>Stress (Kj)</source>
         <translation>Charge (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="669"/>
+        <location filename="../../Charts/LTMTool.cpp" line="643"/>
         <source>Work (Kj) Short Term Stress</source>
         <translation>STS Charge à court terme selon le Travail (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="684"/>
+        <location filename="../../Charts/LTMTool.cpp" line="658"/>
         <source>Work (Kj) Stress Balance</source>
         <translation>TSB Equilibre de charge selon le travail (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="699"/>
+        <location filename="../../Charts/LTMTool.cpp" line="673"/>
         <source>Work (Kj) STS Ramp</source>
         <translation>Rampe STS selon le travail (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="714"/>
+        <location filename="../../Charts/LTMTool.cpp" line="688"/>
         <source>Work (Kj) LTS Ramp</source>
         <translation>Rampe LTS selon le travail (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="730"/>
+        <location filename="../../Charts/LTMTool.cpp" line="704"/>
         <source>W&apos; Work (Kj) Long Term Stress</source>
         <translation>LTS Charge à long terme selon le W&apos; (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="745"/>
+        <location filename="../../Charts/LTMTool.cpp" line="719"/>
         <source>W&apos; Work (Kj) Short Term Stress</source>
         <translation>STS Charge à court terme selon le W&apos; (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="760"/>
+        <location filename="../../Charts/LTMTool.cpp" line="734"/>
         <source>W&apos; Work (Kj) Stress Balance</source>
         <translation>TSB Equilibre de charge selon le W&apos; (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="775"/>
+        <location filename="../../Charts/LTMTool.cpp" line="749"/>
         <source>W&apos; Work (Kj) STS Ramp</source>
         <translation>Rampe STS selon le W&apos; (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="790"/>
+        <location filename="../../Charts/LTMTool.cpp" line="764"/>
         <source>W&apos; Work (Kj) LTS Ramp</source>
         <translation>Rampe LTS selon le W&apos; (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="806"/>
+        <location filename="../../Charts/LTMTool.cpp" line="780"/>
         <source>Below CP Work (Kj) Long Term Stress</source>
         <translation>LTS Charge à long terme selon le travail sous CP (Kj)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="821"/>
+        <location filename="../../Charts/LTMTool.cpp" line="795"/>
         <source>Below CP Work (Kj) Short Term Stress</source>
         <translation>STS Charge à court terme selon le travail sous CP (Kj)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="836"/>
+        <location filename="../../Charts/LTMTool.cpp" line="810"/>
         <source>Below CP Work (Kj) Stress Balance</source>
         <translation>TSB Equilibre de charge selon le travail sous CP (Kj)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="851"/>
+        <location filename="../../Charts/LTMTool.cpp" line="825"/>
         <source>Below CP Work (Kj) STS Ramp</source>
         <translation>Rampe STS selon le travail sous CP (Kj)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="866"/>
+        <location filename="../../Charts/LTMTool.cpp" line="840"/>
         <source>Below CP Work (Kj) LTS Ramp</source>
         <translation>Rampe LTS selon le travail sous CP (Kj)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="882"/>
+        <location filename="../../Charts/LTMTool.cpp" line="856"/>
         <source>Distance (km|mi) Long Term Stress</source>
         <translation>LTS Charge à long terme selon la distance (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="884"/>
-        <location filename="../../Charts/LTMTool.cpp" line="899"/>
+        <location filename="../../Charts/LTMTool.cpp" line="858"/>
+        <location filename="../../Charts/LTMTool.cpp" line="873"/>
         <source>Stress (km|mi)</source>
         <translation>Charge (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="897"/>
+        <location filename="../../Charts/LTMTool.cpp" line="871"/>
         <source>Distance (km|mi) Short Term Stress</source>
         <translation>STS Charge à court terme selon la distance (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="912"/>
+        <location filename="../../Charts/LTMTool.cpp" line="886"/>
         <source>Distance (km|mi) Stress Balance</source>
         <translation>TSB Equilibre de charge selon la distance (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="927"/>
+        <location filename="../../Charts/LTMTool.cpp" line="901"/>
         <source>Distance (km|mi) STS Ramp</source>
         <translation>Rampe STS selon la distance (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="942"/>
+        <location filename="../../Charts/LTMTool.cpp" line="916"/>
         <source>Distance (km|mi) LTS Ramp</source>
         <translation>Rampe LTS selon la distance (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="958"/>
+        <location filename="../../Charts/LTMTool.cpp" line="932"/>
         <source>Coggan Chronic Training Load</source>
         <translation>CTL Charge à long terme selon Coggan</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="973"/>
+        <location filename="../../Charts/LTMTool.cpp" line="947"/>
         <source>Coggan Acute Training Load</source>
         <translation>ATL Charge à court terme selon Coggan</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="988"/>
+        <location filename="../../Charts/LTMTool.cpp" line="962"/>
         <source>Coggan Training Stress Balance</source>
         <translation>TSB Equilibre de charge selon Coggan</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1003"/>
+        <location filename="../../Charts/LTMTool.cpp" line="977"/>
         <source>Coggan STS Ramp</source>
         <translation>Rampe STS selon Coggan</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1018"/>
+        <location filename="../../Charts/LTMTool.cpp" line="992"/>
         <source>Coggan LTS Ramp</source>
         <translation>Rampe LTS selon Coggan</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1033"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1007"/>
         <source>Coggan Expected Chronic Training Load</source>
         <translation>Charge à long terme selon Coggan attendue</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1048"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1022"/>
         <source>Coggan Expected Acute Training Load</source>
         <translation>Charge à court terme selon Coggan attendue</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1063"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1037"/>
         <source>Coggan Expected Training Stress Balance</source>
         <translation>Equilibre de charge selon Coggan attendu</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1053"/>
         <source>TRIMP Long Term Stress</source>
         <translation>Charge à long terme selon points TRIMP</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1067"/>
         <source>TRIMP Short Term Stress</source>
         <translation>STS Charge à court terme selon points TRIMP</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1082"/>
         <source>TRIMP Stress Balance</source>
         <translation>Equilibre de charge selon points TRIMP</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1123"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1097"/>
         <source>TRIMP STS Ramp</source>
         <translation>Rampe STS selon points TRIMP</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1138"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1112"/>
         <source>TRIMP LTS Ramp</source>
         <translation>Rampe LTS selon points TRIMP</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="268"/>
         <source>Edit</source>
-        <translation>Editer</translation>
+        <translation type="vanished">Editer</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="124"/>
+        <location filename="../../Charts/LTMTool.cpp" line="125"/>
         <source>Use sidebar chart settings</source>
         <translation>Utiliser la barre latérale de configuration</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Basic</source>
         <translation>Simple</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="314"/>
+        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Preset</source>
         <translation>Pré-réglage</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="289"/>
         <source>Curves</source>
         <translation>Courbes</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1128"/>
         <source>TriScore Long Term Stress</source>
         <translation>LTS Charge à long terme selon TriScore</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1169"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1143"/>
         <source>TriScore Short Term Stress</source>
         <translation>STS Charge à court terme selon TriScore</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1184"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1158"/>
         <source>TriScore Stress Balance</source>
         <translation>TSB Equilibre de charge selon TriScore</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1173"/>
         <source>TriScore STS Ramp</source>
         <translation>Rampe STS selon TriScore</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1214"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1188"/>
         <source>TriScore LTS Ramp</source>
         <translation>Rampe LTS selon TriScore</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Details</source>
         <translation>Détails</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1305"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1274"/>
         <source>Peak</source>
         <translation>Pic</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1307"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1276"/>
         <source>Estimate</source>
         <translation>Estimation</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1311"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1280"/>
         <source>Formula</source>
         <translation>Formule</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1282"/>
         <source>Measure</source>
         <translation>Mesure</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1284"/>
         <source>Performance</source>
         <translation>Performance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1317"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1286"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1463"/>
         <source>Chart %1</source>
         <translation>Graphique %1</translation>
     </message>
@@ -18797,31 +18780,23 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
         <translation type="vanished">Mettre à jour</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2590"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2602"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2591"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2603"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2596"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2608"/>
         <source>Add</source>
-        <translation>Ajouter</translation>
+        <translation type="vanished">Ajouter</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2597"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2609"/>
         <source>Delete</source>
-        <translation>Effacer</translation>
+        <translation type="vanished">Effacer</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2599"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2467"/>
         <source>Def</source>
         <translation>Déf</translation>
     </message>
@@ -18830,14 +18805,14 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
         <translation type="vanished">Depuis une date</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2651"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2790"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2494"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2631"/>
         <source>Lactate Threshold</source>
         <translation>Seuil lactique</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2652"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2791"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2495"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2632"/>
         <source>Aerobic Threshold</source>
         <translation>Seuil aérobie</translation>
     </message>
@@ -18850,45 +18825,45 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
         <translation type="vanished">Maximum de 10 zones atteint.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2967"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2974"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2804"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2811"/>
         <source>New</source>
         <translation>Nouveau</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2969"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2976"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2806"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2813"/>
         <source>New (%1)</source>
         <translation>Nouveau (%1)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2653"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2496"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
         <source>Rest HR</source>
         <translation>FC repos</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2628"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2690"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2770"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2775"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2780"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2785"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2473"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2478"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2488"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2611"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2621"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2626"/>
         <source>bpm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2650"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2493"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2630"/>
         <source>Start Date</source>
         <translation type="unfinished">Date</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2654"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2497"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2634"/>
         <source>Max HR</source>
         <translation>FC max</translation>
     </message>
@@ -18897,24 +18872,24 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
         <translation type="vanished">d MMM, yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2701"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2544"/>
         <source>Short</source>
         <translatorcomment>As observed in GUI</translatorcomment>
         <translation>Zone</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2702"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2545"/>
         <source>Long</source>
         <translatorcomment>As observed in GUI</translatorcomment>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2703"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2546"/>
         <source>From BPM</source>
         <translation>Depuis</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2704"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2547"/>
         <source>Trimp k</source>
         <translation>TRIMP k</translation>
     </message>
@@ -19658,62 +19633,62 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
 <context>
     <name>Library</name>
     <message>
+        <location filename="../../Train/Library.cpp" line="126"/>
         <location filename="../../Train/Library.cpp" line="130"/>
-        <location filename="../../Train/Library.cpp" line="134"/>
         <source>Import Videos, VideoSyncs and Workouts</source>
         <translation>Importer des vidéos, VideoSyncs et des entraînements</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="127"/>
         <location filename="../../Train/Library.cpp" line="131"/>
-        <location filename="../../Train/Library.cpp" line="135"/>
         <source>No supported videos, videoSyncs or workouts were found to import</source>
         <translation>Aucune vidéo, VideoSyncs ou entraînements n&apos;ont été trouvé à importer</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="189"/>
         <location filename="../../Train/Library.cpp" line="193"/>
-        <location filename="../../Train/Library.cpp" line="197"/>
+        <location filename="../../Train/Library.cpp" line="198"/>
         <location filename="../../Train/Library.cpp" line="202"/>
-        <location filename="../../Train/Library.cpp" line="206"/>
         <source>Copy VideoSync Failed</source>
         <translation>La copie de VideoSync à échoué</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="190"/>
         <location filename="../../Train/Library.cpp" line="194"/>
-        <location filename="../../Train/Library.cpp" line="198"/>
         <source>%1 already exists in videoSync library: %2</source>
         <translation>%1 existe déjà dans la bibliothèque des videoSync: %2</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="203"/>
+        <location filename="../../Train/Library.cpp" line="199"/>
         <source>%1 cannot be written to videoSync library %2. Check library path, permissions and free space</source>
         <translation>%1 ne peut pas être écrit dans la bibliothèque videoSync %2. Vérifiez le répertoire de la bibliothèque, les autorisations d&apos;accès et l&apos;espace disponible</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="207"/>
+        <location filename="../../Train/Library.cpp" line="203"/>
         <source>%1 cannot be written to videoSync library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="253"/>
+        <location filename="../../Train/Library.cpp" line="249"/>
         <source>%1 cannot be written to workout library %2. Check library path, permissions and free space</source>
         <translation>%1 ne peut pas être écrit dans la bibliothèque d&apos;entraînements %2. Vérifiez le répertoire de la bibliothèque, les autorisations d&apos;accès et l&apos;espace disponible</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="257"/>
+        <location filename="../../Train/Library.cpp" line="253"/>
         <source>%1 cannot be written to workout library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="239"/>
         <location filename="../../Train/Library.cpp" line="243"/>
-        <location filename="../../Train/Library.cpp" line="247"/>
+        <location filename="../../Train/Library.cpp" line="248"/>
         <location filename="../../Train/Library.cpp" line="252"/>
-        <location filename="../../Train/Library.cpp" line="256"/>
         <source>Copy Workout Failed</source>
         <translation>La copie d&apos;entraînement à échoué</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="240"/>
         <location filename="../../Train/Library.cpp" line="244"/>
-        <location filename="../../Train/Library.cpp" line="248"/>
         <source>%1 already exists in workout library: %2</source>
         <translation>%1 existe déjà dans la bibliothèque des entraînements: %2</translation>
     </message>
@@ -19721,89 +19696,89 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
 <context>
     <name>LibrarySearchDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="330"/>
+        <location filename="../../Train/Library.cpp" line="326"/>
         <source>Search for Workouts, Syncs and Media</source>
         <translation>Rechercher des entraînements, Syncs et des vidéos</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="337"/>
+        <location filename="../../Train/Library.cpp" line="333"/>
         <source>Workout files (.erg, .mrc, .zwo etc)</source>
         <translation>Fichiers d&apos;entraînement (.erg, .mrc, .zwo etc)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="339"/>
+        <location filename="../../Train/Library.cpp" line="335"/>
         <source>Video files (.mp4, .avi etc)</source>
         <translation>fichiers vidéo (.mp4, .avi etc)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="341"/>
+        <location filename="../../Train/Library.cpp" line="337"/>
         <source>VideoSync files (.rlv, .tts etc)</source>
         <translation>Fichiers VideoSync (.rlv, .tts etc)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="359"/>
+        <location filename="../../Train/Library.cpp" line="353"/>
         <source>Search Path</source>
         <translation>Répertoire de recherche</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="379"/>
+        <location filename="../../Train/Library.cpp" line="373"/>
         <source>Video references</source>
         <translation>Préférences vidéo</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="391"/>
+        <location filename="../../Train/Library.cpp" line="385"/>
         <source>Searching...</source>
         <translation>Recherche...</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="394"/>
+        <location filename="../../Train/Library.cpp" line="388"/>
         <source>Videos</source>
         <translation>Vidéos</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="396"/>
+        <location filename="../../Train/Library.cpp" line="390"/>
         <source>Workouts</source>
         <translation>Entraînements</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="398"/>
+        <location filename="../../Train/Library.cpp" line="392"/>
         <source>VideoSyncs</source>
         <translation>VideoSyncs</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="407"/>
-        <location filename="../../Train/Library.cpp" line="494"/>
+        <location filename="../../Train/Library.cpp" line="401"/>
+        <location filename="../../Train/Library.cpp" line="484"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="409"/>
+        <location filename="../../Train/Library.cpp" line="403"/>
         <source>Search</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="412"/>
+        <location filename="../../Train/Library.cpp" line="406"/>
         <source>Files to search for:</source>
         <translation>Rechercher des fichiers pour:</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="475"/>
+        <location filename="../../Train/Library.cpp" line="466"/>
         <source>Abort Search</source>
         <translation>Annuler la recherche</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="515"/>
-        <location filename="../../Train/Library.cpp" line="559"/>
+        <location filename="../../Train/Library.cpp" line="504"/>
+        <location filename="../../Train/Library.cpp" line="548"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="557"/>
+        <location filename="../../Train/Library.cpp" line="546"/>
         <source>Search completed.</source>
         <translation>Recherche terminée.</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="645"/>
+        <location filename="../../Train/Library.cpp" line="634"/>
         <source>Select Directory</source>
         <translation>Sélectionner un répertoire</translation>
     </message>
@@ -19811,12 +19786,12 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
 <context>
     <name>ListEditWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="623"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="654"/>
         <source>New</source>
         <translation type="unfinished">Nouveau</translation>
     </message>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="625"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="656"/>
         <source>New (%1)</source>
         <translation type="unfinished">Nouveau (%1)</translation>
     </message>
@@ -19829,7 +19804,12 @@ La correction de couple - cette valeur définie une valeur absolue en newton mè
         <translation>URL de base pour OSM</translation>
     </message>
     <message>
-        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="90"/>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="85"/>
+        <source>Initial Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="98"/>
         <source>Apply changes</source>
         <translation>Appliquer les modifications</translation>
     </message>
@@ -20121,23 +20101,23 @@ on and that its display says, &quot;PC Link&quot;</source>
         <translation type="vanished">Télécharger des entraînements depuis ErgDB...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Chart Import</source>
         <translation>Importer des graphiques</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
         <source>No activity selected</source>
         <translation>Pas d&apos;activité sélectionnée</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
         <source>Current activity contains no data to split</source>
         <translation>L&apos;activité sélectionnée ne contient pas de donnée à couper</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Current activity contains no data to merge</source>
         <translation>L&apos;activité sélectionnée ne contient pas de donnée à combiner</translation>
     </message>
@@ -20438,56 +20418,56 @@ on and that its display says, &quot;PC Link&quot;</source>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Activity Import</source>
         <translation>Importer une activité</translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Closing of athlete window not possible while background activity import is in progress...</source>
         <translation>Impossible de fermer l&apos;athlète tant que l&apos;importation est en cours...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>Import Images Failed</source>
         <translation>Echec de l&apos;importation des images</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>You can only import images on the activities view with an activity selected.</source>
         <translation>Vous pouvez uniquement importer des images dans la vue activités quand une activité est sélectionnée.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>Import Images to Activity</source>
         <translation>Importer des images dans l&apos;activité</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>%1 images imported.</source>
         <translation>%1 image(s) importée(s).</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
         <source>Select Activity</source>
         <translation>Sélectionner l&apos;activité</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>No activity selected!</source>
         <translation>Pas d&apos;activité sélectionnée!</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1724"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1734"/>
         <source>Export Activity</source>
         <translation>Exporter l&apos;activité</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1777"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1787"/>
         <source>Export Failed</source>
         <translation>L&apos;export a échoué</translation>
     </message>
@@ -20558,13 +20538,13 @@ on and that its display says, &quot;PC Link&quot;</source>
         <translation>Sélectionner les graphiques</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Imported %1 metric charts</source>
         <translation>Graphiques métrique %1 importés</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2400"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2421"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2410"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2431"/>
         <source>The workout directory is not configured, or the directory selected no longer exists.
 
 Please check your preference settings.</source>
@@ -20573,7 +20553,7 @@ Please check your preference settings.</source>
 Vérifiez vos options.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2611"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2621"/>
         <source>Loading activities: %1%</source>
         <translation>Chargement des activités: %1%</translation>
     </message>
@@ -20586,14 +20566,14 @@ Vérifiez vos options.</translation>
         <translation type="vanished">Gérer les Traitements Python ad hoc...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>CloudDB</source>
         <translation>CloudDB</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>Current athlete is not registered as curator - please contact the GoldenCheetah team</source>
         <translation>L&apos;athlète actuel n&apos;est pas inscrit en tant que &quot;réparateur&quot; - veuillez contacter l&apos;équipe de GoldenCheetah</translation>
     </message>
@@ -20663,12 +20643,12 @@ Vérifiez vos options.</translation>
         <translation>Voulez-vous continuer?</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2165"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2175"/>
         <source>&amp;New Athlete...</source>
         <translation>&amp;Nouvel Athlète...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2342"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2352"/>
         <source>Refresh in Progress</source>
         <translation>Actualisation en cours</translation>
     </message>
@@ -20693,12 +20673,12 @@ Vérifiez vos options.</translation>
         <translation>A &amp;Propos de GoldenCheetah</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>Delete Activity</source>
         <translation>Effacer l&apos;activité</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1778"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1788"/>
         <source>Failed to export activity, please check permissions</source>
         <translation>Echec de l&apos;export de l&apos;activité, veuillez vérifier les permissions d&apos;écriture</translation>
     </message>
@@ -20708,52 +20688,52 @@ Vérifiez vos options.</translation>
         <translation>Obtenir des mesures...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1815"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1825"/>
         <source>There is no currently selected activity to save.</source>
         <translation>Il n&apos;y a pas d&apos;activité sélectionnée à enregistrer.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
         <location filename="../../Gui/MainWindow.cpp" line="1886"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Split Activity</source>
         <translation>Diviser l&apos;activité</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1799"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2369"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1809"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2379"/>
         <source>Import from File</source>
         <translation>Importer un fichier</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1814"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1824"/>
         <source>No Activity To Save</source>
         <translation>Pas d&apos;activité à enregistrer</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1904"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1914"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation>Etes-vous certain de vouloir supprimer cette activité:</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Export Metrics</source>
         <translation>Exporter les métriques</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation>Comma Separated Variables (*.csv)</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2399"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2420"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2409"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2430"/>
         <source>Workout Directory Invalid</source>
         <translation>Le dossier pour les séances d&apos;entraînements est invalide</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1906"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1916"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
@@ -21709,23 +21689,23 @@ Vérifiez vos options.</translation>
         <translation type="vanished">Mesures dépendantes du temps %1</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="656"/>
+        <location filename="../../Gui/AthletePages.cpp" line="641"/>
         <source>From Date - Time</source>
         <translation>Depuis Date - Heure</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="780"/>
+        <location filename="../../Gui/AthletePages.cpp" line="751"/>
         <source>Start Date</source>
         <translation type="unfinished">Date</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="893"/>
+        <location filename="../../Gui/AthletePages.cpp" line="864"/>
         <source>MMM d, yyyy - hh:mm:ss</source>
         <translation>d MMM, yyyy - hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="659"/>
-        <location filename="../../Gui/AthletePages.cpp" line="807"/>
+        <location filename="../../Gui/AthletePages.cpp" line="644"/>
+        <location filename="../../Gui/AthletePages.cpp" line="778"/>
         <source>Comment</source>
         <translation>Commentaire</translation>
     </message>
@@ -21734,32 +21714,28 @@ Vérifiez vos options.</translation>
         <translation type="vanished">Mettre à jour</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="662"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="663"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">Ajouter</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">Effacer</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="668"/>
-        <source>Add</source>
-        <translation>Ajouter</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="669"/>
-        <source>Delete</source>
-        <translation>Effacer</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="698"/>
         <source>Source</source>
         <translation>Source</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="699"/>
+        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Original Source</source>
         <translation>Source primaire</translation>
     </message>
@@ -22460,17 +22436,17 @@ Pas d&apos;activité trouvée à importer.
 <context>
     <name>MultiDeviceDialog</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3048"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3060"/>
         <source>Multiple Device Configuration</source>
         <translation>Configuration de plusieurs périphériques</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3103"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3115"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3106"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3118"/>
         <source>Apply</source>
         <translation>Appliquer</translation>
     </message>
@@ -23500,44 +23476,40 @@ Pas d&apos;activité trouvée à importer.
 <context>
     <name>PaceSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3154"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3155"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3160"/>
         <source>Add</source>
-        <translation>Ajouter</translation>
+        <translation type="vanished">Ajouter</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3161"/>
         <source>Delete</source>
-        <translation>Effacer</translation>
+        <translation type="vanished">Effacer</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3176"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2987"/>
         <source>Short</source>
         <translatorcomment>As observed in GUI</translatorcomment>
         <translation>Zone</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3177"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2988"/>
         <source>Long</source>
         <translatorcomment>As observed in GUI</translatorcomment>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3178"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2989"/>
         <source>Percent of CV</source>
         <translation>Pourcentage de la CV</translation>
     </message>
@@ -23546,14 +23518,14 @@ Pas d&apos;activité trouvée à importer.
         <translation type="vanished">Maximum de 10 zones atteint.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3220"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3227"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3037"/>
         <source>New</source>
         <translation>Nouveau</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3222"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3229"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3032"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3039"/>
         <source>New (%1)</source>
         <translation>Nouveau (%1)</translation>
     </message>
@@ -23753,27 +23725,27 @@ Pas d&apos;activité trouvée à importer.
 <context>
     <name>PaceZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3082"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2905"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3084"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2907"/>
         <source>Run</source>
         <translation>Course</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3085"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2908"/>
         <source>Swim</source>
         <translation>Natation</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3126"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2949"/>
         <source>Critical Velocity</source>
         <translation>Vitesse Critique</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2950"/>
         <source>Default</source>
         <translation>Défaut</translation>
     </message>
@@ -25921,78 +25893,79 @@ Voulez-vous continuer?</translation>
 <context>
     <name>PerspectiveDialog</name>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="34"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="35"/>
         <source>Manage Perspectives</source>
         <translation>Gérer les perspectives</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="43"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="44"/>
         <source>Perspectives</source>
         <translation>Perspectives</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="60"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="61"/>
         <source>Charts</source>
         <translation>Graphiques</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Edit</source>
-        <translation>Editer</translation>
+        <translation type="vanished">Editer</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="83"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="78"/>
         <source>Import</source>
         <translation>Importer</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="84"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="77"/>
         <source>Export</source>
         <translation>Exporter</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="90"/>
         <source>Add</source>
-        <translation>Ajouter</translation>
+        <translation type="vanished">Ajouter</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="91"/>
         <source>Delete</source>
-        <translation>Effacer</translation>
+        <translation type="vanished">Effacer</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="98"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Drag charts to move to a perspective</source>
         <translation>Faites glisser les graphiques pour passer sur une perspective</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="287"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="256"/>
         <source>Export Persepctive</source>
         <translation>Exporter une perspective</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
         <source>Export Perspective</source>
         <translation>Exporter la perspective</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>No perspective file selected!</source>
         <translation>Aucune perspective sélectionnée!</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
         <source>Select Perspective file to export</source>
-        <translation>Sélectionnez un fichier de perspective à exporter</translation>
+        <translation type="vanished">Sélectionnez un fichier de perspective à exporter</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
         <source>GoldenCheetah Perspective Files (*.gchartset)</source>
         <translation>Fichier de perspectives GoldenCheetah (*.gchartset)</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
+        <source>Select Perspective file to import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>Import Perspective</source>
         <translation>Importer une perspective</translation>
     </message>
@@ -27154,307 +27127,307 @@ Python désactivé dans les préférences.</translation>
 <context>
     <name>RealtimeData</name>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="621"/>
+        <location filename="../../Train/RealtimeData.cpp" line="623"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="624"/>
+        <location filename="../../Train/RealtimeData.cpp" line="626"/>
         <source>Time</source>
         <translation>Temps</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="627"/>
+        <location filename="../../Train/RealtimeData.cpp" line="629"/>
         <source>Lap</source>
         <translation>Intervalle</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="630"/>
+        <location filename="../../Train/RealtimeData.cpp" line="632"/>
         <source>Lap Time</source>
         <translation>Temps sur l&apos;intervalle</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="633"/>
+        <location filename="../../Train/RealtimeData.cpp" line="635"/>
         <source>Lap Time Remaining</source>
         <translation>Temps restant pour l&apos;intervalle</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="636"/>
+        <location filename="../../Train/RealtimeData.cpp" line="638"/>
         <source>Section Time Remaining</source>
         <translation>Temps restant pour la section</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="639"/>
+        <location filename="../../Train/RealtimeData.cpp" line="641"/>
         <source>BikeStress</source>
         <translation>BikeStress</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="645"/>
+        <location filename="../../Train/RealtimeData.cpp" line="647"/>
         <source>kJoules</source>
         <translation>kJoules</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="648"/>
+        <location filename="../../Train/RealtimeData.cpp" line="650"/>
         <source>W&apos; bal</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="651"/>
+        <location filename="../../Train/RealtimeData.cpp" line="653"/>
         <source>XPower</source>
         <translation>xPower</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="654"/>
+        <location filename="../../Train/RealtimeData.cpp" line="656"/>
         <source>Iso Power</source>
         <translation>Puissance normalisée</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="657"/>
+        <location filename="../../Train/RealtimeData.cpp" line="659"/>
         <source>Intensity Factor</source>
         <translation>Facteur d&apos;intensité</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="660"/>
+        <location filename="../../Train/RealtimeData.cpp" line="662"/>
         <source>Relative Intensity</source>
         <translation>Intensité relative</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="663"/>
+        <location filename="../../Train/RealtimeData.cpp" line="665"/>
         <source>Skiba Variability Index</source>
         <translation>Index Skiba de variabilité</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="666"/>
+        <location filename="../../Train/RealtimeData.cpp" line="668"/>
         <source>Variability Index</source>
         <translation>Index de variabilité</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="669"/>
+        <location filename="../../Train/RealtimeData.cpp" line="671"/>
         <source>Distance</source>
         <translation>Distance</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="672"/>
+        <location filename="../../Train/RealtimeData.cpp" line="674"/>
         <source>Route Distance</source>
         <translation>Distance de l&apos;itinéraire</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="675"/>
+        <location filename="../../Train/RealtimeData.cpp" line="677"/>
         <source>Distance Remaining</source>
         <translation>Distance restante</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="678"/>
+        <location filename="../../Train/RealtimeData.cpp" line="680"/>
         <source>Alternate Power</source>
         <translation>Puissance (alternative)</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="681"/>
+        <location filename="../../Train/RealtimeData.cpp" line="683"/>
         <source>Power</source>
         <translation>Puissance</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="684"/>
+        <location filename="../../Train/RealtimeData.cpp" line="686"/>
         <source>Speed</source>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="687"/>
+        <location filename="../../Train/RealtimeData.cpp" line="689"/>
         <source>Virtual Speed</source>
         <translation>Vitesse Virtuelle</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="690"/>
+        <location filename="../../Train/RealtimeData.cpp" line="692"/>
         <source>Cadence</source>
         <translation>Cadence</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="693"/>
+        <location filename="../../Train/RealtimeData.cpp" line="695"/>
         <source>Heart Rate</source>
         <translation>Fréquence cardiaque</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="696"/>
+        <location filename="../../Train/RealtimeData.cpp" line="698"/>
         <source>Target Power</source>
         <translation>Puissance cible</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="699"/>
+        <location filename="../../Train/RealtimeData.cpp" line="701"/>
         <source>Average Power</source>
         <translation>Puissance moyenne</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="702"/>
+        <location filename="../../Train/RealtimeData.cpp" line="704"/>
         <source>Average Speed</source>
         <translation>Vitesse Moyenne</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="705"/>
+        <location filename="../../Train/RealtimeData.cpp" line="707"/>
         <source>Average Heartrate</source>
         <translation>FC moyenne</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="708"/>
+        <location filename="../../Train/RealtimeData.cpp" line="710"/>
         <source>Average Cadence</source>
         <translation>Cadence moyenne</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="711"/>
+        <location filename="../../Train/RealtimeData.cpp" line="713"/>
         <source>Lap Power</source>
         <translation>Puissance sur l&apos;intervalle</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="714"/>
+        <location filename="../../Train/RealtimeData.cpp" line="716"/>
         <source>Lap Speed</source>
         <translation>Vitesse sur l&apos;intervalle</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="717"/>
+        <location filename="../../Train/RealtimeData.cpp" line="719"/>
         <source>Lap Heartrate</source>
         <translation>FC sur l&apos;intervalle</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="720"/>
+        <location filename="../../Train/RealtimeData.cpp" line="722"/>
         <source>Lap Cadence</source>
         <translation>Cadence sur l&apos;intervalle</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="723"/>
+        <location filename="../../Train/RealtimeData.cpp" line="725"/>
         <source>Left/Right Balance</source>
         <translation>Equilibre gauche/droit</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="726"/>
+        <location filename="../../Train/RealtimeData.cpp" line="728"/>
         <source>Total Hb Mass</source>
         <translation>Masse totale Hb</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="729"/>
+        <location filename="../../Train/RealtimeData.cpp" line="731"/>
         <source>Hb O2 Saturation</source>
         <translation>Saturation O2 d&apos;Hb</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="732"/>
+        <location filename="../../Train/RealtimeData.cpp" line="734"/>
         <source>Deoxy Hb</source>
         <translation>Deoxy Hb</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="735"/>
+        <location filename="../../Train/RealtimeData.cpp" line="737"/>
         <source>Oxy Hb</source>
         <translation>Oxy Hb</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="738"/>
+        <location filename="../../Train/RealtimeData.cpp" line="740"/>
         <source>Left Torque Effectiveness</source>
         <translation>Efficacité du pédalage gauche</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="741"/>
+        <location filename="../../Train/RealtimeData.cpp" line="743"/>
         <source>Right Torque Effectiveness</source>
         <translation>Efficacité du pédalage droit</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="744"/>
+        <location filename="../../Train/RealtimeData.cpp" line="746"/>
         <source>Left Pedal Smoothness</source>
         <translation>Lissage du pédalage gauche</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="747"/>
+        <location filename="../../Train/RealtimeData.cpp" line="749"/>
         <source>Right Pedal Smoothness</source>
         <translation>Lissage du pédalage droit</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="750"/>
+        <location filename="../../Train/RealtimeData.cpp" line="752"/>
         <source>Right Power Phase Start</source>
         <translation type="unfinished">Début phase de pédalage droite</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="753"/>
+        <location filename="../../Train/RealtimeData.cpp" line="755"/>
         <source>Right Power Phase End</source>
         <translation type="unfinished">Fin phase de pédalage droite</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="756"/>
+        <location filename="../../Train/RealtimeData.cpp" line="758"/>
         <source>Right Power Phase Peak Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="759"/>
+        <location filename="../../Train/RealtimeData.cpp" line="761"/>
         <source>Right Power Phase Peak End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="762"/>
+        <location filename="../../Train/RealtimeData.cpp" line="764"/>
         <source>Slope</source>
         <translation>Pente</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="765"/>
+        <location filename="../../Train/RealtimeData.cpp" line="767"/>
         <source>Lap Distance</source>
         <translation>Distance de l&apos;intervalle</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="768"/>
+        <location filename="../../Train/RealtimeData.cpp" line="770"/>
         <source>Lap Distance Remaining</source>
         <translation>Distance restante pour l&apos;intervalle</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="771"/>
+        <location filename="../../Train/RealtimeData.cpp" line="773"/>
         <source>Latitude</source>
         <translation>Latitude</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="774"/>
+        <location filename="../../Train/RealtimeData.cpp" line="776"/>
         <source>Longitude</source>
         <translation>Longitude</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="777"/>
+        <location filename="../../Train/RealtimeData.cpp" line="779"/>
         <source>Altitude</source>
         <translation>Altitude</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="780"/>
+        <location filename="../../Train/RealtimeData.cpp" line="782"/>
         <source>Respiratory Frequency</source>
         <translation>Fréquence respiratoire</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="783"/>
+        <location filename="../../Train/RealtimeData.cpp" line="785"/>
         <source>Ventilation</source>
         <translation>Ventilation</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="786"/>
+        <location filename="../../Train/RealtimeData.cpp" line="788"/>
         <source>VO2</source>
         <translation>VO2</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="789"/>
+        <location filename="../../Train/RealtimeData.cpp" line="791"/>
         <source>VCO2</source>
         <translation>VCO2</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="792"/>
+        <location filename="../../Train/RealtimeData.cpp" line="794"/>
         <source>Respiratory Exchange Ratio</source>
         <translation>Rapport d&apos;échange respiratoire</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="795"/>
+        <location filename="../../Train/RealtimeData.cpp" line="797"/>
         <source>Tidal Volume</source>
         <translation>Volume courant</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="798"/>
+        <location filename="../../Train/RealtimeData.cpp" line="800"/>
         <source>Fraction O2 Expired</source>
         <translation>Fraction O2 Expiré</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="801"/>
+        <location filename="../../Train/RealtimeData.cpp" line="803"/>
         <source>Temperature</source>
         <translation type="unfinished">Température</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="804"/>
+        <location filename="../../Train/RealtimeData.cpp" line="806"/>
         <source>CoreTemp</source>
         <translation type="unfinished"></translation>
     </message>
@@ -27550,22 +27523,22 @@ Python désactivé dans les préférences.</translation>
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Series</source>
         <translation>Série</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="172"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
         <source>Power</source>
         <translation>Puissance</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="176"/>
         <source>Heart Rate</source>
         <translation>Fréquence cardiaque</translation>
     </message>
@@ -29869,318 +29842,318 @@ Devons-nous le faire?
 <context>
     <name>ScatterPlot</name>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="113"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
         <source>Power (watts)</source>
         <translation>Puissance (watts)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
         <source>Cadence (rpm)</source>
         <translation>Cadence (t/min)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="116"/>
         <source>Heartrate (bpm)</source>
         <translation>Fréquence cardiaque (bpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="118"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="119"/>
         <source>Speed (kph)</source>
         <translation>Vitesse (km/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="120"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="121"/>
         <source>Speed (mph)</source>
         <translation>Vitesse (mph)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="124"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="125"/>
         <source>Altitude (meters)</source>
         <translation>Altitude (mètres)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="126"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="127"/>
         <source>Altitude (feet)</source>
         <translation>Altitude (pieds)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="128"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
         <source>Torque (N)</source>
         <translatorcomment>proper torque unit is Nm so source text is questionable</translatorcomment>
         <translation>Couple (Nm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="130"/>
         <source>Elapsed Time (secs)</source>
         <translation>Temps écoulé (secs)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="132"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="133"/>
         <source>Elapsed Distance (km)</source>
         <translation>Distance parcourue (km)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="134"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="135"/>
         <source>Elapsed Distance (mi)</source>
         <translation>Distance parcourue (mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="136"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
         <source>Interval Number</source>
         <translation>Numéro de l&apos;intervalle</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
         <source>Latitude (degree offset)</source>
         <translation>Latitude (degré d&apos;offset)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
         <source>Longitude (degree offset)</source>
         <translation>Longitude (degré d&apos;offset)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
         <source>Circumferential Pedal Velocity (m/s)</source>
         <translation>Vitesse circonférentielle de la pédale (m/s)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="141"/>
         <source>Average Effective Pedal Force (N)</source>
         <translation>Force effective moyenne à la pédale (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="144"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
         <source>Time at X/Y (%)</source>
         <translation>Temps à X/Y (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
         <source>Power Zone</source>
         <translation>Zone de puissance</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
         <source>Headwind (kph)</source>
         <translation>Vent de face (km/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
         <source>Slope (gradient)</source>
         <translation>Pente (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
         <source>Temperature (C)</source>
         <translation>Température (°C)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
         <source>L/R Balance</source>
         <translation>Equilibre gauche droite</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
         <source>Torque Efficiency</source>
         <translation>Efficacité du couple</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
         <source>Pedal Smoothness</source>
         <translation>Lissage du pédalage</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
         <source>Running Vertical Oscillation</source>
         <translation>Oscillation verticale de course</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
         <source>Running Ground Contact Time</source>
         <translation>Temps de contact au sol</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
         <source>Running Cadence</source>
         <translation>Cadence de course</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
         <source>Gear Ratio</source>
         <translation>Braquet</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
         <source>Muscle Oxygen</source>
         <translation>Oxygénation</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
         <source>Haemoglobin Mass</source>
         <translation>Masse d&apos;hémoglobine</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
         <source>Deoxygenated Haemoglobin</source>
         <translation>Hémoglobine désoxygénée</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="160"/>
         <source>Oxygenated Haemoglobin</source>
         <translation>Hémoglobine oxygénée</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="161"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="162"/>
         <source>Unknown</source>
         <translation>Inconnu</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="165"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
         <source>Power</source>
         <translation>Puissance</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
         <source>Cadence</source>
         <translation>Cadence</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
         <source>Heartrate</source>
         <translation>Fréquence cardiaque</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
         <source>Speed</source>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
         <source>Altitude</source>
         <translation>Altitude</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
         <source>Pedal Force</source>
         <translation>Force sur la pédale</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
         <source>Time</source>
         <translation>Temps</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
         <source>Distance</source>
         <translation>Distance</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
         <source>Interval</source>
         <translation>Intervalle</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
         <source>Latitude</source>
         <translation>Latitude</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
         <source>Longitude</source>
         <translation>Longitude</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
         <source>Time at X/Y</source>
         <translation>Temps à X/Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
         <source>Zone</source>
         <translation>Zone</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
         <source>CPV</source>
         <translation>CPV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
         <source>AEPF</source>
         <translation>AEPF</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
         <source>Headwind</source>
         <translation>Vent de face</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
         <source>Slope</source>
         <translation>Pente</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
         <source>Temp</source>
         <translation>Température</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
         <source>Balance</source>
         <translation>Equilibre</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
         <source>TE</source>
         <translation>TE</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
         <source>PS</source>
         <translation>PS</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
         <source>RV</source>
         <translation>RV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
         <source>GCT</source>
         <translation>GCT</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
         <source>Run Cad</source>
         <translation>Cadence de course</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
         <source>Gear</source>
         <translation>Braquet</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="194"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="195"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="196"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
@@ -30418,42 +30391,38 @@ Devons-nous le faire?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1012"/>
         <source>Add</source>
-        <translation>Ajouter</translation>
+        <translation type="vanished">Ajouter</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1013"/>
         <source>Delete</source>
-        <translation>Effacer</translation>
+        <translation type="vanished">Effacer</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1006"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1007"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1023"/>
+        <location filename="../../Gui/AthletePages.cpp" line="982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="988"/>
         <source>Short</source>
         <translation>Zone</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="989"/>
         <source>Long</source>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1031"/>
+        <location filename="../../Gui/AthletePages.cpp" line="990"/>
         <source>Percent of CP</source>
         <translation>Pourcentage de la CP</translation>
     </message>
@@ -30462,14 +30431,14 @@ Devons-nous le faire?
         <translation type="vanished">Maximum de 10 zones atteint.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1069"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1076"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1034"/>
         <source>New</source>
         <translation>Nouveau</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1071"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1078"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1036"/>
         <source>New (%1)</source>
         <translation>Nouveau (%1)</translation>
     </message>
@@ -30642,64 +30611,64 @@ Devons-nous le faire?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3821"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3569"/>
         <source>Add</source>
         <translation>Ajouter</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3822"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3570"/>
         <source>Delete</source>
         <translation>Effacer</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3823"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3571"/>
         <source>Up</source>
         <translation>Vers le haut</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3824"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3572"/>
         <source>Down</source>
         <translation>Vers le bas</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3870"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3872"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3963"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3965"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3711"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3713"/>
         <source>ddd MMM d, yyyy</source>
         <translation>ddd d MMM, yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3557"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3810"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3558"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3804"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3835"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3583"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3805"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3836"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3553"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3584"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3806"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3837"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3554"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3585"/>
         <source>From</source>
         <translation>De</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3807"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3838"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3555"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3586"/>
         <source>To</source>
         <translation>A</translation>
     </message>
@@ -33151,40 +33120,40 @@ tab.</source>
 <context>
     <name>TrainSidebar</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="253"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="257"/>
         <source>Save workout data</source>
         <translation>Sauver les données de l&apos;entraînement</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="259"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="263"/>
         <source>Devices</source>
         <translation>Périphériques</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="262"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="267"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="311"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="321"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="271"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="315"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="325"/>
         <source>Menu</source>
         <translation>Menu</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="270"/>
         <source>Workouts</source>
         <translation>Entraînements</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="310"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="314"/>
         <source>Media</source>
         <translation>Médias</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="320"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="324"/>
         <source>VideoSync</source>
         <translation>VideoSync</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="506"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
         <source>Import Workout from File</source>
         <translation>Importer des fichiers d&apos;entraînements</translation>
     </message>
@@ -33193,153 +33162,153 @@ tab.</source>
         <translation type="vanished">Télécharger des entraînements depuis ErgDB</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="509"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="513"/>
         <source>Create Workout via Wizard</source>
         <translation>Créer un entraînement avec le guide</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="514"/>
         <source>Scan for Workouts</source>
         <translation>Balayer à la recherche d&apos;entraînement</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="534"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="538"/>
         <source>Delete selected Workout</source>
         <translation>Effacer l&apos;entraînement sélectionné</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="541"/>
         <source>Delete %1 selected Workouts</source>
         <translation>Effacer ler %1 entraînements sélectionnés</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Train mode active</source>
         <translation>Mode Entraînement actif</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Please stop the train mode before closing the window or application.</source>
         <translation>Veuillez arrêter le mode &apos;Entraînement&apos; avant de fermer la fenêtre ou l&apos;application.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="635"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="639"/>
         <source>Remove reference to selected video</source>
         <translation>Retirer les références sur la vidéo sélectionnée</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="650"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="654"/>
         <source>Import VideoSync from File</source>
         <translation>Importer un VideoSync</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="651"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="655"/>
         <source>Scan for VideoSyncs</source>
         <translation>Balayer à la recherche de VideoSyncs</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="668"/>
         <source>Delete selected VideoSync</source>
         <translation>Effacer la VideoSync sélectionnée</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1064"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1068"/>
         <source>Are you sure you want to remove the reference to this video?</source>
         <translation>Etes-vous sûr de vouloir retirer les références à cette vidéo?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1066"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1128"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1204"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1070"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1132"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1208"/>
         <source>Remove</source>
         <translation>Retirer</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1099"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1103"/>
         <source>Are you sure you want to delete this VideoSync?</source>
         <translation>Etes-vous sûr de vouloir effacer cette VideoSync?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1126"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1130"/>
         <source>The VideoSync file is either not valid or not existing and will be removed from the library.</source>
         <translation>Cette VideoSync n&apos;existe plus ou n&apos;est pas valide elle sera supprimée de la bibliothèque.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1160"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1164"/>
         <source>Are you sure you want to delete this Workout?</source>
         <translation>Etes-vous sur de vouloir supprimer cet entraînement?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1163"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1167"/>
         <source>Are you sure you want to delete this %1 workouts?</source>
         <translation>Etes-vous sûr de vouloir supprimer ces %1 entraînements?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1202"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1206"/>
         <source>The Workout file is either not valid or not existing and will be removed from the library.</source>
         <translation>Cet entraînement n&apos;existe plus ou n&apos;est pas valide. Il sera supprimé.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1309"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1313"/>
         <source>Resuming..</source>
         <translation>Reprise..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1336"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1340"/>
         <source>Paused..</source>
         <translation>En pause..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1347"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1351"/>
         <source>Starting in %1</source>
         <translation>Démarrage dans %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1465"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1469"/>
         <source>Starting..</source>
         <translation>Départ..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1673"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1677"/>
         <source>Stopped..</source>
         <translation>Arrêté..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1763"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1769"/>
         <source>Connected..</source>
         <translation>Connecté..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1787"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1793"/>
         <source>Disconnected..</source>
         <translation>Déconnecté..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2198"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2210"/>
         <source>New lap..</source>
         <translation>Nouveau tour ..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2225"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2237"/>
         <source>Recalibrating steering..</source>
         <translation>Recalibrer la direction..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2521"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2525"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2594"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2645"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2649"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2533"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2606"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2657"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2661"/>
         <source>Requesting calibration..</source>
         <translation>Demander un étalonnage ..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2532"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2544"/>
         <source>Calibrating...</source>
         <translation>Calibration...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2536"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2548"/>
         <source>Calibrating...
 Current speed %1 kph
 Increase speed to %2 kph</source>
@@ -33348,14 +33317,14 @@ Vitesse actuelle%1 km / h
 Augmenter la vitesse à%2 km / h</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2540"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2552"/>
         <source>Calibrating...
 Stop pedalling until speed drops to 0</source>
         <translation>Calibration ...
 Arrêtez de pédaler jusqu&apos;à ce que la vitesse chute à 0</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2545"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2557"/>
         <source>Calibration completed successfully!
 Spindown %1 ms
 Zero Offset %2</source>
@@ -33364,30 +33333,30 @@ Spindown%1 ms
 Décalage zéro%2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2553"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2620"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2672"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2565"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2632"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2684"/>
         <source>Calibration failed!</source>
         <translation>La calibration a échoué !</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2573"/>
         <source>Calibration Failed: Loosen Roller</source>
         <translation>Échec du calibrage: desserrez le rouleau</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2569"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2581"/>
         <source>Calibration Failed: Tighten Roller</source>
         <translation>Échec du calibrage: Serrer le rouleau</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2588"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2639"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2600"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2651"/>
         <source>Unclip or stop pedalling to begin calibration..</source>
         <translation>Déclipez ou arrêtez de pédaler pour commencer le calibrage.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2607"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2619"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Torque %1</source>
@@ -33396,7 +33365,7 @@ Déclipez ou arrêtez de pédaler jusqu&apos;à la fin du processus.
 Couple%1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2612"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2624"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Torque %2</source>
@@ -33405,7 +33374,7 @@ Décalage zéro%1
 Couple%2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2659"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2671"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Zero Offset %1</source>
@@ -33414,7 +33383,7 @@ Déclipez ou arrêtez de pédaler jusqu&apos;à la fin du processus.
 Zéro (Offset) %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2676"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Slope %2</source>
@@ -33423,79 +33392,79 @@ Zéro (Offset) %1
 Pente %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2693"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2705"/>
         <source>Give the pedal a kick to start calibration...
 The motor will run until calibration is complete.</source>
         <translation>Pédaler pour commencer l&apos;étalonnage...
 Le moteur fonctionne jusqu&apos;à la fin de l&apos;étalonnage.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2695"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
         <source>Allow wheel speed to settle, DO NOT PEDAL...
 The motor will run until calibration is complete.</source>
         <translation>Laisser la vitesse de la roue se stabiliser, NE PAS PÉDALER...
 Le moteur fonctionne jusqu&apos;à la fin du calibrage.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2700"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2712"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Gathering enough samples to calculate average: %1</source>
         <translation>Calibrage... NE PAS PÉDALER, rester assis...
 Collecte de suffisamment d&apos;échantillons pour calculer la moyenne : %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2719"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Waiting for value to stabilize (max %1s): %2 (%3W @ %4kph)</source>
         <translation>Calibrage... NE PÉDALEZ PAS, restez assis...
 En attente de stabilisation de la valeur (max %1s)&#xa0;: %2 (%3W @ %4kph)</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2722"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
         <source>Calibration completed successfully!
 Final calibration value %1 (%2W @ %3kph)</source>
         <translation>Calibration terminée avec succès&#xa0;!
 Valeur d&apos;étalonnage finale %1 (%2W @ %3kph)</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2746"/>
         <source>Calibration failed! Do not pedal while calibration is taking place.
 Allow wheel to run freely.</source>
         <translation>L&apos;étalonnage a échoué! Ne pédalez pas pendant le calibrage.
 Laissez la roue tourner librement.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2780"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2792"/>
         <source>Fast forward..</source>
         <translation>Avance rapide..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2813"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2825"/>
         <source>Rewind..</source>
         <translation>Rembobiner..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2843"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2855"/>
         <source>Next Lap..</source>
         <translation>Tour suivant..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2876"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2888"/>
         <source>Back Lap..</source>
         <translation>Retour arrière..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2902"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2914"/>
         <source>Increasing intensity..</source>
         <translation>Intensité croissante..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2928"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2940"/>
         <source>Decreasing intensity..</source>
         <translation>Intensité décroissante..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="621"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="625"/>
         <source>Import Video from File</source>
         <translation>Importer une vidéo</translation>
     </message>
@@ -33504,73 +33473,73 @@ Laissez la roue tourner librement.</translation>
         <translation type="obsolete">Filtrer...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="303"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="307"/>
         <source>Workout Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="507"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="511"/>
         <source>Get Workouts from TrainerDay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="508"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="512"/>
         <source>Get Workouts from Strava Routes</source>
         <translation>Obtenir des entraînements à partir d&apos;itinéraires Strava</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="622"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="626"/>
         <source>Scan for Videos</source>
         <translation>Balayer à la recherche de vidéos</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1101"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1173"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3183"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1105"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1177"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3195"/>
         <source>Delete</source>
         <translation>Effacer</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>No Devices Configured</source>
         <translation>Pas d&apos;appareil configuré</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>Please configure a device in Preferences.</source>
         <translation>Veuillez configurer un appareil dans les Préférences.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2483"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2495"/>
         <source>Exiting calibration..</source>
         <translation>Sortir de la calibration..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2498"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2510"/>
         <source>Calibration not supported for this device.</source>
         <translation>La calibration n&apos;est pas pris en charge pour cet appareil.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2505"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2517"/>
         <source>Calibrating...
 Press F3 on Controller when done.</source>
         <translation>Calibration...
 Appuyer sur F3 sur le contrôleur une fois effectué.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3135"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3153"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3147"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3165"/>
         <source>Add Device</source>
         <translation>Ajouter un périphérique</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3140"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3158"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3152"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3170"/>
         <source>Delete Device</source>
         <translation>Effacer un périphérique</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3181"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3193"/>
         <source>Are you sure you want to delete this device?</source>
         <translation>Etes-vous sûr de vouloir supprimer le périphérique?</translation>
     </message>
@@ -33883,7 +33852,7 @@ Appuyer sur F3 sur le contrôleur une fois effectué.</translation>
 <context>
     <name>UniqueLabelEditDelegate</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="77"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="108"/>
         <source>The given value &quot;%1&quot; is not unique</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33899,171 +33868,167 @@ Appuyer sur F3 sur le contrôleur une fois effectué.</translation>
 <context>
     <name>UserChartSettings</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="772"/>
+        <location filename="../../Charts/UserChart.cpp" line="773"/>
         <source>Chart</source>
         <translation>Graphique</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="782"/>
+        <location filename="../../Charts/UserChart.cpp" line="783"/>
         <source>Sub-title</source>
         <translation>Sous-titre</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="785"/>
+        <location filename="../../Charts/UserChart.cpp" line="786"/>
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="791"/>
+        <location filename="../../Charts/UserChart.cpp" line="792"/>
         <source>Line Chart</source>
         <translation>Graphique en courbes</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="792"/>
+        <location filename="../../Charts/UserChart.cpp" line="793"/>
         <source>Scatter Chart</source>
         <translation>Graphique à nuages de points</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="793"/>
+        <location filename="../../Charts/UserChart.cpp" line="794"/>
         <source>Bar Chart</source>
         <translation>Graphique à barres</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="794"/>
+        <location filename="../../Charts/UserChart.cpp" line="795"/>
         <source>Stacked Bar Chart</source>
         <translation>Histogramme empilé</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="795"/>
+        <location filename="../../Charts/UserChart.cpp" line="796"/>
         <source>Stacked Percent Chart</source>
         <translation>Histogramme empilé à 100 %</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="796"/>
+        <location filename="../../Charts/UserChart.cpp" line="797"/>
         <source>Pie Chart</source>
         <translation>Graphique circulaire</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="800"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="801"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="804"/>
+        <location filename="../../Charts/UserChart.cpp" line="805"/>
         <source>Vertical</source>
         <translation>Vertical</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="805"/>
+        <location filename="../../Charts/UserChart.cpp" line="806"/>
         <source>Horizontal</source>
         <translation>Horizontal</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="808"/>
+        <location filename="../../Charts/UserChart.cpp" line="809"/>
         <source>Layout</source>
         <translation>Disposition</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="812"/>
+        <location filename="../../Charts/UserChart.cpp" line="813"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="813"/>
+        <location filename="../../Charts/UserChart.cpp" line="814"/>
         <source>Top</source>
         <translation>Haut</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="814"/>
+        <location filename="../../Charts/UserChart.cpp" line="815"/>
         <source>Left</source>
         <translation>Gauche</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="815"/>
+        <location filename="../../Charts/UserChart.cpp" line="816"/>
         <source>Right</source>
         <translation>Droite</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="816"/>
+        <location filename="../../Charts/UserChart.cpp" line="817"/>
         <source>Bottom</source>
         <translation>Bas</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="820"/>
+        <location filename="../../Charts/UserChart.cpp" line="821"/>
         <source>Legend</source>
         <translation>Légende</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="829"/>
+        <location filename="../../Charts/UserChart.cpp" line="830"/>
         <source>Font scaling</source>
         <translation>Mise à l&apos;échelle des polices</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="831"/>
-        <location filename="../../Charts/UserChart.cpp" line="833"/>
+        <location filename="../../Charts/UserChart.cpp" line="832"/>
+        <location filename="../../Charts/UserChart.cpp" line="834"/>
         <source>Background</source>
         <translation>Fond</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="836"/>
+        <location filename="../../Charts/UserChart.cpp" line="837"/>
         <source>Animate</source>
         <translation>Animer</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="838"/>
+        <location filename="../../Charts/UserChart.cpp" line="839"/>
         <source>Single series per plot</source>
         <translation>Série unique par tracé</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="841"/>
+        <location filename="../../Charts/UserChart.cpp" line="842"/>
         <source>Refresh for intervals</source>
         <translation>Actualiser pour les intervalles</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="848"/>
+        <location filename="../../Charts/UserChart.cpp" line="849"/>
         <source>Series</source>
         <translation>Série</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Group</source>
         <translation>Groupe</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Y Formula</source>
         <translation>Formule Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="870"/>
-        <location filename="../../Charts/UserChart.cpp" line="932"/>
         <source>Edit</source>
-        <translation>Editer</translation>
+        <translation type="vanished">Editer</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="889"/>
         <source>Up</source>
-        <translation>Vers le haut</translation>
+        <translation type="vanished">Vers le haut</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="890"/>
         <source>Down</source>
-        <translation>Vers le bas</translation>
+        <translation type="vanished">Vers le bas</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="911"/>
+        <location filename="../../Charts/UserChart.cpp" line="885"/>
         <source>Axes</source>
         <translation>Axes</translation>
     </message>
@@ -34737,72 +34702,72 @@ Appuyer sur F3 sur le contrôleur une fois effectué.</translation>
 <context>
     <name>VideoWindow</name>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> kph</source>
         <translation> km/h</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="119"/>
+        <location filename="../../Train/VideoWindow.cpp" line="144"/>
         <source>Meters layout</source>
         <translation>Disposition des compteurs</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="127"/>
+        <location filename="../../Train/VideoWindow.cpp" line="152"/>
         <source>Reset Meters layout to default</source>
         <translation>Réinitialiser la disposition des compteurs par défaut</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> mph</source>
         <translation> mph</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> m</source>
         <translation> m</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> feet</source>
         <translation> feet</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="625"/>
+        <location filename="../../Train/VideoWindow.cpp" line="681"/>
         <source>w</source>
         <translation>w</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="629"/>
+        <location filename="../../Train/VideoWindow.cpp" line="685"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> km</source>
         <translation> km</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> mi</source>
         <translation> mi</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="673"/>
+        <location filename="../../Train/VideoWindow.cpp" line="729"/>
         <source>Calibration required</source>
         <translation>Calibration requise</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="678"/>
+        <location filename="../../Train/VideoWindow.cpp" line="734"/>
         <source>Configuration required</source>
         <translation>Configuration requise</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="683"/>
+        <location filename="../../Train/VideoWindow.cpp" line="739"/>
         <source>brake fault</source>
         <translation>Faute sur le frein</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="688"/>
+        <location filename="../../Train/VideoWindow.cpp" line="744"/>
         <source>Ready</source>
         <translation>Prêt</translation>
     </message>
@@ -35237,27 +35202,27 @@ Appuyer sur F3 sur le contrôleur une fois effectué.</translation>
 <context>
     <name>WheelSizeCalculator</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="202"/>
+        <location filename="../../Gui/AthletePages.cpp" line="187"/>
         <source>Wheel Size Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="221"/>
+        <location filename="../../Gui/AthletePages.cpp" line="206"/>
         <source>Rim Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="222"/>
+        <location filename="../../Gui/AthletePages.cpp" line="207"/>
         <source>Tire Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="223"/>
+        <location filename="../../Gui/AthletePages.cpp" line="208"/>
         <source>Wheel Size</source>
         <translation type="unfinished">Taille de la roue</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="227"/>
         <source>mm</source>
         <translation type="unfinished">mm</translation>
     </message>
@@ -35369,12 +35334,12 @@ Appuyer sur F3 sur le contrôleur une fois effectué.</translation>
 <context>
     <name>WorkoutFilterBox</name>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="34"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="44"/>
         <source>Filter...</source>
         <translation type="unfinished">Filtrer...</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="64"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="95"/>
         <source>ERROR: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -35382,12 +35347,12 @@ Appuyer sur F3 sur le contrôleur une fois effectué.</translation>
 <context>
     <name>WorkoutImportDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="820"/>
+        <location filename="../../Train/Library.cpp" line="809"/>
         <source>Import to Library</source>
         <translation>Importer dans la bibliothèque</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="854"/>
+        <location filename="../../Train/Library.cpp" line="843"/>
         <source>Please note, that when importing or drag and dropping videos into the library we DO NOT copy the file into the GoldenCheetah library, instead we add a REFERENCE to it. We DO copy workout and videoSync files, since they are smaller.
 
 You can remove references when managing the library via the context menu options</source>
@@ -35396,24 +35361,107 @@ You can remove references when managing the library via the context menu options
 Vous pouvez supprimer des références lors de la gestion de la bibliothèque via les options du menu contextuel</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="868"/>
+        <location filename="../../Train/Library.cpp" line="857"/>
         <source>Files</source>
         <translation>Fichiers</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="878"/>
+        <location filename="../../Train/Library.cpp" line="867"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="880"/>
+        <location filename="../../Train/Library.cpp" line="869"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="884"/>
+        <location filename="../../Train/Library.cpp" line="873"/>
         <source>Overwite existing files</source>
         <translation>Ecraser les fichiers existants</translation>
+    </message>
+</context>
+<context>
+    <name>WorkoutMenuProvider</name>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="271"/>
+        <source>Select Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="274"/>
+        <source>Manage Filters</source>
+        <translation type="unfinished">Gérer les filtres</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="275"/>
+        <source>Add Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="289"/>
+        <source>Add Tag to Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="292"/>
+        <source>Filter Tags...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="310"/>
+        <source>Match all selected tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="353"/>
+        <source>Manage Workout Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="360"/>
+        <source>Name</source>
+        <translation type="unfinished">Nom</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="361"/>
+        <source>Filter</source>
+        <translation type="unfinished">Filtre</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="362"/>
+        <source>_index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="370"/>
+        <source>Execute</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="371"/>
+        <source>Update</source>
+        <translation type="unfinished">Mettre à jour</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="423"/>
+        <source>Add Workout Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="426"/>
+        <source>Name of the Filter...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="467"/>
+        <source>New</source>
+        <translation type="unfinished">Nouveau</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="469"/>
+        <source>New (%1)</source>
+        <translation type="unfinished">Nouveau (%1)</translation>
     </message>
 </context>
 <context>
@@ -35428,42 +35476,42 @@ Vous pouvez supprimer des références lors de la gestion de la bibliothèque vi
     <name>WorkoutPlotWindow</name>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="40"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="104"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
         <source>Ergmode specific settings</source>
         <translation>Paramètres spécifiques au mode Erg</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="46"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
         <source>Color power zones</source>
         <translation>Colorer les zones de puissance</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="48"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="56"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
         <source>Never</source>
         <translation>Jamais</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="49"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
         <source>Always</source>
         <translation>Toujours</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="50"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="57"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="109"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="113"/>
         <source>When stopped</source>
         <translatorcomment>not 100% sure</translatorcomment>
         <translation>A l&apos;arrêt</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="54"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="110"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
         <source>Show tooltip</source>
         <translation>Afficher l&apos;infobulle</translation>
     </message>
@@ -35553,12 +35601,12 @@ Vous pouvez supprimer des références lors de la gestion de la bibliothèque vi
 <context>
     <name>WorkoutWidget</name>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="1531"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="1532"/>
         <source>File save failed.</source>
         <translation>L&apos;enregistrement du fichier a échoué.</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="2367"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="2368"/>
         <source>Intensity</source>
         <translation>Intensité</translation>
     </message>
@@ -35712,26 +35760,22 @@ Vous pouvez supprimer des références lors de la gestion de la bibliothèque vi
 <context>
     <name>XDataDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="44"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="45"/>
         <source>xData</source>
         <translation>xData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="58"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="59"/>
         <source>Data Series</source>
         <translation>Série de données</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="78"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="80"/>
         <source>Add</source>
-        <translation>Ajouter</translation>
+        <translation type="vanished">Ajouter</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="79"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="81"/>
         <source>Delete</source>
-        <translation>Supprimer</translation>
+        <translation type="vanished">Supprimer</translation>
     </message>
 </context>
 <context>
@@ -35808,32 +35852,32 @@ Vous pouvez supprimer des références lors de la gestion de la bibliothèque vi
 <context>
     <name>XDataSeriesSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="333"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="315"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="338"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="320"/>
         <source>Units</source>
         <translation>Unités</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="346"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="328"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="347"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="329"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Name is blank</source>
         <translation>Le nom est vide</translation>
     </message>
@@ -35841,48 +35885,48 @@ Vous pouvez supprimer des références lors de la gestion de la bibliothèque vi
 <context>
     <name>XDataSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="262"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="244"/>
         <source>xData</source>
         <translation>xData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="269"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="251"/>
         <source>Data Series</source>
         <translation>Série de données</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="270"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="252"/>
         <source>Units</source>
         <translation>Unités</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="274"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="256"/>
         <source>Series %1</source>
         <translation>Séries %1</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="281"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="263"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="282"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="264"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
         <source>XData name is blank</source>
         <translation>Le nom XData est vide</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Must have at least one data series.</source>
         <translation>Doit avoir au moins une série de données.</translation>
     </message>
@@ -36203,17 +36247,17 @@ Vous pouvez supprimer des références lors de la gestion de la bibliothèque vi
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="915"/>
+        <location filename="../../Gui/AthletePages.cpp" line="886"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="962"/>
+        <location filename="../../Gui/AthletePages.cpp" line="933"/>
         <source>Critical Power</source>
         <translation>Puissance critique</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="963"/>
+        <location filename="../../Gui/AthletePages.cpp" line="934"/>
         <source>Default</source>
         <translation>Défaut</translation>
     </message>

--- a/src/Resources/translations/gc_it.ts
+++ b/src/Resources/translations/gc_it.ts
@@ -107,38 +107,38 @@ Potrebbe essere necessario disabilitarlo manualmente.</translation>
         <translation type="vanished">LTS medio (giorni)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="504"/>
+        <location filename="../../Gui/AthletePages.cpp" line="489"/>
         <source>s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="517"/>
-        <location filename="../../Gui/AthletePages.cpp" line="522"/>
+        <location filename="../../Gui/AthletePages.cpp" line="502"/>
+        <location filename="../../Gui/AthletePages.cpp" line="507"/>
         <source>days</source>
         <translation>giorni</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="525"/>
+        <location filename="../../Gui/AthletePages.cpp" line="510"/>
         <source>PMC Stress Balance Today</source>
         <translation>PMC Bilancio Stress Oggi</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="528"/>
+        <location filename="../../Gui/AthletePages.cpp" line="513"/>
         <source>Restore Defaults</source>
         <translation>Ripristina Predefiniti</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="517"/>
         <source>W&apos;bal tau</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="518"/>
         <source>Short Term Stress (STS) average</source>
         <translation>Media Short Term Stress (STS)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="534"/>
+        <location filename="../../Gui/AthletePages.cpp" line="519"/>
         <source>Long Term Stress (LTS) average</source>
         <translation>Media Long Term Stress (LTS)</translation>
     </message>
@@ -154,96 +154,96 @@ Potrebbe essere necessario disabilitarlo manualmente.</translation>
 <context>
     <name>AboutRiderPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="372"/>
+        <location filename="../../Gui/AthletePages.cpp" line="357"/>
         <source>Nickname</source>
         <translation>Alias</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="373"/>
+        <location filename="../../Gui/AthletePages.cpp" line="358"/>
         <source>Date of Birth</source>
         <translation>Data di nascita</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="374"/>
+        <location filename="../../Gui/AthletePages.cpp" line="359"/>
         <source>Sex</source>
         <translation>Sesso</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="376"/>
+        <location filename="../../Gui/AthletePages.cpp" line="361"/>
         <source>Weight</source>
         <translation>Peso</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="375"/>
+        <location filename="../../Gui/AthletePages.cpp" line="360"/>
         <source>Height</source>
         <translation>Altezza</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="279"/>
+        <location filename="../../Gui/AthletePages.cpp" line="264"/>
         <source>Male</source>
         <translation>Uomo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="280"/>
+        <location filename="../../Gui/AthletePages.cpp" line="265"/>
         <source>Female</source>
         <translation>Donna</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> kg</source>
         <translation> kg</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> lb</source>
         <translation> lb</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> cm</source>
         <translation> cm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> in</source>
         <translation> in</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="359"/>
+        <location filename="../../Gui/AthletePages.cpp" line="344"/>
         <source>Calculate...</source>
         <translation>Calcola...</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="378"/>
+        <location filename="../../Gui/AthletePages.cpp" line="363"/>
         <source>Bike</source>
         <translation>Bicicletta</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="379"/>
+        <location filename="../../Gui/AthletePages.cpp" line="364"/>
         <source>Crank Length</source>
         <translation>Lunghezza pedivella</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="380"/>
+        <location filename="../../Gui/AthletePages.cpp" line="365"/>
         <source>Wheelsize</source>
         <translation>Dimensione ruota</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="438"/>
+        <location filename="../../Gui/AthletePages.cpp" line="423"/>
         <source>Images</source>
         <translation>Immagini</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="356"/>
+        <location filename="../../Gui/AthletePages.cpp" line="341"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="437"/>
+        <location filename="../../Gui/AthletePages.cpp" line="422"/>
         <source>Choose Picture</source>
         <translation>Seleziona foto</translation>
     </message>
@@ -2277,397 +2277,394 @@ Clicca Successivo per Continuare
 <context>
     <name>AllPlotWindow</name>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="190"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="444"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="165"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
         <source>Smooth</source>
         <translation>Approssima</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="198"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="173"/>
         <source>Stacked</source>
         <translation>Grafici sovrapposti</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="199"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="174"/>
         <source>by series</source>
         <translation>per serie</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="200"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="175"/>
         <source>Fullplot</source>
         <translation>Disegno Intero</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="201"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="176"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="239"/>
         <source>Overlay</source>
         <translation>Sovrapponi</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="229"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="204"/>
         <source>View</source>
         <translation>Vista</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="206"/>
         <source>Stack</source>
         <translation>Pila</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="210"/>
         <source>By Series</source>
         <translation>Per serie</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="246"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="221"/>
         <source>Stack Zoom</source>
         <translation>ingrandimento Pila</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="248"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="223"/>
         <source>Full plot</source>
         <translation>Grafico completo</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="227"/>
         <source>Show Interval Markers</source>
         <translation>Mostra i Marcatori degli Intervalli</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="256"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
         <source>Interval Navigator</source>
         <translation>Navigatore Intervalli</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="260"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
         <source>Hover intervals</source>
         <translation>Selezionare Intervalli</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="268"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="243"/>
         <source>Fill Curves</source>
         <translation>Riempi le curve</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="247"/>
         <source>Grid</source>
         <translation>Griglia</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="277"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
         <source>Acceleration</source>
         <translation>Accelerazione</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="279"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="254"/>
         <source>Delta Series</source>
         <translation>Serie Delta</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="280"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="255"/>
         <source>Power %1</source>
         <translation>Potenza %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="283"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="258"/>
         <source>Cadence %1</source>
         <translation>Cadenza %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="261"/>
         <source>Torque %1</source>
         <translation>Coppia torcente %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="289"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
         <source>Heartrate %1</source>
         <translation>Frequenza Cardiaca %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="295"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="270"/>
         <source>Balance</source>
         <translation>Bilancio</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
         <source>Left/Right</source>
         <translation>Sinistra/Destra</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="274"/>
         <source>Torque Effectiveness</source>
         <translation>Efficacità Coppia torcente</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="303"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="278"/>
         <source>Smoothness</source>
         <translation>Omogeneità</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="282"/>
         <source>Pedal Center Offset</source>
         <translation>Scarto centro pedale</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="311"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
         <source>Power Phase</source>
         <translation>Fase Potenza</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="290"/>
         <source>Peak Power Phase</source>
         <translation>Fase Picco di potenza</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="322"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
         <source>Vertical Oscillation</source>
         <translation>Oscillazione verticale</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="324"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
         <source>Running</source>
         <translation>Correre</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="326"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="301"/>
         <source>Ground Contact Time</source>
         <translation>Tempo di contatto al suolo</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
         <source>Cadence </source>
         <translation>Cadenza </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="313"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="340"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
         <source>Moxy</source>
         <translation>Moxy</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="317"/>
         <source>tHb</source>
         <translation>tHB</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="321"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="325"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="355"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="330"/>
         <source>Heart Rate</source>
         <translation>Frequenza Cardiaca</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="357"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
         <source>Data series</source>
         <translation>Serie di Dati</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="359"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="334"/>
         <source>Core Temperature</source>
         <translation>Temperatura di base</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="363"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
         <source>Speed</source>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="367"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
         <source>Cadence</source>
         <translation>Cadenza</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="94"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="95"/>
         <source>Basic</source>
         <translation>Base</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="109"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="110"/>
         <source>Curves</source>
         <translation>Curve</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="116"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="117"/>
         <source>User Data</source>
         <translation>Dati utente</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="132"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="134"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Formula</source>
         <translation>Formula</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="144"/>
         <source>Edit</source>
-        <translation>Modifica</translation>
+        <translation type="vanished">Modifica</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="163"/>
         <source>Up</source>
-        <translation>Sopra</translation>
+        <translation type="vanished">Sopra</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="164"/>
         <source>Down</source>
-        <translation>Sotto</translation>
+        <translation type="vanished">Sotto</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="371"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
         <source>Altitude</source>
         <translation>Quota</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
         <source>Temperature</source>
         <translation>Temperatura</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="379"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="354"/>
         <source>Headwind</source>
         <translation>Vento Contrario</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="383"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="358"/>
         <source>Torque</source>
         <translation>Coppia</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="387"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="362"/>
         <source>Gear Ratio</source>
         <translation>Rapporti</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="391"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="366"/>
         <source>Slope</source>
         <translation>Pendenza</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="373"/>
         <source>No Alt/Slope</source>
         <translation>No Alt/Pendenza</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="399"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="374"/>
         <source>0.1km|mi -  1min</source>
         <translation>0.1km|mi -  1min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="400"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
         <source>0.5km|mi -  5min</source>
         <translation>0.5km|mi -  5min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="401"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="376"/>
         <source>1.0km|mi - 10min</source>
         <translation>1km|mi -  10min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1528"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="377"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="1503"/>
         <source>Alt/Slope</source>
         <translation>Alt/Pendenza</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="382"/>
         <source>Anaerobic TISS</source>
         <translation>TISS Anaerobico</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="384"/>
         <source>Metrics</source>
         <translation>Misure</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="411"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="386"/>
         <source>Aerobic TISS</source>
         <translation>TISS Aerobico</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="390"/>
         <source>Iso Power</source>
         <translation>Potenza Iso</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="394"/>
         <source>Skiba xPower</source>
         <translation>xPower Skiba</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="423"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
         <source>Altitude Power</source>
         <translation>Potenza Altitudine</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="427"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
         <source>W&apos; balance</source>
         <translation>Bilancio W&apos;</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="441"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="416"/>
         <source>Time of day</source>
         <translation>Orario del Giorno</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="742"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="717"/>
         <source>Intervals</source>
         <translation>Intervalli</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="2253"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="2228"/>
         <source>Selection #%1 </source>
         <translation>Selezione #%1 </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="432"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
         <source>Power + shade</source>
         <translation>Potenza + sfondo</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="433"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="408"/>
         <source>Power - shade</source>
         <translation>Potenza - sfondo</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="434"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
         <source>No Power</source>
         <translation>Senza Potenza</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="435"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="410"/>
         <source>Shading</source>
         <translation>Ombreggia</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="439"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="414"/>
         <source>Time</source>
         <translation>Tempo</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="440"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
         <source>Distance</source>
         <translation>Distanza</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="442"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="417"/>
         <source>X Axis</source>
         <translation>Asse X</translation>
     </message>
@@ -3478,51 +3475,45 @@ Clicca Successivo per Continuare
 <context>
     <name>AutoImportPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4028"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4029"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
         <source>Browse</source>
         <translation type="vanished">Sfoglia</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4040"/>
         <source>Add</source>
-        <translation>Aggiungi</translation>
+        <translation type="vanished">Aggiungi</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4041"/>
         <source>Delete</source>
-        <translation>Cancella</translation>
+        <translation type="vanished">Cancella</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4042"/>
         <source>Up</source>
-        <translation>Sopra</translation>
+        <translation type="vanished">Sopra</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4043"/>
         <source>Down</source>
-        <translation>Sotto</translation>
+        <translation type="vanished">Sotto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4054"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3779"/>
         <source>Enter a directory</source>
         <translation>Seleziona una cartella</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4059"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3784"/>
         <source>Directory</source>
         <translation>Cartella</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4060"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3785"/>
         <source>Import Rule</source>
         <translation>Regola importazione</translation>
     </message>
@@ -4341,37 +4332,37 @@ Clicca Successivo per Continuare
 <context>
     <name>BackupPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="608"/>
+        <location filename="../../Gui/AthletePages.cpp" line="593"/>
         <source>Enter a directory</source>
         <translation>Seleziona una cartella</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="601"/>
         <source>every</source>
         <translation>ogni</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="617"/>
+        <location filename="../../Gui/AthletePages.cpp" line="602"/>
         <source>times</source>
         <translation>volte</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="603"/>
         <source>never</source>
         <translation>mai</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="605"/>
         <source>Backup now</source>
         <translation>Avvia il backup</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="623"/>
+        <location filename="../../Gui/AthletePages.cpp" line="608"/>
         <source>Auto Backup Folder</source>
         <translation>Cartella di backup automatico</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="624"/>
+        <location filename="../../Gui/AthletePages.cpp" line="609"/>
         <source>Auto Backup after closing the athlete</source>
         <translation>Backup automatico dopo la chiusura dell&apos;atleta</translation>
     </message>
@@ -5201,41 +5192,33 @@ Iniziamo la configurazione.</translation>
         <translation type="vanished">Aggiorna</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1202"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1203"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1204"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1150"/>
         <source>Review...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1206"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1152"/>
         <source>Changed power estimates are available</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1213"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1225"/>
         <source>Add</source>
-        <translation>Aggiungi</translation>
+        <translation type="vanished">Aggiungi</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1214"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1226"/>
         <source>Delete</source>
-        <translation>Cancella</translation>
+        <translation type="vanished">Cancella</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1216"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1158"/>
         <source>Def</source>
         <translation>Def</translation>
     </message>
@@ -5244,27 +5227,27 @@ Iniziamo la configurazione.</translation>
         <translation type="vanished">Da data</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1218"/>
         <source>Critical Power</source>
         <translation>Potenza Critica (CP)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1305"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>AeTP</source>
         <translation>AeTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1306"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>FTP</source>
         <translation>FTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1307"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1221"/>
         <source>W&apos;</source>
         <translation>W&apos;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1308"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1222"/>
         <source>Pmax</source>
         <translation>Pmax</translation>
     </message>
@@ -5277,207 +5260,207 @@ Iniziamo la configurazione.</translation>
         <translation type="vanished">La Potenza Critica deve essere &gt; 0</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1347"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1261"/>
         <source>Short</source>
         <translation>Corto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1247"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1169"/>
         <source>Use CP for all metrics</source>
         <translation>Usa CP per tutte le misure</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1240"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1162"/>
         <source>Manual</source>
         <translation type="unfinished">Manuale</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1241"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1163"/>
         <source>Semi-Automatic (CP2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1164"/>
         <source>Semi-Automatic (CP3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1243"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1165"/>
         <source>Semi-Automatic (Extended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1170"/>
         <source>Use FTP for Coggan metrics</source>
         <translation>Usa FTP per le misure di Coggan</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1273"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1279"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1285"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1342"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1618"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1631"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2283"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2289"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2310"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1187"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1193"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1199"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1211"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1537"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1545"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2180"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2186"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2194"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2207"/>
         <source>W</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1205"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1547"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2201"/>
         <source>J</source>
         <translation>J</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1303"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1217"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2145"/>
         <source>Start Date</source>
         <translation type="unfinished">Data di partenza</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1309"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1223"/>
         <source>Model Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1262"/>
         <source>Long</source>
         <translation>Lungo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1349"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1263"/>
         <source>From Watts</source>
         <translation>Da watt</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1598"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1512"/>
         <source>Review range starting on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1614"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1528"/>
         <source>Current</source>
         <translation type="unfinished">In uso</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1615"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1529"/>
         <source>Estimate</source>
         <translation type="unfinished">Stima</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1530"/>
         <source>Accept</source>
         <translation type="unfinished">Accetta</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1788"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1691"/>
         <source>🗹</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1692"/>
         <source>Estimate and settings &lt;b&gt;match&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1695"/>
         <source>☐</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1696"/>
         <source>Estimate and settings &lt;b&gt;differ&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1797"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1700"/>
         <source>⏲</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1800"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1703"/>
         <source>Range is %1 days older than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1802"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1705"/>
         <source>Range is %1 days younger than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1808"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1711"/>
         <source>∅</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1712"/>
         <source>No estimate available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1902"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1805"/>
         <source>New range from estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2237"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2134"/>
         <source>The proposed value for AeTP is a very rough estimate, assuming %1 % of CP. Usually it is determined by a&lt;ul&gt;&lt;li&gt;Metabolic test&lt;/li&gt;&lt;li&gt;Lactate ramp test&lt;/li&gt;&lt;li&gt;Run / Cycling ‘conversational’ test&lt;/li&gt;&lt;li&gt;Run Decoupling test&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2239"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2136"/>
         <source>Updating FTP internally to match CP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2139"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2244"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2141"/>
         <source>Your selected model does not deliver values for PMax, using default value of %1 W instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2246"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2143"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;li&gt;PMax, assuming a default of %1 W&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2250"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2147"/>
         <source>Critical Power (CP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2252"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2149"/>
         <source>Aerobic Threshold Power (AeTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2254"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2151"/>
         <source>Functional Threshold Power (FTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2153"/>
         <source>Anaerobic Work Capacity (W&apos;)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2258"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2155"/>
         <source>Maximum Power (PMax)</source>
         <translation type="unfinished">Potenza Massima (PMax)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2270"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2167"/>
         <source>Manual range</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5486,14 +5469,14 @@ Iniziamo la configurazione.</translation>
         <translation type="vanished">Raggiunto il massimo di 10 zone.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2018"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2025"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1917"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1924"/>
         <source>New</source>
         <translation>Nuovo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2020"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1919"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1926"/>
         <source>New (%1)</source>
         <translation>Nuovo (%1)</translation>
     </message>
@@ -5946,52 +5929,44 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">Aggiorna</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3307"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3319"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3308"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3320"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3313"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3325"/>
         <source>Add</source>
-        <translation>Aggiungi</translation>
+        <translation type="vanished">Aggiungi</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3314"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3326"/>
         <source>Delete</source>
-        <translation>Cancella</translation>
+        <translation type="vanished">Cancella</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3316"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3109"/>
         <source>Def</source>
         <translation>Def</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3359"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3506"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3272"/>
         <source>Start Date</source>
         <translation type="unfinished">Data di partenza</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3249"/>
         <source>New range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3507"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3273"/>
         <source>Critical Velocity (CV)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3508"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3274"/>
         <source>Aerobic Threshold (AeT)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6000,12 +5975,12 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">Da data</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3360"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3128"/>
         <source>Critical Velocity</source>
         <translation>Velocità Critica</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3361"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3129"/>
         <source>Aerobic Threshold</source>
         <translation>Soglia Aerobica</translation>
     </message>
@@ -6018,17 +5993,17 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">d MMM, yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3403"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
         <source>Short</source>
         <translation>Corto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3404"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3172"/>
         <source>Long</source>
         <translation>Lungo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3405"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3173"/>
         <source>From</source>
         <translation>Da</translation>
     </message>
@@ -6037,14 +6012,14 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">Raggiunto il massimo di 10 zone.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3679"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3686"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3441"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3448"/>
         <source>New</source>
         <translation>Nuovo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3681"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3688"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3443"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3450"/>
         <source>New (%1)</source>
         <translation>Nuovo (%1)</translation>
     </message>
@@ -7583,37 +7558,32 @@ Vuoi procedere e riavviare Golden Cheetah?</translation>
 <context>
     <name>CredentialsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="67"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
+    </message>
+    <message>
+        <source>-</source>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="vanished">Modifica</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">Aggiungi</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">Cancella</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="68"/>
-        <source>-</source>
-        <translation>-</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="69"/>
-        <source>Edit</source>
-        <translation>Modifica</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="74"/>
-        <source>Add</source>
-        <translation>Aggiungi</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="75"/>
-        <source>Delete</source>
-        <translation>Cancella</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="86"/>
         <source>Service</source>
         <translation>Servizio</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="87"/>
+        <location filename="../../Gui/AthletePages.cpp" line="69"/>
         <source>Description</source>
         <translation>Descrizione</translation>
     </message>
@@ -8300,7 +8270,7 @@ Vuoi procedere e riavviare Golden Cheetah?</translation>
 <context>
     <name>DataFilterEdit</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2743"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2712"/>
         <source>Warning: sample() is slow -- update code to use samples()</source>
         <translation>Attenzione: la funzione sample() e&apos; lenta -- aggiorna il codice usando samples()</translation>
     </message>
@@ -8659,7 +8629,7 @@ Vuoi procedere e riavviare Golden Cheetah?</translation>
 <context>
     <name>DirectoryPathWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="277"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="308"/>
         <source>Browse</source>
         <translation>Sfoglia</translation>
     </message>
@@ -8894,28 +8864,28 @@ Forse ti occorre (ri)installare FTDI o PL2303 drivers prima del download.</trans
 <context>
     <name>Dropbox</name>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="68"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="77"/>
         <source>Problem accessing Dropbox data</source>
         <translation>Problema nell&apos;accesso aii dati di Dropbox</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="130"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="139"/>
         <source>You must authorise with Dropbox first</source>
         <translation>Devi prima ottenere un autorizzazzione da Dropbox</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="205"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="214"/>
         <source>Parsing Error: %1</source>
         <translation>Errore di Parsing: %1</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="293"/>
-        <location filename="../../Cloud/Dropbox.cpp" line="312"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="302"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="321"/>
         <source>Completed.</source>
         <translation>Completato.</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="297"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="306"/>
         <source>Network Error - Upload failed.</source>
         <translation>Errore di rete - Caricamento non riuscito.</translation>
     </message>
@@ -9060,136 +9030,136 @@ Forse ti occorre (ri)installare FTDI o PL2303 drivers prima del download.</trans
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2064"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2033"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2034"/>
         <source>Axis Label / Units</source>
         <translation>Etichetta Assi / Unità</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1558"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1527"/>
         <source>Estimate %1 %2 Power</source>
         <translation>Stima Potenza %1 %2</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1562"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1531"/>
         <source>Endurance Index</source>
         <translation>Indice resistenza</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1532"/>
         <source>Vo2Max Estimate</source>
         <translation>Vo2MAX stimata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1597"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1566"/>
         <source>Curve Settings</source>
         <translation>Impostazioni curva</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1605"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1574"/>
         <source>Metric</source>
         <translation>Misura</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1606"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1575"/>
         <source>Best</source>
         <translation>Migliore</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1607"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1576"/>
         <source>Estimate</source>
         <translation>Stima</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1577"/>
         <source>PMC</source>
         <translation>PMC</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1609"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1578"/>
         <source>Formula</source>
         <translation>Formula</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1610"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1579"/>
         <source>Measure</source>
         <translation>Misura</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1611"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1580"/>
         <source>Performance</source>
         <translation>Performance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1612"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1581"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1684"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1767"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1653"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1736"/>
         <source>seconds</source>
         <translation>secondi</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1685"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1768"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1737"/>
         <source>minutes</source>
         <translation>minuti</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1769"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1655"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1738"/>
         <source>hours</source>
         <translation>ore</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1723"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1816"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1692"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1785"/>
         <source>Peak</source>
         <translation>Picco</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1781"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1750"/>
         <source>Absolute</source>
         <translation>Assoluto</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1751"/>
         <source>Per Kilogram</source>
         <translation>Per kilogrammo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1813"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
         <source>Total</source>
         <translation>Totale</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1814"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1783"/>
         <source>Running Total</source>
         <translation>Totale corsa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1815"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1784"/>
         <source>Average</source>
         <translation>Media</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1817"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1786"/>
         <source>Low</source>
         <translation>Basso</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1820"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1789"/>
         <source>Aggregate:</source>
         <translation>Unisci:</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1828"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1797"/>
         <source># type in a formula to use
 # for e.g. BikeStress / Duration
 # as you type the available metrics
@@ -9202,292 +9172,292 @@ Forse ti occorre (ri)installare FTDI o PL2303 drivers prima del download.</trans
 </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1839"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1808"/>
         <source>Weekly Best Performances</source>
         <translation>Migliori Performances Settimanali</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1840"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1809"/>
         <source>Submaximal Weekly Best</source>
         <translation>Migliore Submassimale Settimanale</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1841"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1810"/>
         <source>Performance Tests</source>
         <translation>Test di PErformance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1933"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1902"/>
         <source>Short Term Stress (STS/ATL)</source>
         <translation>Stress di Breve Durata (STS/ATL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1934"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1903"/>
         <source>Long Term Stress  (LTS/CTL)</source>
         <translation>Stress di Lunga Durata (LTS/CTL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1935"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1904"/>
         <source>Stress Balance    (SB/TSB)</source>
         <translation>Bilancio Stress    (SB/TSB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1936"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1905"/>
         <source>Stress Ramp Rate  (RR)</source>
         <translation>Tasso Aumento Stress  (RR)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1944"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1913"/>
         <source>Stress Type</source>
         <translation>Tipo di Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1949"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1918"/>
         <source>Negative Training Effect (NTE)</source>
         <translation>Effetto Negativo dell&apos;Allenamento (NTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1950"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1919"/>
         <source>Positive Training Effect (PTE)</source>
         <translation>Effetto Positivo dell&apos;Allenamento (PTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1951"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1920"/>
         <source>Performance (Power Index)</source>
         <translation>Performance (Indice Potenza)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1952"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1921"/>
         <source>Predicted CP (Watts)</source>
         <translation>CP Previsto (Watts)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1969"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1938"/>
         <source>Curve Type</source>
         <translation>Tipo di Curva</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1945"/>
         <source>Perf. Metric</source>
         <translation>Metrica Perf</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2006"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1975"/>
         <source>Metadata Field</source>
         <translation>Campo Metadati</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2007"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
         <source>PMC metric</source>
         <translation>Misura PMC</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2032"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2001"/>
         <source>Measure Group</source>
         <translation>Gruppo di Misura</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2009"/>
         <source>Measure Field</source>
         <translation>Campo di Misura</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2029"/>
         <source>Filter</source>
         <translation>Filtro</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2071"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
         <source>Style</source>
         <translation>Stile</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2042"/>
         <source>Bar</source>
         <translation>Barra</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2074"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2043"/>
         <source>Line</source>
         <translation>Linea</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2075"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2044"/>
         <source>Sticks</source>
         <translation>Stecche</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2076"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2045"/>
         <source>Dots</source>
         <translation>Punti</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2048"/>
         <source>Stack</source>
         <translation>Pila</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2053"/>
         <source>Symbol</source>
         <translation>Simbolo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2086"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2055"/>
         <source>None</source>
         <translation>Nessuno</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2087"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2056"/>
         <source>Circle</source>
         <translation>Cerchio</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2057"/>
         <source>Square</source>
         <translation>Quadrato</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2089"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2058"/>
         <source>Diamond</source>
         <translation>Diamante</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2090"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2059"/>
         <source>Triangle</source>
         <translation>Triangolo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2091"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
         <source>Cross</source>
         <translation>Croce</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2092"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2061"/>
         <source>Hexagon</source>
         <translation>Esagono</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2062"/>
         <source>Star</source>
         <translation>Stella</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
         <source>Color</source>
         <translation>Colore</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2100"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2069"/>
         <source>Fill curve</source>
         <translation>Riempi curve</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
         <source>Data labels</source>
         <translation>Etichette Dati</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2080"/>
         <source>Highlight Highest</source>
         <translation>Evidenzia il più alto</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
         <source>Highlight Lowest</source>
         <translation>Evidenzia il più basso</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2127"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
         <source>Highlight Outliers</source>
         <translation>Evidenzia Outliers</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2135"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
         <source>Baseline</source>
         <translation>Normale</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2143"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2112"/>
         <source>Smooth Curve</source>
         <translation>Approssima Curva</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2147"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2116"/>
         <source>No trend Line</source>
         <translation>Nessuna linea di trend</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2148"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2117"/>
         <source>Linear Trend</source>
         <translation>Trend lineare</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2149"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2118"/>
         <source>Quadratic Trend</source>
         <translation>Trend quadratico</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2150"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
         <source>Moving Average</source>
         <translation>Media di movimento</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2151"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2120"/>
         <source>Simple Average</source>
         <translation>Media semplice</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2123"/>
         <source>Ignore Zeros</source>
         <translation>Ignora Zeri</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2168"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2201"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2170"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancella</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2431"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2400"/>
         <source>Peak %1</source>
         <translation>Picco %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2402"/>
         <source> second </source>
         <translation> secondo </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2434"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2403"/>
         <source> minute </source>
         <translation> minuto </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2436"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2405"/>
         <source> hour </source>
         <translation> ora </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2456"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2425"/>
         <source>%1 - %2</source>
         <translation>%1 - %2</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2470"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2439"/>
         <source>Performances</source>
         <translation>Performances</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2471"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2440"/>
         <source>Power Index</source>
         <translation>Indice Potenza</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2588"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2557"/>
         <source>Performances_%1_%2_%3</source>
         <translation>Performances_%1_%2_%3</translation>
     </message>
@@ -9817,93 +9787,93 @@ Forse ti occorre (ri)installare FTDI o PL2303 drivers prima del download.</trans
 <context>
     <name>EditUserAxisDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1731"/>
+        <location filename="../../Charts/UserChart.cpp" line="1689"/>
         <source>Edit Axis</source>
         <translation>Modifica Asse</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1741"/>
+        <location filename="../../Charts/UserChart.cpp" line="1699"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1742"/>
+        <location filename="../../Charts/UserChart.cpp" line="1700"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancella</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1750"/>
+        <location filename="../../Charts/UserChart.cpp" line="1708"/>
         <source>Units</source>
         <translation>Unità</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1760"/>
+        <location filename="../../Charts/UserChart.cpp" line="1718"/>
         <source>Logarithmic Scale</source>
         <translation>Scala Logaritmica</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1757"/>
+        <location filename="../../Charts/UserChart.cpp" line="1715"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1761"/>
-        <location filename="../../Charts/UserChart.cpp" line="1780"/>
+        <location filename="../../Charts/UserChart.cpp" line="1719"/>
+        <location filename="../../Charts/UserChart.cpp" line="1738"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1763"/>
+        <location filename="../../Charts/UserChart.cpp" line="1721"/>
         <source>Fixed</source>
         <translation>Fisso</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1774"/>
+        <location filename="../../Charts/UserChart.cpp" line="1732"/>
         <source> from </source>
         <translation> da </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1776"/>
+        <location filename="../../Charts/UserChart.cpp" line="1734"/>
         <source> to </source>
         <translation> a </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1779"/>
+        <location filename="../../Charts/UserChart.cpp" line="1737"/>
         <source>Range</source>
         <translation>Intervallo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1787"/>
+        <location filename="../../Charts/UserChart.cpp" line="1745"/>
         <source>Smoothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1792"/>
+        <location filename="../../Charts/UserChart.cpp" line="1750"/>
         <source>None</source>
         <translation type="unfinished">Nessuno</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1793"/>
+        <location filename="../../Charts/UserChart.cpp" line="1751"/>
         <source>Day</source>
         <translation type="unfinished">Giorno</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1794"/>
+        <location filename="../../Charts/UserChart.cpp" line="1752"/>
         <source>Week</source>
         <translation type="unfinished">Settimana</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1795"/>
+        <location filename="../../Charts/UserChart.cpp" line="1753"/>
         <source>Month</source>
         <translation type="unfinished">Mese</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1796"/>
+        <location filename="../../Charts/UserChart.cpp" line="1754"/>
         <source>Year</source>
         <translation type="unfinished">Anno</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1798"/>
+        <location filename="../../Charts/UserChart.cpp" line="1756"/>
         <source>Group By</source>
         <translation type="unfinished">Raggruppa per</translation>
     </message>
@@ -10100,158 +10070,158 @@ Forse ti occorre (ri)installare FTDI o PL2303 drivers prima del download.</trans
 <context>
     <name>EditUserSeriesDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1398"/>
+        <location filename="../../Charts/UserChart.cpp" line="1356"/>
         <source>Edit Data Series</source>
         <translation>Modifica la serie dei dati</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1414"/>
+        <location filename="../../Charts/UserChart.cpp" line="1372"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1415"/>
+        <location filename="../../Charts/UserChart.cpp" line="1373"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancella</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1422"/>
+        <location filename="../../Charts/UserChart.cpp" line="1380"/>
         <source>Group</source>
         <translation type="unfinished">Gruppo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1430"/>
+        <location filename="../../Charts/UserChart.cpp" line="1388"/>
         <source>Series Name</source>
         <translation>Nome Serie</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1519"/>
+        <location filename="../../Charts/UserChart.cpp" line="1477"/>
         <source>Y units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1524"/>
+        <location filename="../../Charts/UserChart.cpp" line="1482"/>
         <source>X units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1528"/>
+        <location filename="../../Charts/UserChart.cpp" line="1486"/>
         <source>Sum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1529"/>
+        <location filename="../../Charts/UserChart.cpp" line="1487"/>
         <source>Average</source>
         <translation type="unfinished">Media</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1530"/>
+        <location filename="../../Charts/UserChart.cpp" line="1488"/>
         <source>Peak</source>
         <translation type="unfinished">Picco</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1531"/>
+        <location filename="../../Charts/UserChart.cpp" line="1489"/>
         <source>Low</source>
         <translation type="unfinished">Basso</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1532"/>
+        <location filename="../../Charts/UserChart.cpp" line="1490"/>
         <source>Running Total</source>
         <translation type="unfinished">Totale corsa</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1533"/>
+        <location filename="../../Charts/UserChart.cpp" line="1491"/>
         <source>Mean Square Root</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1534"/>
+        <location filename="../../Charts/UserChart.cpp" line="1492"/>
         <source>Std Deviation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1537"/>
+        <location filename="../../Charts/UserChart.cpp" line="1495"/>
         <source>Aggregate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1541"/>
-        <location filename="../../Charts/UserChart.cpp" line="1557"/>
+        <location filename="../../Charts/UserChart.cpp" line="1499"/>
+        <location filename="../../Charts/UserChart.cpp" line="1515"/>
         <source>None</source>
         <translation>Nessuno</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1542"/>
+        <location filename="../../Charts/UserChart.cpp" line="1500"/>
         <source>Solid</source>
         <translation>Continua</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1543"/>
+        <location filename="../../Charts/UserChart.cpp" line="1501"/>
         <source>Dashed</source>
         <translation>Tratteggiata</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1544"/>
+        <location filename="../../Charts/UserChart.cpp" line="1502"/>
         <source>Dot</source>
         <translation>Punto</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1545"/>
+        <location filename="../../Charts/UserChart.cpp" line="1503"/>
         <source>Dash Dot</source>
         <translation>Punto Tratteggiato</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1546"/>
+        <location filename="../../Charts/UserChart.cpp" line="1504"/>
         <source>Fast Graphics</source>
         <translation>Grafico Veloce</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1547"/>
+        <location filename="../../Charts/UserChart.cpp" line="1505"/>
         <source>Show on Legend</source>
         <translation>Mostra nella Legenda</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1548"/>
+        <location filename="../../Charts/UserChart.cpp" line="1506"/>
         <source>Show Data Labels</source>
         <translation>Mostra Etichette Dati</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1554"/>
+        <location filename="../../Charts/UserChart.cpp" line="1512"/>
         <source>Line Style</source>
         <translation>Stile Linea</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1558"/>
+        <location filename="../../Charts/UserChart.cpp" line="1516"/>
         <source>Circle</source>
         <translation>Cerchio</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1559"/>
+        <location filename="../../Charts/UserChart.cpp" line="1517"/>
         <source>Rectangle</source>
         <translation>Rettangolo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1564"/>
+        <location filename="../../Charts/UserChart.cpp" line="1522"/>
         <source>Symbol</source>
         <translation>Simbolo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1572"/>
+        <location filename="../../Charts/UserChart.cpp" line="1530"/>
         <source>Color</source>
         <translation>Colore</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1575"/>
+        <location filename="../../Charts/UserChart.cpp" line="1533"/>
         <source>Fill curve</source>
         <translation>Riempi curva</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1583"/>
+        <location filename="../../Charts/UserChart.cpp" line="1541"/>
         <source>Opacity (%)</source>
         <translation>Trasparenza (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1589"/>
+        <location filename="../../Charts/UserChart.cpp" line="1547"/>
         <source>Size/Width</source>
         <translation>Dimensione/Larghezza</translation>
     </message>
@@ -10298,6 +10268,24 @@ Forse ti occorre (ri)installare FTDI o PL2303 drivers prima del download.</trans
         <location filename="../../Metrics/BasicRideMetrics.cpp" line="144"/>
         <source>Only useful for intervals, time the interval started</source>
         <translation>Solo utile per intervalli, tempo di inizio dell&apos;intervallo</translation>
+    </message>
+</context>
+<context>
+    <name>ElevationChartWindow</name>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="221"/>
+        <source>Profile Distance (m)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="229"/>
+        <source>Seconds for delta slope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="237"/>
+        <source>Elevation window size (%) relative to current altitude</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10736,7 +10724,7 @@ Forse ti occorre (ri)installare FTDI o PL2303 drivers prima del download.</trans
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ExhaustionDialog.cpp" line="160"/>
+        <location filename="../../Charts/ExhaustionDialog.cpp" line="162"/>
         <source>Time</source>
         <translation>Tempo</translation>
     </message>
@@ -13413,42 +13401,42 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GcCrashDialog</name>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="78"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="74"/>
         <source>%1 Crash Recovery</source>
         <translation>%1 Ripristino Crash</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="116"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="112"/>
         <source>&lt;b&gt;GoldenCheetah appears to have PREVIOUSLY crashed for this athlete. &lt;/b&gt;&lt;br&gt;&lt;br&gt;The report below gives some diagnostic information that will be useful to the developers. Feel free to post this with a short description of what was occurring when the crash happened to the &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah forums&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;We respect privacy - this log does NOT contain ids, passwords or personal information.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;When this dialog is closed the athlete will be opened.&lt;/b&gt;</source>
         <translation>&lt;b&gt;GoldenCheetah e&apos; andato in Crash per questo Atleta. &lt;/b&gt;&lt;br&gt;&lt;br&gt;Il rapporto sottostante può dare delle utili informazioni agli sviluppatori. Sentiti libero di inviare una breve descrizione di cosa e&apos; successo prima del crash a &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah forums&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;Noi rispettiamo la privacy - questo log non contiene alcun identità dell&apos;utente, passwords o informazioni personali.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;Quando questa finestra di dialogo verrà chiusa l&apos;atleta verrà riaperto.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="141"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="137"/>
         <source>Save Crash Report...</source>
         <translation>Salva Rapporto Crash ...</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="143"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="139"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="225"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="221"/>
         <source>&lt;p&gt;Build date: %1 %2&lt;br&gt;Build id: %3&lt;br&gt;Version: %4&lt;br&gt;DB Schema: %5&lt;br&gt;Metrics: %7&lt;br&gt;OS: %6&lt;br&gt;OpenGL: %10&lt;br&gt;UI: dpi scale (%8) font size (%9)&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="255"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="251"/>
         <source>&lt;table&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QT&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QWT&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;%3&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SRMIO&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;D2XX&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;ICAL&lt;/td&gt;&lt;td&gt;%9&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;USBXPRESS&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LIBUSB&lt;/td&gt;&lt;td&gt;%11&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VLC&lt;/td&gt;&lt;td&gt;%12&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VIDEO&lt;/td&gt;&lt;td&gt;%13&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SAMPLERATE&lt;/td&gt;&lt;td&gt;%14&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SSL&lt;/td&gt;&lt;td&gt;%15&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;R&lt;/td&gt;&lt;td&gt;%16&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;Python&lt;/td&gt;&lt;td&gt;%18&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LMFIT&lt;/td&gt;&lt;td&gt;7.0&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;GSL&lt;/td&gt;&lt;td&gt;%19&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Save Diagnostics</source>
         <translation>Salva Diagnostiche</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Text File (*.txt)</source>
         <translation>File di Testo (*.txt)</translation>
     </message>
@@ -13783,167 +13771,172 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GcWindowRegistry</name>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
         <source>Performance</source>
         <translation>Prestazioni</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="89"/>
         <source>Histogram</source>
         <translation>Istogramma</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
         <source>Distribution</source>
         <translation>Distribuzione</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
         <source>Pedal Force vs Velocity</source>
         <translation>Forza Pedalata vs Velocità</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
         <source>Heartrate vs Power</source>
         <translation>Frequenza cardiaca vs Potenza</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
         <source>Python Chart</source>
         <translation>Grafico Python</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
         <source>Python Chart </source>
         <translation>Grafico Python </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="101"/>
         <source>Calendar</source>
         <translation>Calendario</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
         <source>Navigator</source>
         <translation>Navigatore</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="76"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="73"/>
         <source>User Chart</source>
         <translation>Grafico Utilizzatore</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
         <source>Trends</source>
         <translation>Trend</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="78"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
         <source>TreeMap</source>
         <translation>TreeMap</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
         <source>Power Duration </source>
         <translation>Durata Forza </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="83"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
         <source>Activity Overview</source>
         <translation>Panoramica Attività</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="81"/>
         <source>Blank Overview</source>
         <translation>Panoramica Vuota</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="85"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="82"/>
         <source>User Chart </source>
         <translation>Grafico Utilizzatore </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
         <source>Data</source>
         <translation>Dati</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="88"/>
         <source>Power Duration</source>
         <translation>Durata Forza</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
         <source>Scatter</source>
         <translation>Dispersione</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="103"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
         <source>Aerolab</source>
         <translation>Aerolab</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
         <source>Telemetry</source>
         <translation>Telemetria</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
         <source>Workout</source>
         <translation>Allenamento</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="106"/>
         <source>Realtime</source>
         <translation>Tempo Reale</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
         <source>Pedal Stroke</source>
         <translation>Colpo pedale</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="113"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
         <source>Live Map</source>
         <translation>Mappa Live</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="114"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <source>Elevation Chart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
         <source>Web page</source>
         <translation>Pagina Web</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
         <source>Map</source>
         <translation>Mappa</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="71"/>
         <source>Season Overview</source>
         <translation>Panoramica Stagione</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="72"/>
         <source>Blank Overview </source>
         <translation>Panoramica Vuota</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
         <source>R Chart</source>
         <translation>Grafico R</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="98"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
         <source>R Chart </source>
         <translation>Grafico R </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
         <source>Video Player</source>
         <translation>Lettore Video</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
         <source>Workout Editor</source>
         <translation>Editore Allenamento</translation>
     </message>
@@ -15046,142 +15039,147 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
         <translation>Visualizzazione in tempo reale del percorso degli allenamenti simulati in Open Street Map</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="296"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="294"/>
+        <source>Show elevation profile of instant position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
         <source>Predefined and configurable set of data ranges for selection of activities to be analysed</source>
         <translation>Gruppo predefinito e configurabile di intervalli di dati per la selezione delle attività da analizzare</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
         <source>Powerful filter and search engine to determine the activities which are considered in diagram</source>
         <translation>Filtro potente e motore di ricerca per determinare le attività che sono considerate nel diagramma</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
         <source>Configurable list of activities</source>
         <translation>Lista attività configurabile</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="317"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
         <source>Configurable list of training devices</source>
         <translation>Lista configurabile dei dispositivi di allenamento</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
         <source>Configurable list of workout files</source>
         <translation>Lista configurabile dei documenti di allenamento</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
         <source>Configurable list of video files</source>
         <translation>Lista configurabile dei documenti video</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="325"/>
         <source>Configurable list of video sync files</source>
         <translation>Lista configurabile dei documenti di sincronizzazione video</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="327"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
         <source>Entry field for sophisticated Searching and Filtering of activities</source>
         <translation>Campi inserimento per attività sofisticate di ricerca e filtro</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
         <source>Adding intervals to an activity using simple query methods</source>
         <translation>Aggiunta intervalli ad un&apos;attività usando metodi di interrogazione semplice</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
         <source>To compare Activities/Intervals in Activity View and Date Ranges in Trends View</source>
         <translation>Compara Attivita&apos;/Intervalli in Ativita&apos; e Intervalli di date in Trends</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="335"/>
         <source>Workout Control, Intensity Adjustments and Notifications Display</source>
         <translation>Visualizzazione Controllo Allenamenti, Aggiustamenti Intensita&apos; e Notifiche</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
         <source>Athlete Model</source>
         <translation>Modello Atleta</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
         <source>Athlete Measures</source>
         <translation>Misure Atleta</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
         <source>Auto Import</source>
         <translation>Importazione automatica</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
         <source>Backup</source>
         <translation>Backup</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="355"/>
         <source>Cloud Accounts</source>
         <translation>Acconto Cloud</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <source>Automatic Interval Detection</source>
         <translation>Detezione automatica Intervalli</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
         <source>Definition of coloring rules for activities</source>
         <translation>Definizione e modalità di colorazione per le attività</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
         <source>Metrics shown in &apos;Intervals&apos; and &apos;Summary&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
         <source>User/Custom Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
         <source>Create or Edit a User Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
         <source>Measures</source>
         <translation>Misure</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
         <source>Train View devices configuration and preferences</source>
         <translation>Configurazioni e preferenze della pagina Allenameto dei dispositivi</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
         <source>Train View Preferences</source>
         <translation>Preferenze Pagina Allenamento</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
         <source>Remote Controls Configuration</source>
         <translation>Configurazioni Controlli Remoti</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
         <source>Add/Remove Train Devices</source>
         <translation>Aggiungi/Rimuovi Dispositivi Allenamento</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
         <source>Add Train Devices</source>
         <translation>Aggiungi Dispositivi Allenamento</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="394"/>
         <source>Virtual Bicycle configuration for simulation rides</source>
         <translation>Configurazione bicicletta virtuale per uscite simulate</translation>
     </message>
@@ -15215,8 +15213,8 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
     </message>
     <message>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="219"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
         <source>Calendar</source>
         <translation>Calendario</translation>
     </message>
@@ -15251,74 +15249,74 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
         <translation>Impostazioni di filtro/cerca e di intervalli di date specifiche al grafico</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
         <source>Definition of points in time &apos;Events&apos; which are marked explicitely on time related diagrams</source>
         <translation>Definizione di punti in &apos;Eventi&apos; nel tempo i quali sono indicati in diagrammi di tempo</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="316"/>
         <source>Simple summary view</source>
         <translation>Visualizzazione sommario semplice</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
         <source>Alternative access to the charts created for the main view</source>
         <translation>Accesso alternativo ali grafici generati per la visualizzazione principale</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
         <source>Display the available and add new intervals using simple query methods</source>
         <translation>Mostra i disponibili e aggiungi nuovi intervalli usando metodi di semplice interrogazione</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="356"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
         <source>General</source>
         <translation>Generale</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="337"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
         <source>Athlete</source>
         <translation>Atleta</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
         <source>Training Zone definition for power</source>
         <translation>Definizione di Zone di Allenamento per potenza</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
         <source>Training Zone definition for heartrate</source>
         <translation>Definizione di Zone di Allenamento per frequenza cardiaca</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
         <source>Training Zone definition for Swim and Run</source>
         <translation>Definizione di Zone di Allenamento per nuoto e corsa</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
         <source>Appearance</source>
         <translation>Apparenza</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="364"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
         <source>Data Fields</source>
         <translation>Campi Dati</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
         <source>Definition of default value(s) for data fields</source>
         <translation>Definizione del valore(i) di base per i campi dei dati</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
         <source>Definition of processing default parameters for the fix, adjust,... tools</source>
         <translation>Definizione di processamento dei parametri di base, per gli strumenti fissa, aggiusta, ...ecc</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
         <source>Metrics</source>
         <translation>Misure</translation>
     </message>
@@ -15518,47 +15516,43 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2437"/>
         <source>Add</source>
-        <translation>Aggiungi</translation>
+        <translation type="vanished">Aggiungi</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2438"/>
         <source>Delete</source>
-        <translation>Cancella</translation>
+        <translation type="vanished">Cancella</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2431"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2432"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2447"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2332"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2458"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2343"/>
         <source>Short</source>
         <translation>Corto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2459"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2344"/>
         <source>Long</source>
         <translation>Lungo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2460"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2345"/>
         <source>Percent of LT</source>
         <translation>Percentuale di LT</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2461"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2346"/>
         <source>Trimp k</source>
         <translation>Trimp k</translation>
     </message>
@@ -15567,14 +15561,14 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
         <translation type="vanished">Raggiunto ilmassimo di 10 Zone.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2506"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2513"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2390"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2397"/>
         <source>New</source>
         <translation>Nuovo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2508"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2515"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2392"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2399"/>
         <source>New (%1)</source>
         <translation>Nuovo (%1)</translation>
     </message>
@@ -15764,17 +15758,17 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2245"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2395"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2292"/>
         <source>Lactate Threshold</source>
         <translation>Soglia Lattacida</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2396"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2293"/>
         <source>Default</source>
         <translation>Base</translation>
     </message>
@@ -16849,7 +16843,7 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
     <message>
         <location filename="../../Train/InfoWidget.cpp" line="125"/>
         <source>Never</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mai</translation>
     </message>
     <message>
         <location filename="../../Train/InfoWidget.cpp" line="132"/>
@@ -17927,545 +17921,542 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
 <context>
     <name>LTMTool</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="74"/>
+        <location filename="../../Charts/LTMTool.cpp" line="75"/>
         <source>Filter</source>
         <translation>Filtro</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="80"/>
+        <location filename="../../Charts/LTMTool.cpp" line="81"/>
         <source>Date range</source>
         <translation>Intervallo Date</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="84"/>
+        <location filename="../../Charts/LTMTool.cpp" line="85"/>
         <source>Days</source>
         <translation>Giorni</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="85"/>
+        <location filename="../../Charts/LTMTool.cpp" line="86"/>
         <source>Weeks</source>
         <translation>Settimane</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="86"/>
+        <location filename="../../Charts/LTMTool.cpp" line="87"/>
         <source>Months</source>
         <translation>Mesi</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="87"/>
+        <location filename="../../Charts/LTMTool.cpp" line="88"/>
         <source>Years</source>
         <translation>Anni</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="88"/>
+        <location filename="../../Charts/LTMTool.cpp" line="89"/>
         <source>Time Of Day</source>
         <translation>Orario del Giorno</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="91"/>
+        <location filename="../../Charts/LTMTool.cpp" line="92"/>
         <source>Group by</source>
         <translation>Raggruppa per</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="102"/>
+        <location filename="../../Charts/LTMTool.cpp" line="103"/>
         <source>Shade Zones</source>
         <translation>Ombreggia Zone</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="105"/>
+        <location filename="../../Charts/LTMTool.cpp" line="106"/>
         <source>Show Legend</source>
         <translation>Mostra Legenda</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="109"/>
         <source>Show Events</source>
         <translation>Mostra eventi</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1303"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1272"/>
         <source>Metric</source>
         <translation>Misura</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="351"/>
+        <location filename="../../Charts/LTMTool.cpp" line="325"/>
         <source>Skiba Long Term Stress</source>
         <translation>Skiba Stress di Lunga Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="89"/>
+        <location filename="../../Charts/LTMTool.cpp" line="90"/>
         <source>All</source>
         <translation>Tutti</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="94"/>
+        <location filename="../../Charts/LTMTool.cpp" line="95"/>
         <source>Data Table</source>
         <translation>Tabella Dati</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="98"/>
+        <location filename="../../Charts/LTMTool.cpp" line="99"/>
         <source>Show Stack</source>
         <translation>Mostra Pila</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="121"/>
+        <location filename="../../Charts/LTMTool.cpp" line="122"/>
         <source>Stack Zoom</source>
         <translation>Ingrandimento Pila</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="155"/>
+        <location filename="../../Charts/LTMTool.cpp" line="156"/>
         <source>Add Current</source>
         <translation>Aggiungi In Uso</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="146"/>
+        <location filename="../../Charts/LTMTool.cpp" line="147"/>
         <source>Charts</source>
         <translation>Grafici</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="112"/>
         <source>Show Banister Helper</source>
         <translation>Mostra Aiuti per Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="155"/>
         <source>Apply</source>
         <translation>Applica</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Up</source>
-        <translation>Sopra</translation>
+        <translation type="vanished">Sopra</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Down</source>
-        <translation>Sotto</translation>
+        <translation type="vanished">Sotto</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="353"/>
-        <location filename="../../Charts/LTMTool.cpp" line="368"/>
-        <location filename="../../Charts/LTMTool.cpp" line="429"/>
-        <location filename="../../Charts/LTMTool.cpp" line="444"/>
-        <location filename="../../Charts/LTMTool.cpp" line="505"/>
-        <location filename="../../Charts/LTMTool.cpp" line="520"/>
-        <location filename="../../Charts/LTMTool.cpp" line="580"/>
-        <location filename="../../Charts/LTMTool.cpp" line="595"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1080"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1095"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1156"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1171"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1309"/>
+        <location filename="../../Charts/LTMTool.cpp" line="327"/>
+        <location filename="../../Charts/LTMTool.cpp" line="342"/>
+        <location filename="../../Charts/LTMTool.cpp" line="403"/>
+        <location filename="../../Charts/LTMTool.cpp" line="418"/>
+        <location filename="../../Charts/LTMTool.cpp" line="479"/>
+        <location filename="../../Charts/LTMTool.cpp" line="494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="554"/>
+        <location filename="../../Charts/LTMTool.cpp" line="569"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1054"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1069"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1130"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1145"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1278"/>
         <source>Stress</source>
         <translation>Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="366"/>
+        <location filename="../../Charts/LTMTool.cpp" line="340"/>
         <source>Skiba Short Term Stress</source>
         <translation>Stress Breve Durata di Skiba</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="381"/>
+        <location filename="../../Charts/LTMTool.cpp" line="355"/>
         <source>Skiba Stress Balance</source>
         <translation>Bilancio Stress di Skiba</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="383"/>
-        <location filename="../../Charts/LTMTool.cpp" line="459"/>
-        <location filename="../../Charts/LTMTool.cpp" line="535"/>
-        <location filename="../../Charts/LTMTool.cpp" line="610"/>
-        <location filename="../../Charts/LTMTool.cpp" line="686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="762"/>
-        <location filename="../../Charts/LTMTool.cpp" line="838"/>
-        <location filename="../../Charts/LTMTool.cpp" line="914"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1110"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1186"/>
+        <location filename="../../Charts/LTMTool.cpp" line="357"/>
+        <location filename="../../Charts/LTMTool.cpp" line="433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="509"/>
+        <location filename="../../Charts/LTMTool.cpp" line="584"/>
+        <location filename="../../Charts/LTMTool.cpp" line="660"/>
+        <location filename="../../Charts/LTMTool.cpp" line="736"/>
+        <location filename="../../Charts/LTMTool.cpp" line="812"/>
+        <location filename="../../Charts/LTMTool.cpp" line="888"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1160"/>
         <source>Stress Balance</source>
         <translation>Bilancio Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="396"/>
+        <location filename="../../Charts/LTMTool.cpp" line="370"/>
         <source>Skiba STS Ramp</source>
         <translation>Rampa STS Skiba</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="398"/>
-        <location filename="../../Charts/LTMTool.cpp" line="413"/>
-        <location filename="../../Charts/LTMTool.cpp" line="474"/>
-        <location filename="../../Charts/LTMTool.cpp" line="489"/>
-        <location filename="../../Charts/LTMTool.cpp" line="550"/>
-        <location filename="../../Charts/LTMTool.cpp" line="565"/>
-        <location filename="../../Charts/LTMTool.cpp" line="625"/>
-        <location filename="../../Charts/LTMTool.cpp" line="640"/>
-        <location filename="../../Charts/LTMTool.cpp" line="701"/>
-        <location filename="../../Charts/LTMTool.cpp" line="716"/>
-        <location filename="../../Charts/LTMTool.cpp" line="777"/>
-        <location filename="../../Charts/LTMTool.cpp" line="792"/>
-        <location filename="../../Charts/LTMTool.cpp" line="853"/>
-        <location filename="../../Charts/LTMTool.cpp" line="868"/>
-        <location filename="../../Charts/LTMTool.cpp" line="929"/>
-        <location filename="../../Charts/LTMTool.cpp" line="944"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1005"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1020"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1125"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1140"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1201"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1216"/>
+        <location filename="../../Charts/LTMTool.cpp" line="372"/>
+        <location filename="../../Charts/LTMTool.cpp" line="387"/>
+        <location filename="../../Charts/LTMTool.cpp" line="448"/>
+        <location filename="../../Charts/LTMTool.cpp" line="463"/>
+        <location filename="../../Charts/LTMTool.cpp" line="524"/>
+        <location filename="../../Charts/LTMTool.cpp" line="539"/>
+        <location filename="../../Charts/LTMTool.cpp" line="599"/>
+        <location filename="../../Charts/LTMTool.cpp" line="614"/>
+        <location filename="../../Charts/LTMTool.cpp" line="675"/>
+        <location filename="../../Charts/LTMTool.cpp" line="690"/>
+        <location filename="../../Charts/LTMTool.cpp" line="751"/>
+        <location filename="../../Charts/LTMTool.cpp" line="766"/>
+        <location filename="../../Charts/LTMTool.cpp" line="827"/>
+        <location filename="../../Charts/LTMTool.cpp" line="842"/>
+        <location filename="../../Charts/LTMTool.cpp" line="903"/>
+        <location filename="../../Charts/LTMTool.cpp" line="918"/>
+        <location filename="../../Charts/LTMTool.cpp" line="979"/>
+        <location filename="../../Charts/LTMTool.cpp" line="994"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1099"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1114"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1175"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1190"/>
         <source>Ramp</source>
         <translation>Rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="411"/>
+        <location filename="../../Charts/LTMTool.cpp" line="385"/>
         <source>Skiba LTS Ramp</source>
         <translation>Rampa LTS Skiba</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="427"/>
+        <location filename="../../Charts/LTMTool.cpp" line="401"/>
         <source>Aerobic TISS Long Term Stress</source>
         <translation>TISS Aerobico Stress di Lunga Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="442"/>
+        <location filename="../../Charts/LTMTool.cpp" line="416"/>
         <source>Aerobic TISS Short Term Stress</source>
         <translation>TISS Aerobico Stress di Breve Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="457"/>
+        <location filename="../../Charts/LTMTool.cpp" line="431"/>
         <source>Aerobic TISS Stress Balance</source>
         <translation>TISS Aerobico Bilancio Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="472"/>
+        <location filename="../../Charts/LTMTool.cpp" line="446"/>
         <source>Aerobic TISS STS Ramp</source>
         <translation>TISS Aerobico Rampa STS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="487"/>
+        <location filename="../../Charts/LTMTool.cpp" line="461"/>
         <source>Aerobic TISS LTS Ramp</source>
         <translation>TISS Aerobico Rampa LTS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="503"/>
+        <location filename="../../Charts/LTMTool.cpp" line="477"/>
         <source>Anaerobic TISS Long Term Stress</source>
         <translation>TISS Anaerobico Stress di Lunga Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="518"/>
+        <location filename="../../Charts/LTMTool.cpp" line="492"/>
         <source>Anaerobic TISS Short Term Stress</source>
         <translation>TISS Anaerobico Stress di Breve Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="533"/>
+        <location filename="../../Charts/LTMTool.cpp" line="507"/>
         <source>Anaerobic TISS Stress Balance</source>
         <translation>TISS Anaerobico Bilancio Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="548"/>
+        <location filename="../../Charts/LTMTool.cpp" line="522"/>
         <source>Anaerobic TISS STS Ramp</source>
         <translation>TISS Anaerobico Rampa STS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="537"/>
         <source>Anaerobic TISS LTS Ramp</source>
         <translation>TISS Anaerobico Rampa LTS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="578"/>
+        <location filename="../../Charts/LTMTool.cpp" line="552"/>
         <source>Daniels Long Term Stress</source>
         <translation>Stress Lunga Durata di Daniels</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="593"/>
+        <location filename="../../Charts/LTMTool.cpp" line="567"/>
         <source>Daniels Short Term Stress</source>
         <translation>Stress di Breve Durata di Daniels</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="582"/>
         <source>Daniels Stress Balance</source>
         <translation>Bilancio Stress di Daniels</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="623"/>
+        <location filename="../../Charts/LTMTool.cpp" line="597"/>
         <source>Daniels STS Ramp</source>
         <translation>Rampa STS di Daniels</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="638"/>
+        <location filename="../../Charts/LTMTool.cpp" line="612"/>
         <source>Daniels LTS Ramp</source>
         <translation>Rampa LTS di Daniels</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="628"/>
         <source>Work (Kj) Long Term Stress</source>
         <translation>Lavoro (Kj) Stress di Lunga Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="656"/>
-        <location filename="../../Charts/LTMTool.cpp" line="671"/>
-        <location filename="../../Charts/LTMTool.cpp" line="732"/>
-        <location filename="../../Charts/LTMTool.cpp" line="747"/>
-        <location filename="../../Charts/LTMTool.cpp" line="808"/>
-        <location filename="../../Charts/LTMTool.cpp" line="823"/>
+        <location filename="../../Charts/LTMTool.cpp" line="630"/>
+        <location filename="../../Charts/LTMTool.cpp" line="645"/>
+        <location filename="../../Charts/LTMTool.cpp" line="706"/>
+        <location filename="../../Charts/LTMTool.cpp" line="721"/>
+        <location filename="../../Charts/LTMTool.cpp" line="782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="797"/>
         <source>Stress (Kj)</source>
         <translation>Stress (Kj)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="669"/>
+        <location filename="../../Charts/LTMTool.cpp" line="643"/>
         <source>Work (Kj) Short Term Stress</source>
         <translation>Lavoro (Kj) Stress di Breve Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="684"/>
+        <location filename="../../Charts/LTMTool.cpp" line="658"/>
         <source>Work (Kj) Stress Balance</source>
         <translation>Lavoro (Kj) Bilancip Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="699"/>
+        <location filename="../../Charts/LTMTool.cpp" line="673"/>
         <source>Work (Kj) STS Ramp</source>
         <translation>Lavoro (Kj) Rampa STS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="714"/>
+        <location filename="../../Charts/LTMTool.cpp" line="688"/>
         <source>Work (Kj) LTS Ramp</source>
         <translation>Lavoro (Kj) Rampa LTS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="730"/>
+        <location filename="../../Charts/LTMTool.cpp" line="704"/>
         <source>W&apos; Work (Kj) Long Term Stress</source>
         <translation>W&apos; Lavoro (Kj) Stress di Lunga Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="745"/>
+        <location filename="../../Charts/LTMTool.cpp" line="719"/>
         <source>W&apos; Work (Kj) Short Term Stress</source>
         <translation>W&apos; Lavoro (Kj) Stress di Breve Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="760"/>
+        <location filename="../../Charts/LTMTool.cpp" line="734"/>
         <source>W&apos; Work (Kj) Stress Balance</source>
         <translation>W&apos; Lavoro (Kj) Bilancio Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="775"/>
+        <location filename="../../Charts/LTMTool.cpp" line="749"/>
         <source>W&apos; Work (Kj) STS Ramp</source>
         <translation>W&apos; Lavoro (Kj) Rampa STS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="790"/>
+        <location filename="../../Charts/LTMTool.cpp" line="764"/>
         <source>W&apos; Work (Kj) LTS Ramp</source>
         <translation>W&apos; Lavoro (Kj) Rampa LTS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="806"/>
+        <location filename="../../Charts/LTMTool.cpp" line="780"/>
         <source>Below CP Work (Kj) Long Term Stress</source>
         <translation>Lavoro sotto CP (kj) Stress di Lunga Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="821"/>
+        <location filename="../../Charts/LTMTool.cpp" line="795"/>
         <source>Below CP Work (Kj) Short Term Stress</source>
         <translation>Lavoro sotto CP (kj) Stress di Corta Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="836"/>
+        <location filename="../../Charts/LTMTool.cpp" line="810"/>
         <source>Below CP Work (Kj) Stress Balance</source>
         <translation>Lavoro sotto CP (kj) Bilancio Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="851"/>
+        <location filename="../../Charts/LTMTool.cpp" line="825"/>
         <source>Below CP Work (Kj) STS Ramp</source>
         <translation>Lavoro sotto CP (kj) rampa STS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="866"/>
+        <location filename="../../Charts/LTMTool.cpp" line="840"/>
         <source>Below CP Work (Kj) LTS Ramp</source>
         <translation>Lavoro sotto CP (kj) rampa LTS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="882"/>
+        <location filename="../../Charts/LTMTool.cpp" line="856"/>
         <source>Distance (km|mi) Long Term Stress</source>
         <translation>Distanza (km|mi) Stress di Lunga Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="884"/>
-        <location filename="../../Charts/LTMTool.cpp" line="899"/>
+        <location filename="../../Charts/LTMTool.cpp" line="858"/>
+        <location filename="../../Charts/LTMTool.cpp" line="873"/>
         <source>Stress (km|mi)</source>
         <translation>Stress (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="897"/>
+        <location filename="../../Charts/LTMTool.cpp" line="871"/>
         <source>Distance (km|mi) Short Term Stress</source>
         <translation>Distanza (km|mi) Stress di Breve Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="912"/>
+        <location filename="../../Charts/LTMTool.cpp" line="886"/>
         <source>Distance (km|mi) Stress Balance</source>
         <translation>Distanza (km|mi) Bilancio Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="927"/>
+        <location filename="../../Charts/LTMTool.cpp" line="901"/>
         <source>Distance (km|mi) STS Ramp</source>
         <translation>Distanza (km|mi) STS Rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="942"/>
+        <location filename="../../Charts/LTMTool.cpp" line="916"/>
         <source>Distance (km|mi) LTS Ramp</source>
         <translation>Distanza (km|mi) LTS Rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="958"/>
+        <location filename="../../Charts/LTMTool.cpp" line="932"/>
         <source>Coggan Chronic Training Load</source>
         <translation>Carico di Allenamento Cronico di Coggan (CTL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="973"/>
+        <location filename="../../Charts/LTMTool.cpp" line="947"/>
         <source>Coggan Acute Training Load</source>
         <translation>Carico di Allenamento Acuto di Coggan (ATL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="988"/>
+        <location filename="../../Charts/LTMTool.cpp" line="962"/>
         <source>Coggan Training Stress Balance</source>
         <translation>Bilancio del Carico di Allenamento di Coggan</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1003"/>
+        <location filename="../../Charts/LTMTool.cpp" line="977"/>
         <source>Coggan STS Ramp</source>
         <translation>Coggan STS Rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1018"/>
+        <location filename="../../Charts/LTMTool.cpp" line="992"/>
         <source>Coggan LTS Ramp</source>
         <translation>Coggan LTS Rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1033"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1007"/>
         <source>Coggan Expected Chronic Training Load</source>
         <translation>Carico di Allenamento Cronico Atteso secondo Coggan</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1048"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1022"/>
         <source>Coggan Expected Acute Training Load</source>
         <translation>Carico di Allenamento Acuto secondo Coggan</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1063"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1037"/>
         <source>Coggan Expected Training Stress Balance</source>
         <translation>Bilancio del Carico di Allenamento Atteso secondo Coggan</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1053"/>
         <source>TRIMP Long Term Stress</source>
         <translation>TRMP Stress di Lunga Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1067"/>
         <source>TRIMP Short Term Stress</source>
         <translation>TRIMP Stress di Corta Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1082"/>
         <source>TRIMP Stress Balance</source>
         <translation>TRIMP Bilancio Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1123"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1097"/>
         <source>TRIMP STS Ramp</source>
         <translation>TRMP Rampa STS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1138"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1112"/>
         <source>TRIMP LTS Ramp</source>
         <translation>TRIMP Rampa LTS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="268"/>
         <source>Edit</source>
-        <translation>Modifica</translation>
+        <translation type="vanished">Modifica</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="124"/>
+        <location filename="../../Charts/LTMTool.cpp" line="125"/>
         <source>Use sidebar chart settings</source>
         <translation>Usa le impostazioni del grafico della barra laterale</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Basic</source>
         <translation>Di base</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="314"/>
+        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Preset</source>
         <translation>Pre Impostazioni</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1128"/>
         <source>TriScore Long Term Stress</source>
         <translation>TriScore Stress di Lunga Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1169"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1143"/>
         <source>TriScore Short Term Stress</source>
         <translation>TriScore Stress di Breve Durata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1184"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1158"/>
         <source>TriScore Stress Balance</source>
         <translation>TriScore Bilancio Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1173"/>
         <source>TriScore STS Ramp</source>
         <translation>TriScore Rampa STS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1214"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1188"/>
         <source>TriScore LTS Ramp</source>
         <translation>TriScore Rampa LTS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1307"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1276"/>
         <source>Estimate</source>
         <translation>Stima</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1311"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1280"/>
         <source>Formula</source>
         <translation>Formula</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1282"/>
         <source>Measure</source>
         <translation>Misura</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1284"/>
         <source>Performance</source>
         <translation>Performance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1317"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1286"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1463"/>
         <source>Chart %1</source>
         <translation>Grafico %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="289"/>
         <source>Curves</source>
         <translation>Curve</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Details</source>
         <translation>Dettagli</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1305"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1274"/>
         <source>Peak</source>
         <translation>Picco</translation>
     </message>
@@ -18668,31 +18659,23 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
         <translation type="vanished">Aggiorna</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2590"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2602"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2591"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2603"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2596"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2608"/>
         <source>Add</source>
-        <translation>Aggiungi</translation>
+        <translation type="vanished">Aggiungi</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2597"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2609"/>
         <source>Delete</source>
-        <translation>Cancella</translation>
+        <translation type="vanished">Cancella</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2599"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2467"/>
         <source>Def</source>
         <translation>Def</translation>
     </message>
@@ -18701,14 +18684,14 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
         <translation type="vanished">Dalla Data</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2651"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2790"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2494"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2631"/>
         <source>Lactate Threshold</source>
         <translation>Soglia Lattacida</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2652"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2791"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2495"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2632"/>
         <source>Aerobic Threshold</source>
         <translation>Soglia Aerobica</translation>
     </message>
@@ -18721,45 +18704,45 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
         <translation type="vanished">Raggiunto il massimo di 10 zone.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2967"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2974"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2804"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2811"/>
         <source>New</source>
         <translation>Nuovo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2969"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2976"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2806"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2813"/>
         <source>New (%1)</source>
         <translation>Nuovo (%1)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2653"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2496"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
         <source>Rest HR</source>
         <translation>FC a Riposo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2628"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2690"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2770"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2775"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2780"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2785"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2473"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2478"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2488"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2611"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2621"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2626"/>
         <source>bpm</source>
         <translation>bpm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2650"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2493"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2630"/>
         <source>Start Date</source>
         <translation>Data di Inizio</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2654"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2497"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2634"/>
         <source>Max HR</source>
         <translation>FC Massima</translation>
     </message>
@@ -18768,22 +18751,22 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
         <translation type="vanished">d MMM, yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2701"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2544"/>
         <source>Short</source>
         <translation>Breve</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2702"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2545"/>
         <source>Long</source>
         <translation>Lungo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2703"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2546"/>
         <source>From BPM</source>
         <translation>Da BPM</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2704"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2547"/>
         <source>Trimp k</source>
         <translation>Trimp k</translation>
     </message>
@@ -19525,62 +19508,62 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
 <context>
     <name>Library</name>
     <message>
+        <location filename="../../Train/Library.cpp" line="126"/>
         <location filename="../../Train/Library.cpp" line="130"/>
-        <location filename="../../Train/Library.cpp" line="134"/>
         <source>Import Videos, VideoSyncs and Workouts</source>
         <translation>Importa Videos, VideoSyncs ed Allenamenti</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="127"/>
         <location filename="../../Train/Library.cpp" line="131"/>
-        <location filename="../../Train/Library.cpp" line="135"/>
         <source>No supported videos, videoSyncs or workouts were found to import</source>
         <translation>Non sono stati trovati Videos, VideoSyncs ed Allenamenti supportati per l&apos;importazione</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="189"/>
         <location filename="../../Train/Library.cpp" line="193"/>
-        <location filename="../../Train/Library.cpp" line="197"/>
+        <location filename="../../Train/Library.cpp" line="198"/>
         <location filename="../../Train/Library.cpp" line="202"/>
-        <location filename="../../Train/Library.cpp" line="206"/>
         <source>Copy VideoSync Failed</source>
         <translation>Copia VideoSync fallita</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="190"/>
         <location filename="../../Train/Library.cpp" line="194"/>
-        <location filename="../../Train/Library.cpp" line="198"/>
         <source>%1 already exists in videoSync library: %2</source>
         <translation>%1 esiste già nella libreria videoSync: %2</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="203"/>
+        <location filename="../../Train/Library.cpp" line="199"/>
         <source>%1 cannot be written to videoSync library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="207"/>
+        <location filename="../../Train/Library.cpp" line="203"/>
         <source>%1 cannot be written to videoSync library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="253"/>
+        <location filename="../../Train/Library.cpp" line="249"/>
         <source>%1 cannot be written to workout library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="257"/>
+        <location filename="../../Train/Library.cpp" line="253"/>
         <source>%1 cannot be written to workout library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="239"/>
         <location filename="../../Train/Library.cpp" line="243"/>
-        <location filename="../../Train/Library.cpp" line="247"/>
+        <location filename="../../Train/Library.cpp" line="248"/>
         <location filename="../../Train/Library.cpp" line="252"/>
-        <location filename="../../Train/Library.cpp" line="256"/>
         <source>Copy Workout Failed</source>
         <translation>Copia Allenamenti Fallita</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="240"/>
         <location filename="../../Train/Library.cpp" line="244"/>
-        <location filename="../../Train/Library.cpp" line="248"/>
         <source>%1 already exists in workout library: %2</source>
         <translation>%1 esiste gia&apos; nella libreria allenamenti: %2</translation>
     </message>
@@ -19588,89 +19571,89 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
 <context>
     <name>LibrarySearchDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="330"/>
+        <location filename="../../Train/Library.cpp" line="326"/>
         <source>Search for Workouts, Syncs and Media</source>
         <translation>Cerca Allenamenti, Sync e Media</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="337"/>
+        <location filename="../../Train/Library.cpp" line="333"/>
         <source>Workout files (.erg, .mrc, .zwo etc)</source>
         <translation>Files Allenamenti (.erg, mrc, zwo ecc.)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="339"/>
+        <location filename="../../Train/Library.cpp" line="335"/>
         <source>Video files (.mp4, .avi etc)</source>
         <translation>Files Video (.mp4, .avi etc)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="341"/>
+        <location filename="../../Train/Library.cpp" line="337"/>
         <source>VideoSync files (.rlv, .tts etc)</source>
         <translation>Documenti VideoSync (.rlv, .tts etc)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="359"/>
+        <location filename="../../Train/Library.cpp" line="353"/>
         <source>Search Path</source>
         <translation>Cerca Percorso</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="379"/>
+        <location filename="../../Train/Library.cpp" line="373"/>
         <source>Video references</source>
         <translation>Riferimenti video</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="391"/>
+        <location filename="../../Train/Library.cpp" line="385"/>
         <source>Searching...</source>
         <translation>Ricerca...</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="394"/>
+        <location filename="../../Train/Library.cpp" line="388"/>
         <source>Videos</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="396"/>
+        <location filename="../../Train/Library.cpp" line="390"/>
         <source>Workouts</source>
         <translation>Allenamenti</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="398"/>
+        <location filename="../../Train/Library.cpp" line="392"/>
         <source>VideoSyncs</source>
         <translation>VideoSyncs</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="407"/>
-        <location filename="../../Train/Library.cpp" line="494"/>
+        <location filename="../../Train/Library.cpp" line="401"/>
+        <location filename="../../Train/Library.cpp" line="484"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="409"/>
+        <location filename="../../Train/Library.cpp" line="403"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="412"/>
+        <location filename="../../Train/Library.cpp" line="406"/>
         <source>Files to search for:</source>
         <translation>File da ricercare:</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="475"/>
+        <location filename="../../Train/Library.cpp" line="466"/>
         <source>Abort Search</source>
         <translation>Annula cerca</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="515"/>
-        <location filename="../../Train/Library.cpp" line="559"/>
+        <location filename="../../Train/Library.cpp" line="504"/>
+        <location filename="../../Train/Library.cpp" line="548"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="557"/>
+        <location filename="../../Train/Library.cpp" line="546"/>
         <source>Search completed.</source>
         <translation>Ricerca Completata.</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="645"/>
+        <location filename="../../Train/Library.cpp" line="634"/>
         <source>Select Directory</source>
         <translation>Seleziona Cartella</translation>
     </message>
@@ -19678,12 +19661,12 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
 <context>
     <name>ListEditWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="623"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="654"/>
         <source>New</source>
         <translation>Nuovo</translation>
     </message>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="625"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="656"/>
         <source>New (%1)</source>
         <translation>Nuovo (%1)</translation>
     </message>
@@ -19696,7 +19679,12 @@ In modalità Allenamento, visualizza/nasconde la Regolazione Intensità e il Pan
         <translation>URL OSM Base</translation>
     </message>
     <message>
-        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="90"/>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="85"/>
+        <source>Initial Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="98"/>
         <source>Apply changes</source>
         <translation>Applica cambiamenti</translation>
     </message>
@@ -19976,28 +19964,28 @@ on and that its display says, &quot;PC Link&quot;</source>
         <translation>Scarica grafico...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Imported %1 metric charts</source>
         <translation>Importate grafici misure %1</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
         <source>Select Activity</source>
         <translation>Seleziona Attività</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>No activity selected!</source>
         <translation>Nessuna Attività Selezionata!</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1724"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1734"/>
         <source>Export Activity</source>
         <translation>Esporta Attività</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1777"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1787"/>
         <source>Export Failed</source>
         <translation>Esporta Fallita</translation>
     </message>
@@ -20053,31 +20041,31 @@ on and that its display says, &quot;PC Link&quot;</source>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Activity Import</source>
         <translation>Importo Attività</translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Closing of athlete window not possible while background activity import is in progress...</source>
         <translation>Chiusura finestra Atleta nonpossibile mentre è in corso importazione attività in background...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Chart Import</source>
         <translation>Importazione Grafico</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2342"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2352"/>
         <source>Refresh in Progress</source>
         <translation>Ricarica in corso</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2400"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2421"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2410"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2431"/>
         <source>The workout directory is not configured, or the directory selected no longer exists.
 
 Please check your preference settings.</source>
@@ -20086,7 +20074,7 @@ Please check your preference settings.</source>
 Si prega di verificare le impostazioni delle preferenze.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2611"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2621"/>
         <source>Loading activities: %1%</source>
         <translation>Caricamento attività: %1%</translation>
     </message>
@@ -20099,14 +20087,14 @@ Si prega di verificare le impostazioni delle preferenze.</translation>
         <translation type="vanished">Gestisci Python Fixes...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>CloudDB</source>
         <translation>CloudDB</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>Current athlete is not registered as curator - please contact the GoldenCheetah team</source>
         <translation>L&apos;Atleta in uso non è registrato come curatore - si prega di contattare il team di GoldenCheetah</translation>
     </message>
@@ -20146,7 +20134,7 @@ Si prega di verificare le impostazioni delle preferenze.</translation>
         <translation>Vuoi continuare?</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2165"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2175"/>
         <source>&amp;New Athlete...</source>
         <translation>&amp;Nuovo Atleta...</translation>
     </message>
@@ -20310,31 +20298,31 @@ Si prega di verificare le impostazioni delle preferenze.</translation>
         <translation>Nessun documento di grafico selezionato!</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>Delete Activity</source>
         <translation>Cancella Attività</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1778"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1788"/>
         <source>Failed to export activity, please check permissions</source>
         <translation>Fallito il tentativo di esportare attività, per favore controlla le autorizzazioni</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1815"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1825"/>
         <source>There is no currently selected activity to save.</source>
         <translation>Non c&apos;è attualmente nessuna attività selezionata da salvare.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
         <location filename="../../Gui/MainWindow.cpp" line="1886"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Split Activity</source>
         <translation>Dividi Attività</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1799"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2369"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1809"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2379"/>
         <source>Import from File</source>
         <translation>Importa da File</translation>
     </message>
@@ -20546,69 +20534,69 @@ Si prega di verificare le impostazioni delle preferenze.</translation>
         <translation>Importa Prospettiva</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>Import Images Failed</source>
         <translation>Importazione Immagini non riuscita</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>You can only import images on the activities view with an activity selected.</source>
         <translation>È possibile importare immagini solo nella vista attività e con un&apos;attività selezionata.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>Import Images to Activity</source>
         <translation>Importazione Immagini nell&apos;Attività</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>%1 images imported.</source>
         <translation>%1 immagini importate.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1814"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1824"/>
         <source>No Activity To Save</source>
         <translation>Nessuna Attività da Salvare</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
         <source>No activity selected</source>
         <translation>Nessuna attività selezionata</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
         <source>Current activity contains no data to split</source>
         <translation>L&apos;attività in uso non contiene dati da dividere</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Current activity contains no data to merge</source>
         <translation>L&apos;attività in uso non contiene dati da unire</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1904"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1914"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation>Sei sicuro di voler cancellare l&apos;attività&apos;:</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Export Metrics</source>
         <translation>Esporta Misure</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation>Valori separati da virgola (*.csv)</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2399"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2420"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2409"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2430"/>
         <source>Workout Directory Invalid</source>
         <translation>Cartella Allenamenti non valida</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1906"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1916"/>
         <source>Delete</source>
         <translation>Cancella</translation>
     </message>
@@ -21564,23 +21552,23 @@ Si prega di verificare le impostazioni delle preferenze.</translation>
         <translation type="vanished">%1 misure dipendenti dal tempo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="656"/>
+        <location filename="../../Gui/AthletePages.cpp" line="641"/>
         <source>From Date - Time</source>
         <translation>Da data - Orario</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="780"/>
+        <location filename="../../Gui/AthletePages.cpp" line="751"/>
         <source>Start Date</source>
         <translation>Data iniziale</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="893"/>
+        <location filename="../../Gui/AthletePages.cpp" line="864"/>
         <source>MMM d, yyyy - hh:mm:ss</source>
         <translation>MMM d, yyyy - hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="659"/>
-        <location filename="../../Gui/AthletePages.cpp" line="807"/>
+        <location filename="../../Gui/AthletePages.cpp" line="644"/>
+        <location filename="../../Gui/AthletePages.cpp" line="778"/>
         <source>Comment</source>
         <translation>Commento</translation>
     </message>
@@ -21589,32 +21577,28 @@ Si prega di verificare le impostazioni delle preferenze.</translation>
         <translation type="vanished">Aggiorna</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="662"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="663"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">Aggiungi</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">Cancella</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="668"/>
-        <source>Add</source>
-        <translation>Aggiungi</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="669"/>
-        <source>Delete</source>
-        <translation>Cancella</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="698"/>
         <source>Source</source>
         <translation>Sorgente</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="699"/>
+        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Original Source</source>
         <translation>Sorgente di origine</translation>
     </message>
@@ -22315,17 +22299,17 @@ Nessuna uscita in bici trovata da importare.
 <context>
     <name>MultiDeviceDialog</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3048"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3060"/>
         <source>Multiple Device Configuration</source>
         <translation>Configurazione Disposistivi Multipli</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3103"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3115"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3106"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3118"/>
         <source>Apply</source>
         <translation>Applica</translation>
     </message>
@@ -23346,42 +23330,38 @@ Nessuna uscita in bici trovata da importare.
 <context>
     <name>PaceSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3154"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3155"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3160"/>
         <source>Add</source>
-        <translation>Aggiungi</translation>
+        <translation type="vanished">Aggiungi</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3161"/>
         <source>Delete</source>
-        <translation>Cancella</translation>
+        <translation type="vanished">Cancella</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2982"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3176"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2987"/>
         <source>Short</source>
         <translation>Cortp</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3177"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2988"/>
         <source>Long</source>
         <translation>Lungo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3178"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2989"/>
         <source>Percent of CV</source>
         <translation>Percentuale di CV</translation>
     </message>
@@ -23390,14 +23370,14 @@ Nessuna uscita in bici trovata da importare.
         <translation type="vanished">Raggiunto il massimo di 10 zone.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3220"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3227"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3037"/>
         <source>New</source>
         <translation>Nuovo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3222"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3229"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3032"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3039"/>
         <source>New (%1)</source>
         <translation>Nuovo (%1)</translation>
     </message>
@@ -23597,27 +23577,27 @@ Nessuna uscita in bici trovata da importare.
 <context>
     <name>PaceZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3082"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2905"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3084"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2907"/>
         <source>Run</source>
         <translation>Corsa</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3085"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2908"/>
         <source>Swim</source>
         <translation>Nuoto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3126"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2949"/>
         <source>Critical Velocity</source>
         <translation>Velocità Critica</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2950"/>
         <source>Default</source>
         <translation>Base</translation>
     </message>
@@ -25765,78 +25745,79 @@ Vuoi continuare?</translation>
 <context>
     <name>PerspectiveDialog</name>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="34"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="35"/>
         <source>Manage Perspectives</source>
         <translation>Gestisci Prospettive</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="43"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="44"/>
         <source>Perspectives</source>
         <translation>Prospettive</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="60"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="61"/>
         <source>Charts</source>
         <translation>Grafici</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Edit</source>
-        <translation>Modifica</translation>
+        <translation type="vanished">Modifica</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="83"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="78"/>
         <source>Import</source>
         <translation>Importa</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="84"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="77"/>
         <source>Export</source>
         <translation>Esporta</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="90"/>
         <source>Add</source>
-        <translation>Aggiungi</translation>
+        <translation type="vanished">Aggiungi</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="91"/>
         <source>Delete</source>
-        <translation>Cancella</translation>
+        <translation type="vanished">Cancella</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="98"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Drag charts to move to a perspective</source>
         <translation>Trascina grafici per cambiare prospettiva</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="287"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="256"/>
         <source>Export Persepctive</source>
         <translation>Esporta Prospettiva</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
         <source>Export Perspective</source>
         <translation>Esporta Prospettiva</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>No perspective file selected!</source>
         <translation>Nessun file di prospettiva selezionato!</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
         <source>Select Perspective file to export</source>
-        <translation>Seleziona file di prospettiva per l&apos;esportazione</translation>
+        <translation type="vanished">Seleziona file di prospettiva per l&apos;esportazione</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
         <source>GoldenCheetah Perspective Files (*.gchartset)</source>
         <translation>File Prospettiva GoldenCheetah (*.gchartset)</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
+        <source>Select Perspective file to import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>Import Perspective</source>
         <translation>Importa Prospettiva</translation>
     </message>
@@ -26999,307 +26980,307 @@ Python disabilitato nelle preferenze.</translation>
 <context>
     <name>RealtimeData</name>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="621"/>
+        <location filename="../../Train/RealtimeData.cpp" line="623"/>
         <source>None</source>
         <translation>Nessuno</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="624"/>
+        <location filename="../../Train/RealtimeData.cpp" line="626"/>
         <source>Time</source>
         <translation>Tempo</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="627"/>
+        <location filename="../../Train/RealtimeData.cpp" line="629"/>
         <source>Lap</source>
         <translation>Giro</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="630"/>
+        <location filename="../../Train/RealtimeData.cpp" line="632"/>
         <source>Lap Time</source>
         <translation>Tempo Giro</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="633"/>
+        <location filename="../../Train/RealtimeData.cpp" line="635"/>
         <source>Lap Time Remaining</source>
         <translation>Tempo Rimanente sul Giro</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="636"/>
+        <location filename="../../Train/RealtimeData.cpp" line="638"/>
         <source>Section Time Remaining</source>
         <translation>Tempo Rimanente sulla Sezione</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="639"/>
+        <location filename="../../Train/RealtimeData.cpp" line="641"/>
         <source>BikeStress</source>
         <translation>BikeStress</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="645"/>
+        <location filename="../../Train/RealtimeData.cpp" line="647"/>
         <source>kJoules</source>
         <translation>KJoule</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="648"/>
+        <location filename="../../Train/RealtimeData.cpp" line="650"/>
         <source>W&apos; bal</source>
         <translation>W&apos;bal</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="651"/>
+        <location filename="../../Train/RealtimeData.cpp" line="653"/>
         <source>XPower</source>
         <translation>XPower</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="654"/>
+        <location filename="../../Train/RealtimeData.cpp" line="656"/>
         <source>Iso Power</source>
         <translation>Potenza Normalizzata</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="657"/>
+        <location filename="../../Train/RealtimeData.cpp" line="659"/>
         <source>Intensity Factor</source>
         <translation>Fattore di Intensità</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="660"/>
+        <location filename="../../Train/RealtimeData.cpp" line="662"/>
         <source>Relative Intensity</source>
         <translation>Intensità Relativa</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="663"/>
+        <location filename="../../Train/RealtimeData.cpp" line="665"/>
         <source>Skiba Variability Index</source>
         <translation>Indice di Variabilità di Skiba</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="666"/>
+        <location filename="../../Train/RealtimeData.cpp" line="668"/>
         <source>Variability Index</source>
         <translation>Indice di Variabilità</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="669"/>
+        <location filename="../../Train/RealtimeData.cpp" line="671"/>
         <source>Distance</source>
         <translation>Distanza</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="672"/>
+        <location filename="../../Train/RealtimeData.cpp" line="674"/>
         <source>Route Distance</source>
         <translation>Distanza Percorso</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="675"/>
+        <location filename="../../Train/RealtimeData.cpp" line="677"/>
         <source>Distance Remaining</source>
         <translation>Distanza Rimanente</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="678"/>
+        <location filename="../../Train/RealtimeData.cpp" line="680"/>
         <source>Alternate Power</source>
         <translation>Potenza Alternata</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="681"/>
+        <location filename="../../Train/RealtimeData.cpp" line="683"/>
         <source>Power</source>
         <translation>Potenza</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="684"/>
+        <location filename="../../Train/RealtimeData.cpp" line="686"/>
         <source>Speed</source>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="687"/>
+        <location filename="../../Train/RealtimeData.cpp" line="689"/>
         <source>Virtual Speed</source>
         <translation>Velocità Virtuale</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="690"/>
+        <location filename="../../Train/RealtimeData.cpp" line="692"/>
         <source>Cadence</source>
         <translation>Cadenza</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="693"/>
+        <location filename="../../Train/RealtimeData.cpp" line="695"/>
         <source>Heart Rate</source>
         <translation>Frequenza Cardiaca</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="696"/>
+        <location filename="../../Train/RealtimeData.cpp" line="698"/>
         <source>Target Power</source>
         <translation>Potenza Prefissata</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="699"/>
+        <location filename="../../Train/RealtimeData.cpp" line="701"/>
         <source>Average Power</source>
         <translation>Potenza Media</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="702"/>
+        <location filename="../../Train/RealtimeData.cpp" line="704"/>
         <source>Average Speed</source>
         <translation>Velocità Media</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="705"/>
+        <location filename="../../Train/RealtimeData.cpp" line="707"/>
         <source>Average Heartrate</source>
         <translation>Frequenza cardiaca Media</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="708"/>
+        <location filename="../../Train/RealtimeData.cpp" line="710"/>
         <source>Average Cadence</source>
         <translation>Cadenza Media</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="711"/>
+        <location filename="../../Train/RealtimeData.cpp" line="713"/>
         <source>Lap Power</source>
         <translation>Potenza per Giro</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="714"/>
+        <location filename="../../Train/RealtimeData.cpp" line="716"/>
         <source>Lap Speed</source>
         <translation>Velocità per Giro</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="717"/>
+        <location filename="../../Train/RealtimeData.cpp" line="719"/>
         <source>Lap Heartrate</source>
         <translation>Frequenza Cardiaca per Giro</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="720"/>
+        <location filename="../../Train/RealtimeData.cpp" line="722"/>
         <source>Lap Cadence</source>
         <translation>Cadenza per Giro</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="723"/>
+        <location filename="../../Train/RealtimeData.cpp" line="725"/>
         <source>Left/Right Balance</source>
         <translation>Bilanciamento Sinistra/Destra</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="726"/>
+        <location filename="../../Train/RealtimeData.cpp" line="728"/>
         <source>Total Hb Mass</source>
         <translation>Massa Hb totale</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="729"/>
+        <location filename="../../Train/RealtimeData.cpp" line="731"/>
         <source>Hb O2 Saturation</source>
         <translation>Sturazione O2 Hb</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="732"/>
+        <location filename="../../Train/RealtimeData.cpp" line="734"/>
         <source>Deoxy Hb</source>
         <translation>Hb deossigenata</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="735"/>
+        <location filename="../../Train/RealtimeData.cpp" line="737"/>
         <source>Oxy Hb</source>
         <translation>Hb Ossigenata</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="738"/>
+        <location filename="../../Train/RealtimeData.cpp" line="740"/>
         <source>Left Torque Effectiveness</source>
         <translation>Efficacità coppia torcente sinistra</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="741"/>
+        <location filename="../../Train/RealtimeData.cpp" line="743"/>
         <source>Right Torque Effectiveness</source>
         <translation>Efficacità coppia torcente destra</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="744"/>
+        <location filename="../../Train/RealtimeData.cpp" line="746"/>
         <source>Left Pedal Smoothness</source>
         <translation>Omogeneità pedale sinistro</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="747"/>
+        <location filename="../../Train/RealtimeData.cpp" line="749"/>
         <source>Right Pedal Smoothness</source>
         <translation>Omogeneità pedale destro</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="750"/>
+        <location filename="../../Train/RealtimeData.cpp" line="752"/>
         <source>Right Power Phase Start</source>
         <translation>Inizio Fase Potenza destra</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="753"/>
+        <location filename="../../Train/RealtimeData.cpp" line="755"/>
         <source>Right Power Phase End</source>
         <translation>Fine Fase Potenza destra</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="756"/>
+        <location filename="../../Train/RealtimeData.cpp" line="758"/>
         <source>Right Power Phase Peak Start</source>
         <translation>Inizio Fase Picco Potenza destra</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="759"/>
+        <location filename="../../Train/RealtimeData.cpp" line="761"/>
         <source>Right Power Phase Peak End</source>
         <translation>Fine Fase Picco Potenza destra</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="762"/>
+        <location filename="../../Train/RealtimeData.cpp" line="764"/>
         <source>Slope</source>
         <translation>Pendenza</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="765"/>
+        <location filename="../../Train/RealtimeData.cpp" line="767"/>
         <source>Lap Distance</source>
         <translation>Distanza Giro</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="768"/>
+        <location filename="../../Train/RealtimeData.cpp" line="770"/>
         <source>Lap Distance Remaining</source>
         <translation>Distanza Rimanente sul Giro</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="771"/>
+        <location filename="../../Train/RealtimeData.cpp" line="773"/>
         <source>Latitude</source>
         <translation>Latitudine</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="774"/>
+        <location filename="../../Train/RealtimeData.cpp" line="776"/>
         <source>Longitude</source>
         <translation>Longitudine</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="777"/>
+        <location filename="../../Train/RealtimeData.cpp" line="779"/>
         <source>Altitude</source>
         <translation>Quota</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="780"/>
+        <location filename="../../Train/RealtimeData.cpp" line="782"/>
         <source>Respiratory Frequency</source>
         <translation>Frequenza Respiratoria</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="783"/>
+        <location filename="../../Train/RealtimeData.cpp" line="785"/>
         <source>Ventilation</source>
         <translation>Ventilazione</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="786"/>
+        <location filename="../../Train/RealtimeData.cpp" line="788"/>
         <source>VO2</source>
         <translation>VO2</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="789"/>
+        <location filename="../../Train/RealtimeData.cpp" line="791"/>
         <source>VCO2</source>
         <translation>VCO2</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="792"/>
+        <location filename="../../Train/RealtimeData.cpp" line="794"/>
         <source>Respiratory Exchange Ratio</source>
         <translation>Rapporto Scambio Repiratorio</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="795"/>
+        <location filename="../../Train/RealtimeData.cpp" line="797"/>
         <source>Tidal Volume</source>
         <translation>Volume Corrente</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="798"/>
+        <location filename="../../Train/RealtimeData.cpp" line="800"/>
         <source>Fraction O2 Expired</source>
         <translation>Frazione O2 Espirato</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="801"/>
+        <location filename="../../Train/RealtimeData.cpp" line="803"/>
         <source>Temperature</source>
         <translation type="unfinished">Temperatura</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="804"/>
+        <location filename="../../Train/RealtimeData.cpp" line="806"/>
         <source>CoreTemp</source>
         <translation type="unfinished"></translation>
     </message>
@@ -27395,22 +27376,22 @@ Python disabilitato nelle preferenze.</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Series</source>
         <translation>Serie</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="172"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
         <source>Power</source>
         <translation>Potenza</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="176"/>
         <source>Heart Rate</source>
         <translation>Frequenza cardiaca</translation>
     </message>
@@ -29709,317 +29690,317 @@ di GoldenCheetah. Procediamo?
 <context>
     <name>ScatterPlot</name>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="113"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
         <source>Power (watts)</source>
         <translation>Potenza (watt)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
         <source>Cadence (rpm)</source>
         <translation>Cadenza (rpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="116"/>
         <source>Heartrate (bpm)</source>
         <translation>Frequenza Cardiaca (bpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="118"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="119"/>
         <source>Speed (kph)</source>
         <translation>Velocità (km/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="120"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="121"/>
         <source>Speed (mph)</source>
         <translation>Velocità (mi/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="124"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="125"/>
         <source>Altitude (meters)</source>
         <translation>Quota (metri)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="126"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="127"/>
         <source>Altitude (feet)</source>
         <translation>Quota (feet)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="128"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
         <source>Torque (N)</source>
         <translation>Coppia torcente (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="130"/>
         <source>Elapsed Time (secs)</source>
         <translation>Tempo Trascorso (sec)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="132"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="133"/>
         <source>Elapsed Distance (km)</source>
         <translation>Distanza Percorsa (km)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="134"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="135"/>
         <source>Elapsed Distance (mi)</source>
         <translation>Distanza Percorsa (miglia)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="136"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
         <source>Interval Number</source>
         <translation>Numero intervalli</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
         <source>Latitude (degree offset)</source>
         <translation>Latitudine (offset gradi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
         <source>Longitude (degree offset)</source>
         <translation>Longitudine (offset gradi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
         <source>Circumferential Pedal Velocity (m/s)</source>
         <translation>Velocità Tangenziale di Pedalata (m/s)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="141"/>
         <source>Average Effective Pedal Force (N)</source>
         <translation>Forza Media Effettiva Pedalata (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="144"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
         <source>Time at X/Y (%)</source>
         <translation>Tempo a X/Y (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
         <source>Power Zone</source>
         <translation>Zona di Potenza</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
         <source>Headwind (kph)</source>
         <translation>Vento Contrario (km/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
         <source>Slope (gradient)</source>
         <translation>Pendenza (gradiente)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
         <source>Temperature (C)</source>
         <translation>Temperatura (C)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
         <source>L/R Balance</source>
         <translation>Bilanciamento D/S</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
         <source>Torque Efficiency</source>
         <translation>Efficienza coppia torcente</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
         <source>Pedal Smoothness</source>
         <translation>Omogeneità pedalata</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
         <source>Running Vertical Oscillation</source>
         <translation>Oscillazione Verticale Corsa</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
         <source>Running Ground Contact Time</source>
         <translation>Tempo di contatto al suolo corsa</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
         <source>Running Cadence</source>
         <translation>Cadenza di corsa</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
         <source>Gear Ratio</source>
         <translation>Rapporti</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
         <source>Muscle Oxygen</source>
         <translation>Ossigeno muscolare</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
         <source>Haemoglobin Mass</source>
         <translation>Massa Emoglobina</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
         <source>Deoxygenated Haemoglobin</source>
         <translation>Emoglobina Deossigenata</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="160"/>
         <source>Oxygenated Haemoglobin</source>
         <translation>Emoglobina Ossigenata</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="161"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="162"/>
         <source>Unknown</source>
         <translation>Sconosciuto</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="165"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
         <source>Power</source>
         <translation>Potenza</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
         <source>Cadence</source>
         <translation>Cadenza</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
         <source>Heartrate</source>
         <translation>Frequenza Cardiaca</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
         <source>Speed</source>
         <translation>Velocità</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
         <source>Altitude</source>
         <translation>Quota</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
         <source>Pedal Force</source>
         <translation>Forza Pedalata</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
         <source>Time</source>
         <translation>Orario</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
         <source>Distance</source>
         <translation>Distanza</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
         <source>Interval</source>
         <translation>Intervallo</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
         <source>Latitude</source>
         <translation>Latitudine</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
         <source>Longitude</source>
         <translation>Longitudine</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
         <source>Time at X/Y</source>
         <translation>Tempo a X/Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
         <source>Zone</source>
         <translation>Zona</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
         <source>CPV</source>
         <translation>CPV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
         <source>AEPF</source>
         <translation>AEPF</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
         <source>Headwind</source>
         <translation>Vento Contrario</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
         <source>Slope</source>
         <translation>Pendenza</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
         <source>Temp</source>
         <translation>Temp</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
         <source>Balance</source>
         <translation>Bilanciamento</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
         <source>TE</source>
         <translation>TE</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
         <source>PS</source>
         <translation>PS</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
         <source>RV</source>
         <translation>RV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
         <source>GCT</source>
         <translation>GCT</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
         <source>Run Cad</source>
         <translation>Cad corsa</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
         <source>Gear</source>
         <translation>Rapporto</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="194"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="195"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="196"/>
         <source>None</source>
         <translation>Nessuno</translation>
     </message>
@@ -30257,42 +30238,38 @@ di GoldenCheetah. Procediamo?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1012"/>
         <source>Add</source>
-        <translation>Aggiungi</translation>
+        <translation type="vanished">Aggiungi</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1013"/>
         <source>Delete</source>
-        <translation>Cancella</translation>
+        <translation type="vanished">Cancella</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1006"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1007"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1023"/>
+        <location filename="../../Gui/AthletePages.cpp" line="982"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="988"/>
         <source>Short</source>
         <translation>Corto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="989"/>
         <source>Long</source>
         <translation>Lungo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1031"/>
+        <location filename="../../Gui/AthletePages.cpp" line="990"/>
         <source>Percent of CP</source>
         <translation>Percentuale di CP</translation>
     </message>
@@ -30301,14 +30278,14 @@ di GoldenCheetah. Procediamo?
         <translation type="vanished">Raggiunto il massimo di 10 zone.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1069"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1076"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1034"/>
         <source>New</source>
         <translation>Nuovo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1071"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1078"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1036"/>
         <source>New (%1)</source>
         <translation>Nuovo (%1)</translation>
     </message>
@@ -30481,64 +30458,64 @@ di GoldenCheetah. Procediamo?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3821"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3569"/>
         <source>Add</source>
         <translation>Aggiungi</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3822"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3570"/>
         <source>Delete</source>
         <translation>Cancella</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3823"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3571"/>
         <source>Up</source>
         <translation>Sopra</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3824"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3572"/>
         <source>Down</source>
         <translation>Sotto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3870"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3872"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3963"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3965"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3711"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3713"/>
         <source>ddd MMM d, yyyy</source>
         <translation>ddd d MMM, yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3557"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3810"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3558"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3804"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3835"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3583"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3805"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3836"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3553"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3584"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3806"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3837"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3554"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3585"/>
         <source>From</source>
         <translation>Da</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3807"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3838"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3555"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3586"/>
         <source>To</source>
         <translation>a</translation>
     </message>
@@ -32995,25 +32972,25 @@ della bicicletta virtuale.</translation>
 <context>
     <name>TrainSidebar</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="253"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="257"/>
         <source>Save workout data</source>
         <translation>Salva dati allenamento</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="259"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="263"/>
         <source>Devices</source>
         <translation>Dispositivi</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="262"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="267"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="311"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="321"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="271"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="315"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="325"/>
         <source>Menu</source>
         <translation>Menù</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="270"/>
         <source>Workouts</source>
         <translation>Allenamenti</translation>
     </message>
@@ -33022,114 +32999,114 @@ della bicicletta virtuale.</translation>
         <translation type="vanished">Filtro...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="303"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="307"/>
         <source>Workout Info</source>
         <translation>Info Allenamento</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="310"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="314"/>
         <source>Media</source>
         <translation>Multimedia</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="320"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="324"/>
         <source>VideoSync</source>
         <translation>VideoSync</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="506"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
         <source>Import Workout from File</source>
         <translation>Importa Allenamento da file</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="507"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="511"/>
         <source>Get Workouts from TrainerDay</source>
         <translation>Ottieni gli allenamenti da TrainerDay</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="509"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="513"/>
         <source>Create Workout via Wizard</source>
         <translation>Genera un allenamento via Wizard</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="514"/>
         <source>Scan for Workouts</source>
         <translation>Scansiona per nuovi allenamenti</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="534"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="538"/>
         <source>Delete selected Workout</source>
         <translation>Cancella allenamenti selezionati</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="541"/>
         <source>Delete %1 selected Workouts</source>
         <translation>Cancella %1 allenamenti selezionati</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Train mode active</source>
         <translation>Modalità Allenamento attiva</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Please stop the train mode before closing the window or application.</source>
         <translation>Si prega di terminare la modalità allenamento prima di chiudere la finestra o l&apos;applicazione.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="635"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="639"/>
         <source>Remove reference to selected video</source>
         <translation>Rimuovi il riferimento al video selezionato</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="650"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="654"/>
         <source>Import VideoSync from File</source>
         <translation>Importa VideoSync da file</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="651"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="655"/>
         <source>Scan for VideoSyncs</source>
         <translation>Scansiona per VideoSync</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="668"/>
         <source>Delete selected VideoSync</source>
         <translation>Cancella VideoSync selezionati</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1064"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1068"/>
         <source>Are you sure you want to remove the reference to this video?</source>
         <translation>Sei sicuro di voler cancellare il riferimento a questo video?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1066"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1128"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1204"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1070"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1132"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1208"/>
         <source>Remove</source>
         <translation>Rimuovi</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1099"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1103"/>
         <source>Are you sure you want to delete this VideoSync?</source>
         <translation>Sei sicuro di voler cancellare i VideoSync?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1126"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1130"/>
         <source>The VideoSync file is either not valid or not existing and will be removed from the library.</source>
         <translation>Il file VideoSync è o non valido o non esistente e sarà rimosso dalla libreria.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1160"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1164"/>
         <source>Are you sure you want to delete this Workout?</source>
         <translation>Sei sicuro di voler cancellare questo Allenamento?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1163"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1167"/>
         <source>Are you sure you want to delete this %1 workouts?</source>
         <translation>Sei sicuro di voler cancellare questi allenamenti %1?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1202"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1206"/>
         <source>The Workout file is either not valid or not existing and will be removed from the library.</source>
         <translation>Il file Allenamento è o non valido o non esistente e sarà rimosso dalla libreria.</translation>
     </message>
@@ -33138,31 +33115,31 @@ della bicicletta virtuale.</translation>
         <translation type="vanished">ERRORE: %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1347"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1351"/>
         <source>Starting in %1</source>
         <translation>Comincia tra %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2225"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2237"/>
         <source>Recalibrating steering..</source>
         <translation>Ricalibratura sterzo..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2521"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2525"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2594"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2645"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2649"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2533"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2606"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2657"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2661"/>
         <source>Requesting calibration..</source>
         <translation>Sto richiedendo calibrazione..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2532"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2544"/>
         <source>Calibrating...</source>
         <translation>Sto calibrando...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2536"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2548"/>
         <source>Calibrating...
 Current speed %1 kph
 Increase speed to %2 kph</source>
@@ -33171,14 +33148,14 @@ Velocità attuale %1 km/h
 Incremento velocità %2 km/h</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2540"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2552"/>
         <source>Calibrating...
 Stop pedalling until speed drops to 0</source>
         <translation>Sto calibrando...
 Smeti di pedalare fino a che la velocità scende a 0</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2545"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2557"/>
         <source>Calibration completed successfully!
 Spindown %1 ms
 Zero Offset %2</source>
@@ -33187,30 +33164,30 @@ Spindown %1 ms
 Zero Offset %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2553"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2620"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2672"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2565"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2632"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2684"/>
         <source>Calibration failed!</source>
         <translation>Calibrazione non riuscita!</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2573"/>
         <source>Calibration Failed: Loosen Roller</source>
         <translation>Calibrazione non riuscita: rullo non stretto</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2569"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2581"/>
         <source>Calibration Failed: Tighten Roller</source>
         <translation>Calibrazione non riuscita: stringi rullo</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2588"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2639"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2600"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2651"/>
         <source>Unclip or stop pedalling to begin calibration..</source>
         <translation>Sgancia o smetti di pedalare per iniziare la calibrazione..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2607"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2619"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Torque %1</source>
@@ -33219,7 +33196,7 @@ Sgancia o smetti di pedalare fino al completamento del processo..
 Coppia Torcente %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2612"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2624"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Torque %2</source>
@@ -33228,7 +33205,7 @@ Zero Offset %1
 Coppia Torcente %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2659"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2671"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Zero Offset %1</source>
@@ -33237,7 +33214,7 @@ Sgancia o smetti di pedalare fino al completamento del processo..
 Zero Offset %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2676"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Slope %2</source>
@@ -33246,175 +33223,175 @@ Zero Offset %1
 Inclinazione %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2693"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2705"/>
         <source>Give the pedal a kick to start calibration...
 The motor will run until calibration is complete.</source>
         <translation>Pedala per cominciare la calibrazione...
 Il motore gira fini al completamento della calibrazione.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2695"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
         <source>Allow wheel speed to settle, DO NOT PEDAL...
 The motor will run until calibration is complete.</source>
         <translation>Consenti alla velocità della ruota di stabilizzarsi, NON PEDALARE...
 Il motore gira fino al completatmento della calibrazione.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2700"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2712"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Gathering enough samples to calculate average: %1</source>
         <translation>Calibrazione... NON PEDALARE, rimani seduto...
 Raccolta di campioni sufficienti per il calcolo della media: %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2719"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Waiting for value to stabilize (max %1s): %2 (%3W @ %4kph)</source>
         <translation>Calibrazione... NON PEDALARE, rimani seduto...
 In attesa che il valore si stabilizzi (max %1s): %2 (%3W @ %4kph)</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2722"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
         <source>Calibration completed successfully!
 Final calibration value %1 (%2W @ %3kph)</source>
         <translation>Calibrazione completata con successo!
 Valore finale della calibrazione %1 (%2W @ %3kph)</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2746"/>
         <source>Calibration failed! Do not pedal while calibration is taking place.
 Allow wheel to run freely.</source>
         <translation>Calibrazione fallita! Non pedalare mentre procede la calibrazione.
 Permetti alla ruota di girare liberamente.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2780"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2792"/>
         <source>Fast forward..</source>
         <translation>Avanti veloce..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2813"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2825"/>
         <source>Rewind..</source>
         <translation>Indietro..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2843"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2855"/>
         <source>Next Lap..</source>
         <translation>Nuovo giro..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2876"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2888"/>
         <source>Back Lap..</source>
         <translation>Giro indietro..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2902"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2914"/>
         <source>Increasing intensity..</source>
         <translation>Intensità in aumento..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2928"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2940"/>
         <source>Decreasing intensity..</source>
         <translation>Intensità in diminuzione..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="621"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="625"/>
         <source>Import Video from File</source>
         <translation>Importa Video da file</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="508"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="512"/>
         <source>Get Workouts from Strava Routes</source>
         <translation>Ottieni Allenamenti dai Percorsi Strava</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="622"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="626"/>
         <source>Scan for Videos</source>
         <translation>Scansiona per Video</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1101"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1173"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3183"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1105"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1177"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3195"/>
         <source>Delete</source>
         <translation>Cancella</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1309"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1313"/>
         <source>Resuming..</source>
         <translation>Sto ricominciando..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1336"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1340"/>
         <source>Paused..</source>
         <translation>In pausa..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1465"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1469"/>
         <source>Starting..</source>
         <translation>Sto iniziando..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1673"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1677"/>
         <source>Stopped..</source>
         <translation>Fermato..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1763"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1769"/>
         <source>Connected..</source>
         <translation>Connesso..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1787"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1793"/>
         <source>Disconnected..</source>
         <translation>Disconnesso..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2198"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2210"/>
         <source>New lap..</source>
         <translation>Nuovo giro..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>No Devices Configured</source>
         <translation>Nessun Dispositivo Configurato</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>Please configure a device in Preferences.</source>
         <translation>SI prega di configurare un dispositivo nelle Preferenze.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2483"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2495"/>
         <source>Exiting calibration..</source>
         <translation>Uscita calibrazione..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2498"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2510"/>
         <source>Calibration not supported for this device.</source>
         <translation>Calibrazione non supportata da questo strumento.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2505"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2517"/>
         <source>Calibrating...
 Press F3 on Controller when done.</source>
         <translation>Calibrazione in corso...
 Premi F3 sul Controller quando finito.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3135"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3153"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3147"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3165"/>
         <source>Add Device</source>
         <translation>Aggiungi Dispositivo</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3140"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3158"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3152"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3170"/>
         <source>Delete Device</source>
         <translation>Cancella Dispositivo</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3181"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3193"/>
         <source>Are you sure you want to delete this device?</source>
         <translation>Sei sicuro di voler cancellare questo dispositivo?</translation>
     </message>
@@ -33731,7 +33708,7 @@ Premi F3 sul Controller quando finito.</translation>
 <context>
     <name>UniqueLabelEditDelegate</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="77"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="108"/>
         <source>The given value &quot;%1&quot; is not unique</source>
         <translation>Il valore dato &quot;%1&quot; non e&apos; unico</translation>
     </message>
@@ -33747,171 +33724,167 @@ Premi F3 sul Controller quando finito.</translation>
 <context>
     <name>UserChartSettings</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="772"/>
+        <location filename="../../Charts/UserChart.cpp" line="773"/>
         <source>Chart</source>
         <translation>Grafico</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="782"/>
+        <location filename="../../Charts/UserChart.cpp" line="783"/>
         <source>Sub-title</source>
         <translation>Sottotitolo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="785"/>
+        <location filename="../../Charts/UserChart.cpp" line="786"/>
         <source>Description</source>
         <translation>Descrizione</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="791"/>
+        <location filename="../../Charts/UserChart.cpp" line="792"/>
         <source>Line Chart</source>
         <translation>Grafico Linea</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="792"/>
+        <location filename="../../Charts/UserChart.cpp" line="793"/>
         <source>Scatter Chart</source>
         <translation>Grafico Punti</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="793"/>
+        <location filename="../../Charts/UserChart.cpp" line="794"/>
         <source>Bar Chart</source>
         <translation>Grafico a Barre</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="794"/>
+        <location filename="../../Charts/UserChart.cpp" line="795"/>
         <source>Stacked Bar Chart</source>
         <translation>Grafico a barre impilate</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="795"/>
+        <location filename="../../Charts/UserChart.cpp" line="796"/>
         <source>Stacked Percent Chart</source>
         <translation>Grafico Percentuali Impilate</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="796"/>
+        <location filename="../../Charts/UserChart.cpp" line="797"/>
         <source>Pie Chart</source>
         <translation>Grafico a Torta</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="800"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="801"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="804"/>
+        <location filename="../../Charts/UserChart.cpp" line="805"/>
         <source>Vertical</source>
         <translation>verticale</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="805"/>
+        <location filename="../../Charts/UserChart.cpp" line="806"/>
         <source>Horizontal</source>
         <translation>Orizontale</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="808"/>
+        <location filename="../../Charts/UserChart.cpp" line="809"/>
         <source>Layout</source>
         <translation>Struttura Pagina</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="812"/>
+        <location filename="../../Charts/UserChart.cpp" line="813"/>
         <source>None</source>
         <translation>Nessuno</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="813"/>
+        <location filename="../../Charts/UserChart.cpp" line="814"/>
         <source>Top</source>
         <translation>Alto</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="814"/>
+        <location filename="../../Charts/UserChart.cpp" line="815"/>
         <source>Left</source>
         <translation>Sinistra</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="815"/>
+        <location filename="../../Charts/UserChart.cpp" line="816"/>
         <source>Right</source>
         <translation>Destra</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="816"/>
+        <location filename="../../Charts/UserChart.cpp" line="817"/>
         <source>Bottom</source>
         <translation>Basso</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="820"/>
+        <location filename="../../Charts/UserChart.cpp" line="821"/>
         <source>Legend</source>
         <translation>Legenda</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="829"/>
+        <location filename="../../Charts/UserChart.cpp" line="830"/>
         <source>Font scaling</source>
         <translation>Scala Carattere</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="831"/>
-        <location filename="../../Charts/UserChart.cpp" line="833"/>
+        <location filename="../../Charts/UserChart.cpp" line="832"/>
+        <location filename="../../Charts/UserChart.cpp" line="834"/>
         <source>Background</source>
         <translation>Colore Sfondo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="836"/>
+        <location filename="../../Charts/UserChart.cpp" line="837"/>
         <source>Animate</source>
         <translation>Animato</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="838"/>
+        <location filename="../../Charts/UserChart.cpp" line="839"/>
         <source>Single series per plot</source>
         <translation>Serie singola per grafico</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="841"/>
+        <location filename="../../Charts/UserChart.cpp" line="842"/>
         <source>Refresh for intervals</source>
         <translation>Ricarica per intervalli</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="848"/>
+        <location filename="../../Charts/UserChart.cpp" line="849"/>
         <source>Series</source>
         <translation>Serie</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Group</source>
         <translation>Gruppo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Y Formula</source>
         <translation>Formula Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="870"/>
-        <location filename="../../Charts/UserChart.cpp" line="932"/>
         <source>Edit</source>
-        <translation>Modifica</translation>
+        <translation type="vanished">Modifica</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="889"/>
         <source>Up</source>
-        <translation>Sopra</translation>
+        <translation type="vanished">Sopra</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="890"/>
         <source>Down</source>
-        <translation>Sotto</translation>
+        <translation type="vanished">Sotto</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="911"/>
+        <location filename="../../Charts/UserChart.cpp" line="885"/>
         <source>Axes</source>
         <translation>Assi</translation>
     </message>
@@ -34585,72 +34558,72 @@ Premi F3 sul Controller quando finito.</translation>
 <context>
     <name>VideoWindow</name>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> kph</source>
         <translation> Km/h</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="119"/>
+        <location filename="../../Train/VideoWindow.cpp" line="144"/>
         <source>Meters layout</source>
         <translation>Struttura pagina Metri</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="127"/>
+        <location filename="../../Train/VideoWindow.cpp" line="152"/>
         <source>Reset Meters layout to default</source>
         <translation>Resetta struttura pagina Metri ai valori predefiniti</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> mph</source>
         <translation> m/h</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> m</source>
         <translation> m</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> feet</source>
         <translation> piedi</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="625"/>
+        <location filename="../../Train/VideoWindow.cpp" line="681"/>
         <source>w</source>
         <translation>w</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="629"/>
+        <location filename="../../Train/VideoWindow.cpp" line="685"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> km</source>
         <translation> km</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> mi</source>
         <translation> mi</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="673"/>
+        <location filename="../../Train/VideoWindow.cpp" line="729"/>
         <source>Calibration required</source>
         <translation>Richiesta calibrazione</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="678"/>
+        <location filename="../../Train/VideoWindow.cpp" line="734"/>
         <source>Configuration required</source>
         <translation>Richiesta Configurazione</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="683"/>
+        <location filename="../../Train/VideoWindow.cpp" line="739"/>
         <source>brake fault</source>
         <translation>Problema ai freni</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="688"/>
+        <location filename="../../Train/VideoWindow.cpp" line="744"/>
         <source>Ready</source>
         <translation>Pronto</translation>
     </message>
@@ -35085,27 +35058,27 @@ Premi F3 sul Controller quando finito.</translation>
 <context>
     <name>WheelSizeCalculator</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="202"/>
+        <location filename="../../Gui/AthletePages.cpp" line="187"/>
         <source>Wheel Size Calculator</source>
         <translation>Calcolatore Dimensione Ruota</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="221"/>
+        <location filename="../../Gui/AthletePages.cpp" line="206"/>
         <source>Rim Size</source>
         <translation>Dimensione Cerchio</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="222"/>
+        <location filename="../../Gui/AthletePages.cpp" line="207"/>
         <source>Tire Size</source>
         <translation>Dimensione Pneumatico</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="223"/>
+        <location filename="../../Gui/AthletePages.cpp" line="208"/>
         <source>Wheel Size</source>
         <translation>Dimensione Ruota</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="227"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
@@ -35217,12 +35190,12 @@ Premi F3 sul Controller quando finito.</translation>
 <context>
     <name>WorkoutFilterBox</name>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="34"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="44"/>
         <source>Filter...</source>
         <translation type="unfinished">Filtro...</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="64"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="95"/>
         <source>ERROR: %1</source>
         <translation type="unfinished">ERRORE: %1</translation>
     </message>
@@ -35230,12 +35203,12 @@ Premi F3 sul Controller quando finito.</translation>
 <context>
     <name>WorkoutImportDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="820"/>
+        <location filename="../../Train/Library.cpp" line="809"/>
         <source>Import to Library</source>
         <translation>Importa nella Libreria</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="854"/>
+        <location filename="../../Train/Library.cpp" line="843"/>
         <source>Please note, that when importing or drag and dropping videos into the library we DO NOT copy the file into the GoldenCheetah library, instead we add a REFERENCE to it. We DO copy workout and videoSync files, since they are smaller.
 
 You can remove references when managing the library via the context menu options</source>
@@ -35244,24 +35217,107 @@ You can remove references when managing the library via the context menu options
 Si possono rimuovere le referenze quando si gestisce la librearia atraverso le opzioni del menu di contesto</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="868"/>
+        <location filename="../../Train/Library.cpp" line="857"/>
         <source>Files</source>
         <translation>File</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="878"/>
+        <location filename="../../Train/Library.cpp" line="867"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="880"/>
+        <location filename="../../Train/Library.cpp" line="869"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="884"/>
+        <location filename="../../Train/Library.cpp" line="873"/>
         <source>Overwite existing files</source>
         <translation>Sovrascrivi file esistenti</translation>
+    </message>
+</context>
+<context>
+    <name>WorkoutMenuProvider</name>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="271"/>
+        <source>Select Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="274"/>
+        <source>Manage Filters</source>
+        <translation type="unfinished">Gestisci filtri</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="275"/>
+        <source>Add Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="289"/>
+        <source>Add Tag to Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="292"/>
+        <source>Filter Tags...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="310"/>
+        <source>Match all selected tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="353"/>
+        <source>Manage Workout Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="360"/>
+        <source>Name</source>
+        <translation type="unfinished">Nome</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="361"/>
+        <source>Filter</source>
+        <translation type="unfinished">Filtro</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="362"/>
+        <source>_index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="370"/>
+        <source>Execute</source>
+        <translation type="unfinished">Esegue</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="371"/>
+        <source>Update</source>
+        <translation type="unfinished">Aggiorna</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="423"/>
+        <source>Add Workout Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="426"/>
+        <source>Name of the Filter...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="467"/>
+        <source>New</source>
+        <translation type="unfinished">Nuovo</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="469"/>
+        <source>New (%1)</source>
+        <translation type="unfinished">Nuovo (%1)</translation>
     </message>
 </context>
 <context>
@@ -35276,41 +35332,41 @@ Si possono rimuovere le referenze quando si gestisce la librearia atraverso le o
     <name>WorkoutPlotWindow</name>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="40"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="104"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
         <source>Ergmode specific settings</source>
         <translation>Impostazioni specifiche per Ergmode</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="46"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
         <source>Color power zones</source>
         <translation>Colore zone di potenza</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="48"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="56"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
         <source>Never</source>
         <translation>Mai</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="49"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
         <source>Always</source>
         <translation>Sempre</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="50"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="57"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="109"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="113"/>
         <source>When stopped</source>
         <translation>Quando fermato</translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="54"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="110"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
         <source>Show tooltip</source>
         <translation>Mostra descrizione del comando</translation>
     </message>
@@ -35400,12 +35456,12 @@ Si possono rimuovere le referenze quando si gestisce la librearia atraverso le o
 <context>
     <name>WorkoutWidget</name>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="1531"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="1532"/>
         <source>File save failed.</source>
         <translation>Impossibile salvare file.</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="2367"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="2368"/>
         <source>Intensity</source>
         <translation>Intensità</translation>
     </message>
@@ -35559,26 +35615,22 @@ Si possono rimuovere le referenze quando si gestisce la librearia atraverso le o
 <context>
     <name>XDataDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="44"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="45"/>
         <source>xData</source>
         <translation>xData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="58"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="59"/>
         <source>Data Series</source>
         <translation>Serie dei Dati</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="78"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="80"/>
         <source>Add</source>
-        <translation>Aggiungi</translation>
+        <translation type="vanished">Aggiungi</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="79"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="81"/>
         <source>Delete</source>
-        <translation>Cancella</translation>
+        <translation type="vanished">Cancella</translation>
     </message>
 </context>
 <context>
@@ -35655,32 +35707,32 @@ Si possono rimuovere le referenze quando si gestisce la librearia atraverso le o
 <context>
     <name>XDataSeriesSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="333"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="315"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="338"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="320"/>
         <source>Units</source>
         <translation>Unità</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="346"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="328"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="347"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="329"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Name is blank</source>
         <translation>Nome è in bianco</translation>
     </message>
@@ -35688,48 +35740,48 @@ Si possono rimuovere le referenze quando si gestisce la librearia atraverso le o
 <context>
     <name>XDataSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="262"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="244"/>
         <source>xData</source>
         <translation>xData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="269"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="251"/>
         <source>Data Series</source>
         <translation>Serie dei Dati</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="270"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="252"/>
         <source>Units</source>
         <translation>Unità</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="274"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="256"/>
         <source>Series %1</source>
         <translation>Serie %1</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="281"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="263"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="282"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="264"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
         <source>XData name is blank</source>
         <translation>Nome XData è in bianco</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Must have at least one data series.</source>
         <translation>Devi avere almeno una serie di dati.</translation>
     </message>
@@ -36050,17 +36102,17 @@ Si possono rimuovere le referenze quando si gestisce la librearia atraverso le o
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="915"/>
+        <location filename="../../Gui/AthletePages.cpp" line="886"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="962"/>
+        <location filename="../../Gui/AthletePages.cpp" line="933"/>
         <source>Critical Power</source>
         <translation>Potenza Critica (CP)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="963"/>
+        <location filename="../../Gui/AthletePages.cpp" line="934"/>
         <source>Default</source>
         <translation>Base</translation>
     </message>

--- a/src/Resources/translations/gc_ja.ts
+++ b/src/Resources/translations/gc_ja.ts
@@ -99,38 +99,38 @@ It might be necessary to manually disable it.</source>
         <translation type="obsolete">長期ストレス平均に用いる日数</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="504"/>
+        <location filename="../../Gui/AthletePages.cpp" line="489"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="517"/>
-        <location filename="../../Gui/AthletePages.cpp" line="522"/>
+        <location filename="../../Gui/AthletePages.cpp" line="502"/>
+        <location filename="../../Gui/AthletePages.cpp" line="507"/>
         <source>days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="525"/>
+        <location filename="../../Gui/AthletePages.cpp" line="510"/>
         <source>PMC Stress Balance Today</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="528"/>
+        <location filename="../../Gui/AthletePages.cpp" line="513"/>
         <source>Restore Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="517"/>
         <source>W&apos;bal tau</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="518"/>
         <source>Short Term Stress (STS) average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="534"/>
+        <location filename="../../Gui/AthletePages.cpp" line="519"/>
         <source>Long Term Stress (LTS) average</source>
         <translation type="unfinished"></translation>
     </message>
@@ -146,96 +146,96 @@ It might be necessary to manually disable it.</source>
 <context>
     <name>AboutRiderPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="372"/>
+        <location filename="../../Gui/AthletePages.cpp" line="357"/>
         <source>Nickname</source>
         <translation type="unfinished">ニックネーム</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="373"/>
+        <location filename="../../Gui/AthletePages.cpp" line="358"/>
         <source>Date of Birth</source>
         <translation type="unfinished">誕生日</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="374"/>
+        <location filename="../../Gui/AthletePages.cpp" line="359"/>
         <source>Sex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="376"/>
+        <location filename="../../Gui/AthletePages.cpp" line="361"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="375"/>
+        <location filename="../../Gui/AthletePages.cpp" line="360"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="279"/>
+        <location filename="../../Gui/AthletePages.cpp" line="264"/>
         <source>Male</source>
         <translation type="unfinished">男性</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="280"/>
+        <location filename="../../Gui/AthletePages.cpp" line="265"/>
         <source>Female</source>
         <translation type="unfinished">女性</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> kg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> lb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> cm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="359"/>
+        <location filename="../../Gui/AthletePages.cpp" line="344"/>
         <source>Calculate...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="378"/>
+        <location filename="../../Gui/AthletePages.cpp" line="363"/>
         <source>Bike</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="379"/>
+        <location filename="../../Gui/AthletePages.cpp" line="364"/>
         <source>Crank Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="380"/>
+        <location filename="../../Gui/AthletePages.cpp" line="365"/>
         <source>Wheelsize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="438"/>
+        <location filename="../../Gui/AthletePages.cpp" line="423"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="356"/>
+        <location filename="../../Gui/AthletePages.cpp" line="341"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="437"/>
+        <location filename="../../Gui/AthletePages.cpp" line="422"/>
         <source>Choose Picture</source>
         <translation type="unfinished">写真の選択</translation>
     </message>
@@ -2228,397 +2228,382 @@ Press Next to Continue
 <context>
     <name>AllPlotWindow</name>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="190"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="444"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="165"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
         <source>Smooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="198"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="173"/>
         <source>Stacked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="199"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="174"/>
         <source>by series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="200"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="175"/>
         <source>Fullplot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="201"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="176"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="239"/>
         <source>Overlay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="229"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="204"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="206"/>
         <source>Stack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="210"/>
         <source>By Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="246"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="221"/>
         <source>Stack Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="248"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="223"/>
         <source>Full plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="227"/>
         <source>Show Interval Markers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="256"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
         <source>Interval Navigator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="260"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
         <source>Hover intervals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="268"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="243"/>
         <source>Fill Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="247"/>
         <source>Grid</source>
         <translation>グリッド</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="277"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
         <source>Acceleration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="279"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="254"/>
         <source>Delta Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="280"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="255"/>
         <source>Power %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="283"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="258"/>
         <source>Cadence %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="261"/>
         <source>Torque %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="289"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
         <source>Heartrate %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="295"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="270"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="274"/>
         <source>Torque Effectiveness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="303"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="278"/>
         <source>Smoothness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="282"/>
         <source>Pedal Center Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="311"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
         <source>Power Phase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="290"/>
         <source>Peak Power Phase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="322"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
         <source>Vertical Oscillation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="324"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
         <source>Running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="326"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="301"/>
         <source>Ground Contact Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
         <source>Cadence </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="313"/>
         <source>SmO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="340"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
         <source>Moxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="317"/>
         <source>tHb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="321"/>
         <source>O2Hb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="325"/>
         <source>HHb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="355"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="330"/>
         <source>Heart Rate</source>
         <translation>心拍数</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="357"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
         <source>Data series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="359"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="334"/>
         <source>Core Temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="363"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="367"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
         <source>Cadence</source>
         <translation>ケイデンス</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="94"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="95"/>
         <source>Basic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="109"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="110"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="116"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="117"/>
         <source>User Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="132"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="134"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="144"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="163"/>
-        <source>Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="164"/>
-        <source>Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="371"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
         <source>Altitude</source>
         <translation>標高</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
         <source>Temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="379"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="354"/>
         <source>Headwind</source>
         <translation type="unfinished">向かい風</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="383"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="358"/>
         <source>Torque</source>
         <translation type="unfinished">トルク</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="387"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="362"/>
         <source>Gear Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="391"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="366"/>
         <source>Slope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="373"/>
         <source>No Alt/Slope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="399"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="374"/>
         <source>0.1km|mi -  1min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="400"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
         <source>0.5km|mi -  5min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="401"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="376"/>
         <source>1.0km|mi - 10min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1528"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="377"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="1503"/>
         <source>Alt/Slope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="382"/>
         <source>Anaerobic TISS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="384"/>
         <source>Metrics</source>
         <translation type="unfinished">統計</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="411"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="386"/>
         <source>Aerobic TISS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="390"/>
         <source>Iso Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="394"/>
         <source>Skiba xPower</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="423"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
         <source>Altitude Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="427"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
         <source>W&apos; balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="441"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="416"/>
         <source>Time of day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="742"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="717"/>
         <source>Intervals</source>
         <translation type="unfinished">インターバル</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="2253"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="2228"/>
         <source>Selection #%1 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="432"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
         <source>Power + shade</source>
         <translation>出力 (シェード)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="433"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="408"/>
         <source>Power - shade</source>
         <translation>出力 (シェードなし)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="434"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
         <source>No Power</source>
         <translation>出力なし</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="435"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="410"/>
         <source>Shading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="439"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="414"/>
         <source>Time</source>
         <translation type="unfinished">時間</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="440"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
         <source>Distance</source>
         <translation type="unfinished">距離</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="442"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="417"/>
         <source>X Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3424,51 +3409,29 @@ Press Next to Continue
 <context>
     <name>AutoImportPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4028"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4029"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Browse</source>
         <translation type="obsolete">参照</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4040"/>
         <source>Add</source>
-        <translation type="unfinished">追加</translation>
+        <translation type="obsolete">追加</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4041"/>
         <source>Delete</source>
-        <translation type="unfinished">削除</translation>
+        <translation type="obsolete">削除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4042"/>
-        <source>Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4043"/>
-        <source>Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4054"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3779"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4059"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3784"/>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4060"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3785"/>
         <source>Import Rule</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4282,37 +4245,37 @@ Press Next to Continue
 <context>
     <name>BackupPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="608"/>
+        <location filename="../../Gui/AthletePages.cpp" line="593"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="601"/>
         <source>every</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="617"/>
+        <location filename="../../Gui/AthletePages.cpp" line="602"/>
         <source>times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="603"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="605"/>
         <source>Backup now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="623"/>
+        <location filename="../../Gui/AthletePages.cpp" line="608"/>
         <source>Auto Backup Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="624"/>
+        <location filename="../../Gui/AthletePages.cpp" line="609"/>
         <source>Auto Backup after closing the athlete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5114,41 +5077,25 @@ Let&apos;s get you setup.</source>
 <context>
     <name>CPPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1202"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1203"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1204"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1150"/>
         <source>Review...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1206"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1152"/>
         <source>Changed power estimates are available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1213"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1225"/>
         <source>Add</source>
-        <translation type="unfinished">追加</translation>
+        <translation type="obsolete">追加</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1214"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1226"/>
         <source>Delete</source>
-        <translation type="unfinished">削除</translation>
+        <translation type="obsolete">削除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1216"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1158"/>
         <source>Def</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5157,244 +5104,244 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">開始日</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1218"/>
         <source>Critical Power</source>
         <translation>クリティカルパワー</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1305"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>AeTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1306"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>FTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1307"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1221"/>
         <source>W&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1308"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1222"/>
         <source>Pmax</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1347"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1261"/>
         <source>Short</source>
         <translation>略称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1247"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1169"/>
         <source>Use CP for all metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1240"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1162"/>
         <source>Manual</source>
         <translation type="unfinished">手動</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1241"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1163"/>
         <source>Semi-Automatic (CP2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1164"/>
         <source>Semi-Automatic (CP3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1243"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1165"/>
         <source>Semi-Automatic (Extended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1170"/>
         <source>Use FTP for Coggan metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1273"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1279"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1285"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1342"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1618"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1631"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2283"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2289"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2310"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1187"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1193"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1199"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1211"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1537"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1545"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2180"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2186"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2194"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2207"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1205"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1547"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2201"/>
         <source>J</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1303"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1217"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2145"/>
         <source>Start Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1309"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1223"/>
         <source>Model Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1262"/>
         <source>Long</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1349"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1263"/>
         <source>From Watts</source>
         <translation>最低ワット</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1598"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1512"/>
         <source>Review range starting on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1614"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1528"/>
         <source>Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1615"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1529"/>
         <source>Estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1530"/>
         <source>Accept</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1788"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1691"/>
         <source>🗹</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1692"/>
         <source>Estimate and settings &lt;b&gt;match&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1695"/>
         <source>☐</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1696"/>
         <source>Estimate and settings &lt;b&gt;differ&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1797"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1700"/>
         <source>⏲</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1800"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1703"/>
         <source>Range is %1 days older than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1802"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1705"/>
         <source>Range is %1 days younger than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1808"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1711"/>
         <source>∅</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1712"/>
         <source>No estimate available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1902"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1805"/>
         <source>New range from estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2237"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2134"/>
         <source>The proposed value for AeTP is a very rough estimate, assuming %1 % of CP. Usually it is determined by a&lt;ul&gt;&lt;li&gt;Metabolic test&lt;/li&gt;&lt;li&gt;Lactate ramp test&lt;/li&gt;&lt;li&gt;Run / Cycling ‘conversational’ test&lt;/li&gt;&lt;li&gt;Run Decoupling test&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2239"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2136"/>
         <source>Updating FTP internally to match CP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2139"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2244"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2141"/>
         <source>Your selected model does not deliver values for PMax, using default value of %1 W instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2246"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2143"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;li&gt;PMax, assuming a default of %1 W&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2250"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2147"/>
         <source>Critical Power (CP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2252"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2149"/>
         <source>Aerobic Threshold Power (AeTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2254"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2151"/>
         <source>Functional Threshold Power (FTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2153"/>
         <source>Anaerobic Work Capacity (W&apos;)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2258"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2155"/>
         <source>Maximum Power (PMax)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2270"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2167"/>
         <source>Manual range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2018"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2025"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1917"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1924"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2020"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1919"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1926"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5838,52 +5785,36 @@ ddd, dd MMM yyyy</source>
 <context>
     <name>CVPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3307"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3319"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3308"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3320"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3313"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3325"/>
         <source>Add</source>
-        <translation type="unfinished">追加</translation>
+        <translation type="obsolete">追加</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3314"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3326"/>
         <source>Delete</source>
-        <translation type="unfinished">削除</translation>
+        <translation type="obsolete">削除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3316"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3109"/>
         <source>Def</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3359"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3506"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3272"/>
         <source>Start Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3249"/>
         <source>New range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3507"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3273"/>
         <source>Critical Velocity (CV)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3508"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3274"/>
         <source>Aerobic Threshold (AeT)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5892,39 +5823,39 @@ ddd, dd MMM yyyy</source>
         <translation type="obsolete">開始日</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3360"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3128"/>
         <source>Critical Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3361"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3129"/>
         <source>Aerobic Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3403"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
         <source>Short</source>
         <translation type="unfinished">略称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3404"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3172"/>
         <source>Long</source>
         <translation type="unfinished">名称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3405"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3173"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3679"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3686"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3441"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3448"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3681"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3688"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3443"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3450"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7448,37 +7379,20 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>CredentialsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="67"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
+        <source>Add</source>
+        <translation type="obsolete">追加</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="obsolete">削除</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="68"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="69"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="74"/>
-        <source>Add</source>
-        <translation type="unfinished">追加</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="75"/>
-        <source>Delete</source>
-        <translation type="unfinished">削除</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="86"/>
         <source>Service</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="87"/>
+        <location filename="../../Gui/AthletePages.cpp" line="69"/>
         <source>Description</source>
         <translation type="unfinished">説明</translation>
     </message>
@@ -8153,7 +8067,7 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>DataFilterEdit</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2743"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2712"/>
         <source>Warning: sample() is slow -- update code to use samples()</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8488,7 +8402,7 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>DirectoryPathWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="277"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="308"/>
         <source>Browse</source>
         <translation type="unfinished">参照</translation>
     </message>
@@ -8721,28 +8635,28 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>Dropbox</name>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="68"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="77"/>
         <source>Problem accessing Dropbox data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="130"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="139"/>
         <source>You must authorise with Dropbox first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="205"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="214"/>
         <source>Parsing Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="293"/>
-        <location filename="../../Cloud/Dropbox.cpp" line="312"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="302"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="321"/>
         <source>Completed.</source>
         <translation type="unfinished">完了。</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="297"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="306"/>
         <source>Network Error - Upload failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8883,136 +8797,136 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2064"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2033"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2034"/>
         <source>Axis Label / Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1597"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1566"/>
         <source>Curve Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1558"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1527"/>
         <source>Estimate %1 %2 Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1562"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1531"/>
         <source>Endurance Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1532"/>
         <source>Vo2Max Estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1605"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1574"/>
         <source>Metric</source>
         <translation type="unfinished">統計</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1606"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1575"/>
         <source>Best</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1607"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1576"/>
         <source>Estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1577"/>
         <source>PMC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1609"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1578"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1610"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1579"/>
         <source>Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1611"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1580"/>
         <source>Performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1612"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1581"/>
         <source>Banister</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1684"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1767"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1653"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1736"/>
         <source>seconds</source>
         <translation type="unfinished">秒</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1685"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1768"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1737"/>
         <source>minutes</source>
         <translation type="unfinished">分</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1769"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1655"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1738"/>
         <source>hours</source>
         <translation type="unfinished">時間</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1723"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1816"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1692"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1785"/>
         <source>Peak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1781"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1750"/>
         <source>Absolute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1751"/>
         <source>Per Kilogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1813"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
         <source>Total</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1814"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1783"/>
         <source>Running Total</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1815"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1784"/>
         <source>Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1817"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1786"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1820"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1789"/>
         <source>Aggregate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1828"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1797"/>
         <source># type in a formula to use
 # for e.g. BikeStress / Duration
 # as you type the available metrics
@@ -9021,292 +8935,292 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1839"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1808"/>
         <source>Weekly Best Performances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1840"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1809"/>
         <source>Submaximal Weekly Best</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1841"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1810"/>
         <source>Performance Tests</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1933"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1902"/>
         <source>Short Term Stress (STS/ATL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1934"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1903"/>
         <source>Long Term Stress  (LTS/CTL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1935"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1904"/>
         <source>Stress Balance    (SB/TSB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1936"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1905"/>
         <source>Stress Ramp Rate  (RR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1944"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1913"/>
         <source>Stress Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1949"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1918"/>
         <source>Negative Training Effect (NTE)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1950"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1919"/>
         <source>Positive Training Effect (PTE)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1951"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1920"/>
         <source>Performance (Power Index)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1952"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1921"/>
         <source>Predicted CP (Watts)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1969"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1938"/>
         <source>Curve Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1945"/>
         <source>Perf. Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2006"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1975"/>
         <source>Metadata Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2007"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
         <source>PMC metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2032"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2001"/>
         <source>Measure Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2009"/>
         <source>Measure Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2029"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2071"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2042"/>
         <source>Bar</source>
         <translation type="unfinished">バー</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2074"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2043"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2075"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2044"/>
         <source>Sticks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2076"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2045"/>
         <source>Dots</source>
         <translation type="unfinished">ドット</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2048"/>
         <source>Stack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2053"/>
         <source>Symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2086"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2055"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2087"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2056"/>
         <source>Circle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2057"/>
         <source>Square</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2089"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2058"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2090"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2059"/>
         <source>Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2091"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2092"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2061"/>
         <source>Hexagon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2062"/>
         <source>Star</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2100"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2069"/>
         <source>Fill curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
         <source>Data labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2080"/>
         <source>Highlight Highest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
         <source>Highlight Lowest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2127"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
         <source>Highlight Outliers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2135"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
         <source>Baseline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2143"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2112"/>
         <source>Smooth Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2147"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2116"/>
         <source>No trend Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2148"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2117"/>
         <source>Linear Trend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2149"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2118"/>
         <source>Quadratic Trend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2150"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
         <source>Moving Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2151"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2120"/>
         <source>Simple Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2123"/>
         <source>Ignore Zeros</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2168"/>
         <source>&amp;OK</source>
         <translation>OK(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2201"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2170"/>
         <source>&amp;Cancel</source>
         <translation>キャンセル(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2431"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2400"/>
         <source>Peak %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2402"/>
         <source> second </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2434"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2403"/>
         <source> minute </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2436"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2405"/>
         <source> hour </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2456"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2425"/>
         <source>%1 - %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2470"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2439"/>
         <source>Performances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2471"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2440"/>
         <source>Power Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2588"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2557"/>
         <source>Performances_%1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9628,93 +9542,93 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditUserAxisDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1731"/>
+        <location filename="../../Charts/UserChart.cpp" line="1689"/>
         <source>Edit Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1741"/>
+        <location filename="../../Charts/UserChart.cpp" line="1699"/>
         <source>&amp;OK</source>
         <translation type="unfinished">OK(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1742"/>
+        <location filename="../../Charts/UserChart.cpp" line="1700"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished">キャンセル(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1750"/>
+        <location filename="../../Charts/UserChart.cpp" line="1708"/>
         <source>Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1760"/>
+        <location filename="../../Charts/UserChart.cpp" line="1718"/>
         <source>Logarithmic Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1757"/>
+        <location filename="../../Charts/UserChart.cpp" line="1715"/>
         <source>Type</source>
         <translation type="unfinished">種別</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1761"/>
-        <location filename="../../Charts/UserChart.cpp" line="1780"/>
+        <location filename="../../Charts/UserChart.cpp" line="1719"/>
+        <location filename="../../Charts/UserChart.cpp" line="1738"/>
         <source> </source>
         <translation type="unfinished"> </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1763"/>
+        <location filename="../../Charts/UserChart.cpp" line="1721"/>
         <source>Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1774"/>
+        <location filename="../../Charts/UserChart.cpp" line="1732"/>
         <source> from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1776"/>
+        <location filename="../../Charts/UserChart.cpp" line="1734"/>
         <source> to </source>
         <translation type="unfinished"> から </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1779"/>
+        <location filename="../../Charts/UserChart.cpp" line="1737"/>
         <source>Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1787"/>
+        <location filename="../../Charts/UserChart.cpp" line="1745"/>
         <source>Smoothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1792"/>
+        <location filename="../../Charts/UserChart.cpp" line="1750"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1793"/>
+        <location filename="../../Charts/UserChart.cpp" line="1751"/>
         <source>Day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1794"/>
+        <location filename="../../Charts/UserChart.cpp" line="1752"/>
         <source>Week</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1795"/>
+        <location filename="../../Charts/UserChart.cpp" line="1753"/>
         <source>Month</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1796"/>
+        <location filename="../../Charts/UserChart.cpp" line="1754"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1798"/>
+        <location filename="../../Charts/UserChart.cpp" line="1756"/>
         <source>Group By</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9907,158 +9821,158 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditUserSeriesDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1398"/>
+        <location filename="../../Charts/UserChart.cpp" line="1356"/>
         <source>Edit Data Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1414"/>
+        <location filename="../../Charts/UserChart.cpp" line="1372"/>
         <source>&amp;OK</source>
         <translation type="unfinished">OK(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1415"/>
+        <location filename="../../Charts/UserChart.cpp" line="1373"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished">キャンセル(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1422"/>
+        <location filename="../../Charts/UserChart.cpp" line="1380"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1430"/>
+        <location filename="../../Charts/UserChart.cpp" line="1388"/>
         <source>Series Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1519"/>
+        <location filename="../../Charts/UserChart.cpp" line="1477"/>
         <source>Y units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1524"/>
+        <location filename="../../Charts/UserChart.cpp" line="1482"/>
         <source>X units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1528"/>
+        <location filename="../../Charts/UserChart.cpp" line="1486"/>
         <source>Sum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1529"/>
+        <location filename="../../Charts/UserChart.cpp" line="1487"/>
         <source>Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1530"/>
+        <location filename="../../Charts/UserChart.cpp" line="1488"/>
         <source>Peak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1531"/>
+        <location filename="../../Charts/UserChart.cpp" line="1489"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1532"/>
+        <location filename="../../Charts/UserChart.cpp" line="1490"/>
         <source>Running Total</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1533"/>
+        <location filename="../../Charts/UserChart.cpp" line="1491"/>
         <source>Mean Square Root</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1534"/>
+        <location filename="../../Charts/UserChart.cpp" line="1492"/>
         <source>Std Deviation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1537"/>
+        <location filename="../../Charts/UserChart.cpp" line="1495"/>
         <source>Aggregate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1541"/>
-        <location filename="../../Charts/UserChart.cpp" line="1557"/>
+        <location filename="../../Charts/UserChart.cpp" line="1499"/>
+        <location filename="../../Charts/UserChart.cpp" line="1515"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1542"/>
+        <location filename="../../Charts/UserChart.cpp" line="1500"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1543"/>
+        <location filename="../../Charts/UserChart.cpp" line="1501"/>
         <source>Dashed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1544"/>
+        <location filename="../../Charts/UserChart.cpp" line="1502"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1545"/>
+        <location filename="../../Charts/UserChart.cpp" line="1503"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1546"/>
+        <location filename="../../Charts/UserChart.cpp" line="1504"/>
         <source>Fast Graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1547"/>
+        <location filename="../../Charts/UserChart.cpp" line="1505"/>
         <source>Show on Legend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1548"/>
+        <location filename="../../Charts/UserChart.cpp" line="1506"/>
         <source>Show Data Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1554"/>
+        <location filename="../../Charts/UserChart.cpp" line="1512"/>
         <source>Line Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1558"/>
+        <location filename="../../Charts/UserChart.cpp" line="1516"/>
         <source>Circle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1559"/>
+        <location filename="../../Charts/UserChart.cpp" line="1517"/>
         <source>Rectangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1564"/>
+        <location filename="../../Charts/UserChart.cpp" line="1522"/>
         <source>Symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1572"/>
+        <location filename="../../Charts/UserChart.cpp" line="1530"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1575"/>
+        <location filename="../../Charts/UserChart.cpp" line="1533"/>
         <source>Fill curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1583"/>
+        <location filename="../../Charts/UserChart.cpp" line="1541"/>
         <source>Opacity (%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1589"/>
+        <location filename="../../Charts/UserChart.cpp" line="1547"/>
         <source>Size/Width</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10104,6 +10018,24 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
     <message>
         <location filename="../../Metrics/BasicRideMetrics.cpp" line="144"/>
         <source>Only useful for intervals, time the interval started</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ElevationChartWindow</name>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="221"/>
+        <source>Profile Distance (m)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="229"/>
+        <source>Seconds for delta slope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="237"/>
+        <source>Elevation window size (%) relative to current altitude</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10539,7 +10471,7 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ExhaustionDialog.cpp" line="160"/>
+        <location filename="../../Charts/ExhaustionDialog.cpp" line="162"/>
         <source>Time</source>
         <translation type="unfinished">時間</translation>
     </message>
@@ -12711,42 +12643,42 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GcCrashDialog</name>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="78"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="74"/>
         <source>%1 Crash Recovery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="116"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="112"/>
         <source>&lt;b&gt;GoldenCheetah appears to have PREVIOUSLY crashed for this athlete. &lt;/b&gt;&lt;br&gt;&lt;br&gt;The report below gives some diagnostic information that will be useful to the developers. Feel free to post this with a short description of what was occurring when the crash happened to the &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah forums&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;We respect privacy - this log does NOT contain ids, passwords or personal information.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;When this dialog is closed the athlete will be opened.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="141"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="137"/>
         <source>Save Crash Report...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="143"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="139"/>
         <source>Close</source>
         <translation type="unfinished">閉じる</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="225"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="221"/>
         <source>&lt;p&gt;Build date: %1 %2&lt;br&gt;Build id: %3&lt;br&gt;Version: %4&lt;br&gt;DB Schema: %5&lt;br&gt;Metrics: %7&lt;br&gt;OS: %6&lt;br&gt;OpenGL: %10&lt;br&gt;UI: dpi scale (%8) font size (%9)&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="255"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="251"/>
         <source>&lt;table&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QT&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QWT&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;%3&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SRMIO&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;D2XX&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;ICAL&lt;/td&gt;&lt;td&gt;%9&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;USBXPRESS&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LIBUSB&lt;/td&gt;&lt;td&gt;%11&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VLC&lt;/td&gt;&lt;td&gt;%12&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VIDEO&lt;/td&gt;&lt;td&gt;%13&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SAMPLERATE&lt;/td&gt;&lt;td&gt;%14&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SSL&lt;/td&gt;&lt;td&gt;%15&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;R&lt;/td&gt;&lt;td&gt;%16&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;Python&lt;/td&gt;&lt;td&gt;%18&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LMFIT&lt;/td&gt;&lt;td&gt;7.0&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;GSL&lt;/td&gt;&lt;td&gt;%19&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Save Diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Text File (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13081,167 +13013,172 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GcWindowRegistry</name>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
         <source>Performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="89"/>
         <source>Histogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
         <source>Distribution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
         <source>Pedal Force vs Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
         <source>Heartrate vs Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
         <source>Python Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
         <source>Python Chart </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="101"/>
         <source>Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
         <source>Navigator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="71"/>
         <source>Season Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="72"/>
         <source>Blank Overview </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="76"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="73"/>
         <source>User Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
         <source>Trends</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="78"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
         <source>TreeMap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
         <source>Power Duration </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="83"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
         <source>Activity Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="81"/>
         <source>Blank Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="85"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="82"/>
         <source>User Chart </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
         <source>Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="88"/>
         <source>Power Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
         <source>Scatter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="103"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
         <source>Aerolab</source>
         <translation type="unfinished">エアロラボ</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
         <source>Workout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="106"/>
         <source>Realtime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
         <source>Pedal Stroke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="113"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
         <source>Live Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="114"/>
-        <source>Web page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
-        <source>Map</source>
-        <translation type="unfinished">地図</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
-        <source>R Chart</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="98"/>
-        <source>R Chart </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
-        <source>Video Player</source>
+        <source>Elevation Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
+        <source>Web page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <source>Map</source>
+        <translation type="unfinished">地図</translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <source>R Chart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <source>R Chart </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <source>Video Player</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
         <source>Workout Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14334,142 +14271,147 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="296"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="294"/>
+        <source>Show elevation profile of instant position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
         <source>Predefined and configurable set of data ranges for selection of activities to be analysed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
         <source>Powerful filter and search engine to determine the activities which are considered in diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
         <source>Configurable list of activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="317"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
         <source>Configurable list of training devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
         <source>Configurable list of workout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
         <source>Configurable list of video files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="325"/>
         <source>Configurable list of video sync files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="327"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
         <source>Entry field for sophisticated Searching and Filtering of activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
         <source>Adding intervals to an activity using simple query methods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
         <source>To compare Activities/Intervals in Activity View and Date Ranges in Trends View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="335"/>
         <source>Workout Control, Intensity Adjustments and Notifications Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
         <source>Athlete Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
         <source>Athlete Measures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
         <source>Auto Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
         <source>Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="355"/>
         <source>Cloud Accounts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <source>Automatic Interval Detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
         <source>Definition of coloring rules for activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
         <source>Metrics shown in &apos;Intervals&apos; and &apos;Summary&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
         <source>User/Custom Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
         <source>Create or Edit a User Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
         <source>Measures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
         <source>Train View devices configuration and preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
         <source>Train View Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
         <source>Remote Controls Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
         <source>Add/Remove Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
         <source>Add Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="394"/>
         <source>Virtual Bicycle configuration for simulation rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14503,8 +14445,8 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
     </message>
     <message>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="219"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
         <source>Calendar</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14539,74 +14481,74 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
         <source>Definition of points in time &apos;Events&apos; which are marked explicitely on time related diagrams</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="316"/>
         <source>Simple summary view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
         <source>Alternative access to the charts created for the main view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
         <source>Display the available and add new intervals using simple query methods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="356"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="337"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
         <source>Athlete</source>
         <translation type="unfinished">アスリート</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
         <source>Training Zone definition for power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
         <source>Training Zone definition for heartrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
         <source>Training Zone definition for Swim and Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="364"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
         <source>Data Fields</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
         <source>Definition of default value(s) for data fields</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
         <source>Definition of processing default parameters for the fix, adjust,... tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
         <source>Metrics</source>
         <translation type="unfinished">統計</translation>
     </message>
@@ -14806,61 +14748,49 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2437"/>
         <source>Add</source>
-        <translation type="unfinished">追加</translation>
+        <translation type="obsolete">追加</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2438"/>
         <source>Delete</source>
-        <translation type="unfinished">削除</translation>
+        <translation type="obsolete">削除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2431"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2432"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2447"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2332"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2458"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2343"/>
         <source>Short</source>
         <translation>略称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2459"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2344"/>
         <source>Long</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2460"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2345"/>
         <source>Percent of LT</source>
         <translatorcomment>いまいち</translatorcomment>
         <translation>対LTの割合</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2461"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2346"/>
         <source>Trimp k</source>
         <translatorcomment>でいいのかな？</translatorcomment>
         <translation>Trimp係数</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2506"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2513"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2390"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2397"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2508"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2515"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2392"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2399"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15050,17 +14980,17 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2245"/>
         <source>Sport</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2395"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2292"/>
         <source>Lactate Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2396"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2293"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
@@ -17193,545 +17123,530 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTMTool</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1303"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1272"/>
         <source>Metric</source>
         <translation>統計</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="74"/>
+        <location filename="../../Charts/LTMTool.cpp" line="75"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="80"/>
+        <location filename="../../Charts/LTMTool.cpp" line="81"/>
         <source>Date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="84"/>
+        <location filename="../../Charts/LTMTool.cpp" line="85"/>
         <source>Days</source>
         <translation type="unfinished">日</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="85"/>
+        <location filename="../../Charts/LTMTool.cpp" line="86"/>
         <source>Weeks</source>
         <translation type="unfinished">週</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="86"/>
+        <location filename="../../Charts/LTMTool.cpp" line="87"/>
         <source>Months</source>
         <translation type="unfinished">月</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="87"/>
+        <location filename="../../Charts/LTMTool.cpp" line="88"/>
         <source>Years</source>
         <translation type="unfinished">年</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="88"/>
+        <location filename="../../Charts/LTMTool.cpp" line="89"/>
         <source>Time Of Day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="89"/>
+        <location filename="../../Charts/LTMTool.cpp" line="90"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="91"/>
+        <location filename="../../Charts/LTMTool.cpp" line="92"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="102"/>
+        <location filename="../../Charts/LTMTool.cpp" line="103"/>
         <source>Shade Zones</source>
         <translation type="unfinished">ゾーンシェード</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="105"/>
+        <location filename="../../Charts/LTMTool.cpp" line="106"/>
         <source>Show Legend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="109"/>
         <source>Show Events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="351"/>
+        <location filename="../../Charts/LTMTool.cpp" line="325"/>
         <source>Skiba Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="353"/>
-        <location filename="../../Charts/LTMTool.cpp" line="368"/>
-        <location filename="../../Charts/LTMTool.cpp" line="429"/>
-        <location filename="../../Charts/LTMTool.cpp" line="444"/>
-        <location filename="../../Charts/LTMTool.cpp" line="505"/>
-        <location filename="../../Charts/LTMTool.cpp" line="520"/>
-        <location filename="../../Charts/LTMTool.cpp" line="580"/>
-        <location filename="../../Charts/LTMTool.cpp" line="595"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1080"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1095"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1156"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1171"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1309"/>
+        <location filename="../../Charts/LTMTool.cpp" line="327"/>
+        <location filename="../../Charts/LTMTool.cpp" line="342"/>
+        <location filename="../../Charts/LTMTool.cpp" line="403"/>
+        <location filename="../../Charts/LTMTool.cpp" line="418"/>
+        <location filename="../../Charts/LTMTool.cpp" line="479"/>
+        <location filename="../../Charts/LTMTool.cpp" line="494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="554"/>
+        <location filename="../../Charts/LTMTool.cpp" line="569"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1054"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1069"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1130"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1145"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1278"/>
         <source>Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="366"/>
+        <location filename="../../Charts/LTMTool.cpp" line="340"/>
         <source>Skiba Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="381"/>
+        <location filename="../../Charts/LTMTool.cpp" line="355"/>
         <source>Skiba Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="383"/>
-        <location filename="../../Charts/LTMTool.cpp" line="459"/>
-        <location filename="../../Charts/LTMTool.cpp" line="535"/>
-        <location filename="../../Charts/LTMTool.cpp" line="610"/>
-        <location filename="../../Charts/LTMTool.cpp" line="686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="762"/>
-        <location filename="../../Charts/LTMTool.cpp" line="838"/>
-        <location filename="../../Charts/LTMTool.cpp" line="914"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1110"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1186"/>
+        <location filename="../../Charts/LTMTool.cpp" line="357"/>
+        <location filename="../../Charts/LTMTool.cpp" line="433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="509"/>
+        <location filename="../../Charts/LTMTool.cpp" line="584"/>
+        <location filename="../../Charts/LTMTool.cpp" line="660"/>
+        <location filename="../../Charts/LTMTool.cpp" line="736"/>
+        <location filename="../../Charts/LTMTool.cpp" line="812"/>
+        <location filename="../../Charts/LTMTool.cpp" line="888"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1160"/>
         <source>Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="396"/>
+        <location filename="../../Charts/LTMTool.cpp" line="370"/>
         <source>Skiba STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="398"/>
-        <location filename="../../Charts/LTMTool.cpp" line="413"/>
-        <location filename="../../Charts/LTMTool.cpp" line="474"/>
-        <location filename="../../Charts/LTMTool.cpp" line="489"/>
-        <location filename="../../Charts/LTMTool.cpp" line="550"/>
-        <location filename="../../Charts/LTMTool.cpp" line="565"/>
-        <location filename="../../Charts/LTMTool.cpp" line="625"/>
-        <location filename="../../Charts/LTMTool.cpp" line="640"/>
-        <location filename="../../Charts/LTMTool.cpp" line="701"/>
-        <location filename="../../Charts/LTMTool.cpp" line="716"/>
-        <location filename="../../Charts/LTMTool.cpp" line="777"/>
-        <location filename="../../Charts/LTMTool.cpp" line="792"/>
-        <location filename="../../Charts/LTMTool.cpp" line="853"/>
-        <location filename="../../Charts/LTMTool.cpp" line="868"/>
-        <location filename="../../Charts/LTMTool.cpp" line="929"/>
-        <location filename="../../Charts/LTMTool.cpp" line="944"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1005"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1020"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1125"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1140"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1201"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1216"/>
+        <location filename="../../Charts/LTMTool.cpp" line="372"/>
+        <location filename="../../Charts/LTMTool.cpp" line="387"/>
+        <location filename="../../Charts/LTMTool.cpp" line="448"/>
+        <location filename="../../Charts/LTMTool.cpp" line="463"/>
+        <location filename="../../Charts/LTMTool.cpp" line="524"/>
+        <location filename="../../Charts/LTMTool.cpp" line="539"/>
+        <location filename="../../Charts/LTMTool.cpp" line="599"/>
+        <location filename="../../Charts/LTMTool.cpp" line="614"/>
+        <location filename="../../Charts/LTMTool.cpp" line="675"/>
+        <location filename="../../Charts/LTMTool.cpp" line="690"/>
+        <location filename="../../Charts/LTMTool.cpp" line="751"/>
+        <location filename="../../Charts/LTMTool.cpp" line="766"/>
+        <location filename="../../Charts/LTMTool.cpp" line="827"/>
+        <location filename="../../Charts/LTMTool.cpp" line="842"/>
+        <location filename="../../Charts/LTMTool.cpp" line="903"/>
+        <location filename="../../Charts/LTMTool.cpp" line="918"/>
+        <location filename="../../Charts/LTMTool.cpp" line="979"/>
+        <location filename="../../Charts/LTMTool.cpp" line="994"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1099"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1114"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1175"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1190"/>
         <source>Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="411"/>
+        <location filename="../../Charts/LTMTool.cpp" line="385"/>
         <source>Skiba LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="427"/>
+        <location filename="../../Charts/LTMTool.cpp" line="401"/>
         <source>Aerobic TISS Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="442"/>
+        <location filename="../../Charts/LTMTool.cpp" line="416"/>
         <source>Aerobic TISS Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="457"/>
+        <location filename="../../Charts/LTMTool.cpp" line="431"/>
         <source>Aerobic TISS Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="472"/>
+        <location filename="../../Charts/LTMTool.cpp" line="446"/>
         <source>Aerobic TISS STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="487"/>
+        <location filename="../../Charts/LTMTool.cpp" line="461"/>
         <source>Aerobic TISS LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="503"/>
+        <location filename="../../Charts/LTMTool.cpp" line="477"/>
         <source>Anaerobic TISS Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="518"/>
+        <location filename="../../Charts/LTMTool.cpp" line="492"/>
         <source>Anaerobic TISS Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="533"/>
+        <location filename="../../Charts/LTMTool.cpp" line="507"/>
         <source>Anaerobic TISS Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="548"/>
+        <location filename="../../Charts/LTMTool.cpp" line="522"/>
         <source>Anaerobic TISS STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="537"/>
         <source>Anaerobic TISS LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="578"/>
+        <location filename="../../Charts/LTMTool.cpp" line="552"/>
         <source>Daniels Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="593"/>
+        <location filename="../../Charts/LTMTool.cpp" line="567"/>
         <source>Daniels Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="582"/>
         <source>Daniels Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="623"/>
+        <location filename="../../Charts/LTMTool.cpp" line="597"/>
         <source>Daniels STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="638"/>
+        <location filename="../../Charts/LTMTool.cpp" line="612"/>
         <source>Daniels LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="628"/>
         <source>Work (Kj) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="656"/>
-        <location filename="../../Charts/LTMTool.cpp" line="671"/>
-        <location filename="../../Charts/LTMTool.cpp" line="732"/>
-        <location filename="../../Charts/LTMTool.cpp" line="747"/>
-        <location filename="../../Charts/LTMTool.cpp" line="808"/>
-        <location filename="../../Charts/LTMTool.cpp" line="823"/>
+        <location filename="../../Charts/LTMTool.cpp" line="630"/>
+        <location filename="../../Charts/LTMTool.cpp" line="645"/>
+        <location filename="../../Charts/LTMTool.cpp" line="706"/>
+        <location filename="../../Charts/LTMTool.cpp" line="721"/>
+        <location filename="../../Charts/LTMTool.cpp" line="782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="797"/>
         <source>Stress (Kj)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="669"/>
+        <location filename="../../Charts/LTMTool.cpp" line="643"/>
         <source>Work (Kj) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="684"/>
+        <location filename="../../Charts/LTMTool.cpp" line="658"/>
         <source>Work (Kj) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="699"/>
+        <location filename="../../Charts/LTMTool.cpp" line="673"/>
         <source>Work (Kj) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="714"/>
+        <location filename="../../Charts/LTMTool.cpp" line="688"/>
         <source>Work (Kj) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="730"/>
+        <location filename="../../Charts/LTMTool.cpp" line="704"/>
         <source>W&apos; Work (Kj) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="745"/>
+        <location filename="../../Charts/LTMTool.cpp" line="719"/>
         <source>W&apos; Work (Kj) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="760"/>
+        <location filename="../../Charts/LTMTool.cpp" line="734"/>
         <source>W&apos; Work (Kj) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="775"/>
+        <location filename="../../Charts/LTMTool.cpp" line="749"/>
         <source>W&apos; Work (Kj) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="790"/>
+        <location filename="../../Charts/LTMTool.cpp" line="764"/>
         <source>W&apos; Work (Kj) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="806"/>
+        <location filename="../../Charts/LTMTool.cpp" line="780"/>
         <source>Below CP Work (Kj) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="821"/>
+        <location filename="../../Charts/LTMTool.cpp" line="795"/>
         <source>Below CP Work (Kj) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="836"/>
+        <location filename="../../Charts/LTMTool.cpp" line="810"/>
         <source>Below CP Work (Kj) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="851"/>
+        <location filename="../../Charts/LTMTool.cpp" line="825"/>
         <source>Below CP Work (Kj) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="866"/>
+        <location filename="../../Charts/LTMTool.cpp" line="840"/>
         <source>Below CP Work (Kj) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="882"/>
+        <location filename="../../Charts/LTMTool.cpp" line="856"/>
         <source>Distance (km|mi) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="884"/>
-        <location filename="../../Charts/LTMTool.cpp" line="899"/>
+        <location filename="../../Charts/LTMTool.cpp" line="858"/>
+        <location filename="../../Charts/LTMTool.cpp" line="873"/>
         <source>Stress (km|mi)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="897"/>
+        <location filename="../../Charts/LTMTool.cpp" line="871"/>
         <source>Distance (km|mi) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="912"/>
+        <location filename="../../Charts/LTMTool.cpp" line="886"/>
         <source>Distance (km|mi) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="927"/>
+        <location filename="../../Charts/LTMTool.cpp" line="901"/>
         <source>Distance (km|mi) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="942"/>
+        <location filename="../../Charts/LTMTool.cpp" line="916"/>
         <source>Distance (km|mi) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="958"/>
+        <location filename="../../Charts/LTMTool.cpp" line="932"/>
         <source>Coggan Chronic Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="973"/>
+        <location filename="../../Charts/LTMTool.cpp" line="947"/>
         <source>Coggan Acute Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="988"/>
+        <location filename="../../Charts/LTMTool.cpp" line="962"/>
         <source>Coggan Training Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1003"/>
+        <location filename="../../Charts/LTMTool.cpp" line="977"/>
         <source>Coggan STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1018"/>
+        <location filename="../../Charts/LTMTool.cpp" line="992"/>
         <source>Coggan LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1033"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1007"/>
         <source>Coggan Expected Chronic Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1048"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1022"/>
         <source>Coggan Expected Acute Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1063"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1037"/>
         <source>Coggan Expected Training Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1053"/>
         <source>TRIMP Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1067"/>
         <source>TRIMP Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1082"/>
         <source>TRIMP Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1123"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1097"/>
         <source>TRIMP STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1138"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1112"/>
         <source>TRIMP LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="268"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/LTMTool.cpp" line="124"/>
+        <location filename="../../Charts/LTMTool.cpp" line="125"/>
         <source>Use sidebar chart settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Basic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="314"/>
+        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Preset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1307"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1276"/>
         <source>Estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1311"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1280"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1282"/>
         <source>Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1284"/>
         <source>Performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1317"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1286"/>
         <source>Banister</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1463"/>
         <source>Chart %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="94"/>
+        <location filename="../../Charts/LTMTool.cpp" line="95"/>
         <source>Data Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="98"/>
+        <location filename="../../Charts/LTMTool.cpp" line="99"/>
         <source>Show Stack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="121"/>
+        <location filename="../../Charts/LTMTool.cpp" line="122"/>
         <source>Stack Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="155"/>
+        <location filename="../../Charts/LTMTool.cpp" line="156"/>
         <source>Add Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="146"/>
+        <location filename="../../Charts/LTMTool.cpp" line="147"/>
         <source>Charts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="112"/>
         <source>Show Banister Helper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="155"/>
         <source>Apply</source>
         <translation type="unfinished">適用</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="287"/>
-        <source>Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/LTMTool.cpp" line="288"/>
-        <source>Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/LTMTool.cpp" line="315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="289"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1128"/>
         <source>TriScore Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1169"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1143"/>
         <source>TriScore Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1184"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1158"/>
         <source>TriScore Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1173"/>
         <source>TriScore STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1214"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1188"/>
         <source>TriScore LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Type</source>
         <translation type="unfinished">種別</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1305"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1274"/>
         <source>Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17930,31 +17845,15 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2590"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2602"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2591"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2603"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2596"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2608"/>
         <source>Add</source>
-        <translation type="unfinished">追加</translation>
+        <translation type="obsolete">追加</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2597"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2609"/>
         <source>Delete</source>
-        <translation type="unfinished">削除</translation>
+        <translation type="obsolete">削除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2599"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2467"/>
         <source>Def</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17963,77 +17862,77 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">開始日</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2651"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2790"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2494"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2631"/>
         <source>Lactate Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2652"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2791"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2495"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2632"/>
         <source>Aerobic Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2967"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2974"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2804"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2811"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2969"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2976"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2806"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2813"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2653"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2496"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
         <source>Rest HR</source>
         <translation>安静時心拍数</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2628"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2690"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2770"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2775"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2780"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2785"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2473"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2478"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2488"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2611"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2621"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2626"/>
         <source>bpm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2650"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2493"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2630"/>
         <source>Start Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2654"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2497"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2634"/>
         <source>Max HR</source>
         <translation>最大心拍数</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2701"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2544"/>
         <source>Short</source>
         <translation>略称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2702"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2545"/>
         <source>Long</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2703"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2546"/>
         <source>From BPM</source>
         <translation>最低心拍数</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2704"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2547"/>
         <source>Trimp k</source>
         <translation>Trimp係数</translation>
     </message>
@@ -18774,62 +18673,62 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>Library</name>
     <message>
+        <location filename="../../Train/Library.cpp" line="126"/>
         <location filename="../../Train/Library.cpp" line="130"/>
-        <location filename="../../Train/Library.cpp" line="134"/>
         <source>Import Videos, VideoSyncs and Workouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="127"/>
         <location filename="../../Train/Library.cpp" line="131"/>
-        <location filename="../../Train/Library.cpp" line="135"/>
         <source>No supported videos, videoSyncs or workouts were found to import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="189"/>
         <location filename="../../Train/Library.cpp" line="193"/>
-        <location filename="../../Train/Library.cpp" line="197"/>
+        <location filename="../../Train/Library.cpp" line="198"/>
         <location filename="../../Train/Library.cpp" line="202"/>
-        <location filename="../../Train/Library.cpp" line="206"/>
         <source>Copy VideoSync Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="190"/>
         <location filename="../../Train/Library.cpp" line="194"/>
-        <location filename="../../Train/Library.cpp" line="198"/>
         <source>%1 already exists in videoSync library: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="203"/>
+        <location filename="../../Train/Library.cpp" line="199"/>
         <source>%1 cannot be written to videoSync library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="207"/>
+        <location filename="../../Train/Library.cpp" line="203"/>
         <source>%1 cannot be written to videoSync library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="253"/>
+        <location filename="../../Train/Library.cpp" line="249"/>
         <source>%1 cannot be written to workout library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="257"/>
+        <location filename="../../Train/Library.cpp" line="253"/>
         <source>%1 cannot be written to workout library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="239"/>
         <location filename="../../Train/Library.cpp" line="243"/>
-        <location filename="../../Train/Library.cpp" line="247"/>
+        <location filename="../../Train/Library.cpp" line="248"/>
         <location filename="../../Train/Library.cpp" line="252"/>
-        <location filename="../../Train/Library.cpp" line="256"/>
         <source>Copy Workout Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="240"/>
         <location filename="../../Train/Library.cpp" line="244"/>
-        <location filename="../../Train/Library.cpp" line="248"/>
         <source>%1 already exists in workout library: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18837,89 +18736,89 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LibrarySearchDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="330"/>
+        <location filename="../../Train/Library.cpp" line="326"/>
         <source>Search for Workouts, Syncs and Media</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="337"/>
+        <location filename="../../Train/Library.cpp" line="333"/>
         <source>Workout files (.erg, .mrc, .zwo etc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="339"/>
+        <location filename="../../Train/Library.cpp" line="335"/>
         <source>Video files (.mp4, .avi etc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="341"/>
+        <location filename="../../Train/Library.cpp" line="337"/>
         <source>VideoSync files (.rlv, .tts etc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="359"/>
+        <location filename="../../Train/Library.cpp" line="353"/>
         <source>Search Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="379"/>
+        <location filename="../../Train/Library.cpp" line="373"/>
         <source>Video references</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="391"/>
+        <location filename="../../Train/Library.cpp" line="385"/>
         <source>Searching...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="394"/>
+        <location filename="../../Train/Library.cpp" line="388"/>
         <source>Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="396"/>
+        <location filename="../../Train/Library.cpp" line="390"/>
         <source>Workouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="398"/>
+        <location filename="../../Train/Library.cpp" line="392"/>
         <source>VideoSyncs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="407"/>
-        <location filename="../../Train/Library.cpp" line="494"/>
+        <location filename="../../Train/Library.cpp" line="401"/>
+        <location filename="../../Train/Library.cpp" line="484"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="409"/>
+        <location filename="../../Train/Library.cpp" line="403"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="412"/>
+        <location filename="../../Train/Library.cpp" line="406"/>
         <source>Files to search for:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="475"/>
+        <location filename="../../Train/Library.cpp" line="466"/>
         <source>Abort Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="515"/>
-        <location filename="../../Train/Library.cpp" line="559"/>
+        <location filename="../../Train/Library.cpp" line="504"/>
+        <location filename="../../Train/Library.cpp" line="548"/>
         <source>Save</source>
         <translation type="unfinished">保存</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="557"/>
+        <location filename="../../Train/Library.cpp" line="546"/>
         <source>Search completed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="645"/>
+        <location filename="../../Train/Library.cpp" line="634"/>
         <source>Select Directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18927,12 +18826,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>ListEditWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="623"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="654"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="625"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="656"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18945,7 +18844,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="90"/>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="85"/>
+        <source>Initial Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="98"/>
         <source>Apply changes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19164,7 +19068,7 @@ on and that its display says, &quot;PC Link&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>Delete Activity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19326,109 +19230,109 @@ on and that its display says, &quot;PC Link&quot;</source>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Activity Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Closing of athlete window not possible while background activity import is in progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Chart Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>Import Images Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>You can only import images on the activities view with an activity selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>Import Images to Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>%1 images imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1778"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1788"/>
         <source>Failed to export activity, please check permissions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1814"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1824"/>
         <source>No Activity To Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1815"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1825"/>
         <source>There is no currently selected activity to save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
         <location filename="../../Gui/MainWindow.cpp" line="1886"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Split Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
         <source>No activity selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
         <source>Current activity contains no data to split</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Current activity contains no data to merge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1904"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1914"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2400"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2421"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2410"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2431"/>
         <source>The workout directory is not configured, or the directory selected no longer exists.
 
 Please check your preference settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2611"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2621"/>
         <source>Loading activities: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>CloudDB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>Current athlete is not registered as curator - please contact the GoldenCheetah team</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19513,12 +19417,12 @@ Please check your preference settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Imported %1 metric charts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2165"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2175"/>
         <source>&amp;New Athlete...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19528,23 +19432,23 @@ Please check your preference settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
         <source>Select Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>No activity selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1724"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1734"/>
         <source>Export Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1777"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1787"/>
         <source>Export Failed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19811,34 +19715,34 @@ Please check your preference settings.</source>
         <translation>Golden Cheetah について(&amp;A)</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1799"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2369"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1809"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2379"/>
         <source>Import from File</source>
         <translation>ファイルを取り込み</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2342"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2352"/>
         <source>Refresh in Progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Export Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2399"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2420"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2409"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2430"/>
         <source>Workout Directory Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1906"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1916"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
@@ -20730,55 +20634,43 @@ Please check your preference settings.</source>
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="656"/>
+        <location filename="../../Gui/AthletePages.cpp" line="641"/>
         <source>From Date - Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="780"/>
+        <location filename="../../Gui/AthletePages.cpp" line="751"/>
         <source>Start Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="893"/>
+        <location filename="../../Gui/AthletePages.cpp" line="864"/>
         <source>MMM d, yyyy - hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="659"/>
-        <location filename="../../Gui/AthletePages.cpp" line="807"/>
+        <location filename="../../Gui/AthletePages.cpp" line="644"/>
+        <location filename="../../Gui/AthletePages.cpp" line="778"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="662"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="663"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Delete</source>
-        <translation type="unfinished">削除</translation>
+        <translation type="obsolete">削除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="698"/>
+        <location filename="../../Gui/AthletePages.cpp" line="668"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="699"/>
+        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Original Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="668"/>
         <source>Add</source>
-        <translation type="unfinished">追加</translation>
+        <translation type="obsolete">追加</translation>
     </message>
 </context>
 <context>
@@ -21443,17 +21335,17 @@ No rides found to import.
 <context>
     <name>MultiDeviceDialog</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3048"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3060"/>
         <source>Multiple Device Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3103"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3115"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3106"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3118"/>
         <source>Apply</source>
         <translation type="unfinished">適用</translation>
     </message>
@@ -22374,54 +22266,42 @@ No rides found to import.
 <context>
     <name>PaceSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3154"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3155"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3160"/>
         <source>Add</source>
-        <translation type="unfinished">追加</translation>
+        <translation type="obsolete">追加</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3161"/>
         <source>Delete</source>
-        <translation type="unfinished">削除</translation>
+        <translation type="obsolete">削除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3176"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2987"/>
         <source>Short</source>
         <translation type="unfinished">略称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3177"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2988"/>
         <source>Long</source>
         <translation type="unfinished">名称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3178"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2989"/>
         <source>Percent of CV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3220"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3227"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3037"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3222"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3229"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3032"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3039"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -22621,27 +22501,27 @@ No rides found to import.
 <context>
     <name>PaceZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3082"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2905"/>
         <source>Sport</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3084"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2907"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3085"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2908"/>
         <source>Swim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3126"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2949"/>
         <source>Critical Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2950"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
@@ -24786,78 +24666,71 @@ Do you want to continue?</source>
 <context>
     <name>PerspectiveDialog</name>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="34"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="35"/>
         <source>Manage Perspectives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="43"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="44"/>
         <source>Perspectives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="60"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="61"/>
         <source>Charts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="83"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="78"/>
         <source>Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="84"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="77"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="90"/>
         <source>Add</source>
-        <translation type="unfinished">追加</translation>
+        <translation type="obsolete">追加</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="91"/>
         <source>Delete</source>
-        <translation type="unfinished">削除</translation>
+        <translation type="obsolete">削除</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="98"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Drag charts to move to a perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="287"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="256"/>
         <source>Export Persepctive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
         <source>Export Perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>No perspective file selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
-        <source>Select Perspective file to export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
         <source>GoldenCheetah Perspective Files (*.gchartset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
+        <source>Select Perspective file to import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>Import Perspective</source>
         <translation type="unfinished"></translation>
     </message>
@@ -26007,307 +25880,307 @@ Python disabled in preferences.</source>
 <context>
     <name>RealtimeData</name>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="621"/>
+        <location filename="../../Train/RealtimeData.cpp" line="623"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="624"/>
+        <location filename="../../Train/RealtimeData.cpp" line="626"/>
         <source>Time</source>
         <translation type="unfinished">時間</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="627"/>
+        <location filename="../../Train/RealtimeData.cpp" line="629"/>
         <source>Lap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="630"/>
+        <location filename="../../Train/RealtimeData.cpp" line="632"/>
         <source>Lap Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="633"/>
+        <location filename="../../Train/RealtimeData.cpp" line="635"/>
         <source>Lap Time Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="636"/>
+        <location filename="../../Train/RealtimeData.cpp" line="638"/>
         <source>Section Time Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="639"/>
+        <location filename="../../Train/RealtimeData.cpp" line="641"/>
         <source>BikeStress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="645"/>
+        <location filename="../../Train/RealtimeData.cpp" line="647"/>
         <source>kJoules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="648"/>
+        <location filename="../../Train/RealtimeData.cpp" line="650"/>
         <source>W&apos; bal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="651"/>
+        <location filename="../../Train/RealtimeData.cpp" line="653"/>
         <source>XPower</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="654"/>
+        <location filename="../../Train/RealtimeData.cpp" line="656"/>
         <source>Iso Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="657"/>
+        <location filename="../../Train/RealtimeData.cpp" line="659"/>
         <source>Intensity Factor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="660"/>
+        <location filename="../../Train/RealtimeData.cpp" line="662"/>
         <source>Relative Intensity</source>
         <translation type="unfinished">Relative Intensity</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="663"/>
+        <location filename="../../Train/RealtimeData.cpp" line="665"/>
         <source>Skiba Variability Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="666"/>
+        <location filename="../../Train/RealtimeData.cpp" line="668"/>
         <source>Variability Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="669"/>
+        <location filename="../../Train/RealtimeData.cpp" line="671"/>
         <source>Distance</source>
         <translation type="unfinished">距離</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="672"/>
+        <location filename="../../Train/RealtimeData.cpp" line="674"/>
         <source>Route Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="675"/>
+        <location filename="../../Train/RealtimeData.cpp" line="677"/>
         <source>Distance Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="678"/>
+        <location filename="../../Train/RealtimeData.cpp" line="680"/>
         <source>Alternate Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="681"/>
+        <location filename="../../Train/RealtimeData.cpp" line="683"/>
         <source>Power</source>
         <translation type="unfinished">出力</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="684"/>
+        <location filename="../../Train/RealtimeData.cpp" line="686"/>
         <source>Speed</source>
         <translation type="unfinished">速度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="687"/>
+        <location filename="../../Train/RealtimeData.cpp" line="689"/>
         <source>Virtual Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="690"/>
+        <location filename="../../Train/RealtimeData.cpp" line="692"/>
         <source>Cadence</source>
         <translation type="unfinished">ケイデンス</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="693"/>
+        <location filename="../../Train/RealtimeData.cpp" line="695"/>
         <source>Heart Rate</source>
         <translation type="unfinished">心拍数</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="696"/>
+        <location filename="../../Train/RealtimeData.cpp" line="698"/>
         <source>Target Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="699"/>
+        <location filename="../../Train/RealtimeData.cpp" line="701"/>
         <source>Average Power</source>
         <translation type="unfinished">平均出力</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="702"/>
+        <location filename="../../Train/RealtimeData.cpp" line="704"/>
         <source>Average Speed</source>
         <translation type="unfinished">平均速度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="705"/>
+        <location filename="../../Train/RealtimeData.cpp" line="707"/>
         <source>Average Heartrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="708"/>
+        <location filename="../../Train/RealtimeData.cpp" line="710"/>
         <source>Average Cadence</source>
         <translation type="unfinished">平均ケイデンス</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="711"/>
+        <location filename="../../Train/RealtimeData.cpp" line="713"/>
         <source>Lap Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="714"/>
+        <location filename="../../Train/RealtimeData.cpp" line="716"/>
         <source>Lap Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="717"/>
+        <location filename="../../Train/RealtimeData.cpp" line="719"/>
         <source>Lap Heartrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="720"/>
+        <location filename="../../Train/RealtimeData.cpp" line="722"/>
         <source>Lap Cadence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="723"/>
+        <location filename="../../Train/RealtimeData.cpp" line="725"/>
         <source>Left/Right Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="726"/>
+        <location filename="../../Train/RealtimeData.cpp" line="728"/>
         <source>Total Hb Mass</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="729"/>
+        <location filename="../../Train/RealtimeData.cpp" line="731"/>
         <source>Hb O2 Saturation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="732"/>
+        <location filename="../../Train/RealtimeData.cpp" line="734"/>
         <source>Deoxy Hb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="735"/>
+        <location filename="../../Train/RealtimeData.cpp" line="737"/>
         <source>Oxy Hb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="738"/>
+        <location filename="../../Train/RealtimeData.cpp" line="740"/>
         <source>Left Torque Effectiveness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="741"/>
+        <location filename="../../Train/RealtimeData.cpp" line="743"/>
         <source>Right Torque Effectiveness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="744"/>
+        <location filename="../../Train/RealtimeData.cpp" line="746"/>
         <source>Left Pedal Smoothness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="747"/>
+        <location filename="../../Train/RealtimeData.cpp" line="749"/>
         <source>Right Pedal Smoothness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="750"/>
+        <location filename="../../Train/RealtimeData.cpp" line="752"/>
         <source>Right Power Phase Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="753"/>
+        <location filename="../../Train/RealtimeData.cpp" line="755"/>
         <source>Right Power Phase End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="756"/>
+        <location filename="../../Train/RealtimeData.cpp" line="758"/>
         <source>Right Power Phase Peak Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="759"/>
+        <location filename="../../Train/RealtimeData.cpp" line="761"/>
         <source>Right Power Phase Peak End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="762"/>
+        <location filename="../../Train/RealtimeData.cpp" line="764"/>
         <source>Slope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="765"/>
+        <location filename="../../Train/RealtimeData.cpp" line="767"/>
         <source>Lap Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="768"/>
+        <location filename="../../Train/RealtimeData.cpp" line="770"/>
         <source>Lap Distance Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="771"/>
+        <location filename="../../Train/RealtimeData.cpp" line="773"/>
         <source>Latitude</source>
         <translation type="unfinished">緯度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="774"/>
+        <location filename="../../Train/RealtimeData.cpp" line="776"/>
         <source>Longitude</source>
         <translation type="unfinished">経度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="777"/>
+        <location filename="../../Train/RealtimeData.cpp" line="779"/>
         <source>Altitude</source>
         <translation type="unfinished">標高</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="780"/>
+        <location filename="../../Train/RealtimeData.cpp" line="782"/>
         <source>Respiratory Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="783"/>
+        <location filename="../../Train/RealtimeData.cpp" line="785"/>
         <source>Ventilation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="786"/>
+        <location filename="../../Train/RealtimeData.cpp" line="788"/>
         <source>VO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="789"/>
+        <location filename="../../Train/RealtimeData.cpp" line="791"/>
         <source>VCO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="792"/>
+        <location filename="../../Train/RealtimeData.cpp" line="794"/>
         <source>Respiratory Exchange Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="795"/>
+        <location filename="../../Train/RealtimeData.cpp" line="797"/>
         <source>Tidal Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="798"/>
+        <location filename="../../Train/RealtimeData.cpp" line="800"/>
         <source>Fraction O2 Expired</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="801"/>
+        <location filename="../../Train/RealtimeData.cpp" line="803"/>
         <source>Temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="804"/>
+        <location filename="../../Train/RealtimeData.cpp" line="806"/>
         <source>CoreTemp</source>
         <translation type="unfinished"></translation>
     </message>
@@ -26403,22 +26276,22 @@ Python disabled in preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Value</source>
         <translation type="unfinished">値</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="172"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
         <source>Power</source>
         <translation type="unfinished">出力</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="176"/>
         <source>Heart Rate</source>
         <translation type="unfinished">心拍数</translation>
     </message>
@@ -28714,317 +28587,317 @@ native format. Should we do so?
 <context>
     <name>ScatterPlot</name>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="113"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
         <source>Power (watts)</source>
         <translation type="unfinished">出力（ワット）</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
         <source>Cadence (rpm)</source>
         <translation type="unfinished">ケイデンス (rpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="116"/>
         <source>Heartrate (bpm)</source>
         <translation type="unfinished">心拍数 (bpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="118"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="119"/>
         <source>Speed (kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="120"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="121"/>
         <source>Speed (mph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="124"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="125"/>
         <source>Altitude (meters)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="126"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="127"/>
         <source>Altitude (feet)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="128"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
         <source>Torque (N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="130"/>
         <source>Elapsed Time (secs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="132"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="133"/>
         <source>Elapsed Distance (km)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="134"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="135"/>
         <source>Elapsed Distance (mi)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="136"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
         <source>Interval Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
         <source>Latitude (degree offset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
         <source>Longitude (degree offset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
         <source>Circumferential Pedal Velocity (m/s)</source>
         <translation type="unfinished">ペダル周速度 (m/s)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="141"/>
         <source>Average Effective Pedal Force (N)</source>
         <translation type="unfinished">実効平均ペダルフォース (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="144"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
         <source>Time at X/Y (%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
         <source>Power Zone</source>
         <translation type="unfinished">パワーゾーン</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
         <source>Headwind (kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
         <source>Slope (gradient)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
         <source>Temperature (C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
         <source>L/R Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
         <source>Torque Efficiency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
         <source>Pedal Smoothness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
         <source>Running Vertical Oscillation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
         <source>Running Ground Contact Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
         <source>Running Cadence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
         <source>Gear Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
         <source>Muscle Oxygen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
         <source>Haemoglobin Mass</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
         <source>Deoxygenated Haemoglobin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="160"/>
         <source>Oxygenated Haemoglobin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="161"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="162"/>
         <source>Unknown</source>
         <translation type="unfinished">不明</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="165"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
         <source>Power</source>
         <translation type="unfinished">出力</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
         <source>Cadence</source>
         <translation type="unfinished">ケイデンス</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
         <source>Heartrate</source>
         <translation type="unfinished">心拍数</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
         <source>Speed</source>
         <translation type="unfinished">速度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
         <source>Altitude</source>
         <translation type="unfinished">標高</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
         <source>Pedal Force</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
         <source>Time</source>
         <translation type="unfinished">時間</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
         <source>Distance</source>
         <translation type="unfinished">距離</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
         <source>Interval</source>
         <translation type="unfinished">インターバル</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
         <source>Latitude</source>
         <translation type="unfinished">緯度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
         <source>Longitude</source>
         <translation type="unfinished">経度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
         <source>Time at X/Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
         <source>Zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
         <source>CPV</source>
         <translation type="unfinished">CPV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
         <source>AEPF</source>
         <translation type="unfinished">AEPF</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
         <source>Headwind</source>
         <translation type="unfinished">向かい風</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
         <source>Slope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
         <source>Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
         <source>TE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
         <source>PS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
         <source>GCT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
         <source>Run Cad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
         <source>Gear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
         <source>SmO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
         <source>tHb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
         <source>O2Hb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="194"/>
         <source>HHb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="195"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="196"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -29262,54 +29135,42 @@ native format. Should we do so?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1012"/>
         <source>Add</source>
-        <translation type="unfinished">追加</translation>
+        <translation type="obsolete">追加</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1013"/>
         <source>Delete</source>
-        <translation type="unfinished">削除</translation>
+        <translation type="obsolete">削除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1006"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1007"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1023"/>
+        <location filename="../../Gui/AthletePages.cpp" line="982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="988"/>
         <source>Short</source>
         <translation>略称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="989"/>
         <source>Long</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1031"/>
+        <location filename="../../Gui/AthletePages.cpp" line="990"/>
         <source>Percent of CP</source>
         <translation>対CPの割合</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1069"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1076"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1034"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1071"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1078"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1036"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -29482,64 +29343,64 @@ native format. Should we do so?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3821"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3569"/>
         <source>Add</source>
         <translation type="unfinished">追加</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3822"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3570"/>
         <source>Delete</source>
         <translation type="unfinished">削除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3823"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3571"/>
         <source>Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3824"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3572"/>
         <source>Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3870"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3872"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3963"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3965"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3711"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3713"/>
         <source>ddd MMM d, yyyy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3557"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3810"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3558"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3804"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3835"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3583"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3805"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3836"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3553"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3584"/>
         <source>Type</source>
         <translation type="unfinished">種別</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3806"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3837"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3554"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3585"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3807"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3838"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3555"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3586"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
@@ -31820,398 +31681,398 @@ tab.</source>
 <context>
     <name>TrainSidebar</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="253"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="257"/>
         <source>Save workout data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="259"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="263"/>
         <source>Devices</source>
         <translation type="unfinished">デバイス</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="262"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="267"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="311"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="321"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="271"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="315"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="325"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="270"/>
         <source>Workouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="303"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="307"/>
         <source>Workout Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="310"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="314"/>
         <source>Media</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="320"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="324"/>
         <source>VideoSync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="506"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
         <source>Import Workout from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="507"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="511"/>
         <source>Get Workouts from TrainerDay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="509"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="513"/>
         <source>Create Workout via Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="514"/>
         <source>Scan for Workouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="534"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="538"/>
         <source>Delete selected Workout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="541"/>
         <source>Delete %1 selected Workouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Train mode active</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Please stop the train mode before closing the window or application.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="635"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="639"/>
         <source>Remove reference to selected video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="650"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="654"/>
         <source>Import VideoSync from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="651"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="655"/>
         <source>Scan for VideoSyncs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="668"/>
         <source>Delete selected VideoSync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1064"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1068"/>
         <source>Are you sure you want to remove the reference to this video?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1066"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1128"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1204"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1070"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1132"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1208"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1099"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1103"/>
         <source>Are you sure you want to delete this VideoSync?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1126"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1130"/>
         <source>The VideoSync file is either not valid or not existing and will be removed from the library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1160"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1164"/>
         <source>Are you sure you want to delete this Workout?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1163"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1167"/>
         <source>Are you sure you want to delete this %1 workouts?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1202"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1206"/>
         <source>The Workout file is either not valid or not existing and will be removed from the library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1347"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1351"/>
         <source>Starting in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2225"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2237"/>
         <source>Recalibrating steering..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2521"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2525"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2594"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2645"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2649"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2533"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2606"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2657"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2661"/>
         <source>Requesting calibration..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2532"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2544"/>
         <source>Calibrating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2536"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2548"/>
         <source>Calibrating...
 Current speed %1 kph
 Increase speed to %2 kph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2540"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2552"/>
         <source>Calibrating...
 Stop pedalling until speed drops to 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2545"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2557"/>
         <source>Calibration completed successfully!
 Spindown %1 ms
 Zero Offset %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2553"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2620"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2672"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2565"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2632"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2684"/>
         <source>Calibration failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2573"/>
         <source>Calibration Failed: Loosen Roller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2569"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2581"/>
         <source>Calibration Failed: Tighten Roller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2588"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2639"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2600"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2651"/>
         <source>Unclip or stop pedalling to begin calibration..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2607"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2619"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Torque %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2612"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2624"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Torque %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2659"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2671"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Zero Offset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2676"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Slope %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2693"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2705"/>
         <source>Give the pedal a kick to start calibration...
 The motor will run until calibration is complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2695"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
         <source>Allow wheel speed to settle, DO NOT PEDAL...
 The motor will run until calibration is complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2700"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2712"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Gathering enough samples to calculate average: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2719"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Waiting for value to stabilize (max %1s): %2 (%3W @ %4kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2722"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
         <source>Calibration completed successfully!
 Final calibration value %1 (%2W @ %3kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2746"/>
         <source>Calibration failed! Do not pedal while calibration is taking place.
 Allow wheel to run freely.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2780"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2792"/>
         <source>Fast forward..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2813"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2825"/>
         <source>Rewind..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2843"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2855"/>
         <source>Next Lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2876"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2888"/>
         <source>Back Lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2902"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2914"/>
         <source>Increasing intensity..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2928"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2940"/>
         <source>Decreasing intensity..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="621"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="625"/>
         <source>Import Video from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="508"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="512"/>
         <source>Get Workouts from Strava Routes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="622"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="626"/>
         <source>Scan for Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1101"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1173"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3183"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1105"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1177"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3195"/>
         <source>Delete</source>
         <translation type="unfinished">削除</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1309"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1313"/>
         <source>Resuming..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1336"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1340"/>
         <source>Paused..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1465"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1469"/>
         <source>Starting..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1673"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1677"/>
         <source>Stopped..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1763"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1769"/>
         <source>Connected..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1787"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1793"/>
         <source>Disconnected..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2198"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2210"/>
         <source>New lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>No Devices Configured</source>
         <translation type="unfinished">デバイスが設定されていません</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>Please configure a device in Preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2483"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2495"/>
         <source>Exiting calibration..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2498"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2510"/>
         <source>Calibration not supported for this device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2505"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2517"/>
         <source>Calibrating...
 Press F3 on Controller when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3135"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3153"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3147"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3165"/>
         <source>Add Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3140"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3158"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3152"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3170"/>
         <source>Delete Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3181"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3193"/>
         <source>Are you sure you want to delete this device?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -32528,7 +32389,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>UniqueLabelEditDelegate</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="77"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="108"/>
         <source>The given value &quot;%1&quot; is not unique</source>
         <translation type="unfinished"></translation>
     </message>
@@ -32544,171 +32405,155 @@ Press F3 on Controller when done.</source>
 <context>
     <name>UserChartSettings</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="772"/>
+        <location filename="../../Charts/UserChart.cpp" line="773"/>
         <source>Chart</source>
         <translation type="unfinished">チャート</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="782"/>
+        <location filename="../../Charts/UserChart.cpp" line="783"/>
         <source>Sub-title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="785"/>
+        <location filename="../../Charts/UserChart.cpp" line="786"/>
         <source>Description</source>
         <translation type="unfinished">説明</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="791"/>
+        <location filename="../../Charts/UserChart.cpp" line="792"/>
         <source>Line Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="792"/>
+        <location filename="../../Charts/UserChart.cpp" line="793"/>
         <source>Scatter Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="793"/>
+        <location filename="../../Charts/UserChart.cpp" line="794"/>
         <source>Bar Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="794"/>
+        <location filename="../../Charts/UserChart.cpp" line="795"/>
         <source>Stacked Bar Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="795"/>
+        <location filename="../../Charts/UserChart.cpp" line="796"/>
         <source>Stacked Percent Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="796"/>
+        <location filename="../../Charts/UserChart.cpp" line="797"/>
         <source>Pie Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="800"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="801"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Type</source>
         <translation type="unfinished">種別</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="804"/>
+        <location filename="../../Charts/UserChart.cpp" line="805"/>
         <source>Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="805"/>
+        <location filename="../../Charts/UserChart.cpp" line="806"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="808"/>
+        <location filename="../../Charts/UserChart.cpp" line="809"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="812"/>
+        <location filename="../../Charts/UserChart.cpp" line="813"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="813"/>
+        <location filename="../../Charts/UserChart.cpp" line="814"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="814"/>
+        <location filename="../../Charts/UserChart.cpp" line="815"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="815"/>
+        <location filename="../../Charts/UserChart.cpp" line="816"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="816"/>
+        <location filename="../../Charts/UserChart.cpp" line="817"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="820"/>
+        <location filename="../../Charts/UserChart.cpp" line="821"/>
         <source>Legend</source>
         <translation type="unfinished">凡例</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="829"/>
+        <location filename="../../Charts/UserChart.cpp" line="830"/>
         <source>Font scaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="831"/>
-        <location filename="../../Charts/UserChart.cpp" line="833"/>
+        <location filename="../../Charts/UserChart.cpp" line="832"/>
+        <location filename="../../Charts/UserChart.cpp" line="834"/>
         <source>Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="836"/>
+        <location filename="../../Charts/UserChart.cpp" line="837"/>
         <source>Animate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="838"/>
+        <location filename="../../Charts/UserChart.cpp" line="839"/>
         <source>Single series per plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="841"/>
+        <location filename="../../Charts/UserChart.cpp" line="842"/>
         <source>Refresh for intervals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="848"/>
+        <location filename="../../Charts/UserChart.cpp" line="849"/>
         <source>Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Y Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="870"/>
-        <location filename="../../Charts/UserChart.cpp" line="932"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/UserChart.cpp" line="889"/>
-        <source>Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/UserChart.cpp" line="890"/>
-        <source>Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/UserChart.cpp" line="911"/>
+        <location filename="../../Charts/UserChart.cpp" line="885"/>
         <source>Axes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33374,72 +33219,72 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VideoWindow</name>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> kph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="119"/>
+        <location filename="../../Train/VideoWindow.cpp" line="144"/>
         <source>Meters layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="127"/>
+        <location filename="../../Train/VideoWindow.cpp" line="152"/>
         <source>Reset Meters layout to default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> feet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="625"/>
+        <location filename="../../Train/VideoWindow.cpp" line="681"/>
         <source>w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="629"/>
+        <location filename="../../Train/VideoWindow.cpp" line="685"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> km</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> mi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="673"/>
+        <location filename="../../Train/VideoWindow.cpp" line="729"/>
         <source>Calibration required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="678"/>
+        <location filename="../../Train/VideoWindow.cpp" line="734"/>
         <source>Configuration required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="683"/>
+        <location filename="../../Train/VideoWindow.cpp" line="739"/>
         <source>brake fault</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="688"/>
+        <location filename="../../Train/VideoWindow.cpp" line="744"/>
         <source>Ready</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33874,27 +33719,27 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WheelSizeCalculator</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="202"/>
+        <location filename="../../Gui/AthletePages.cpp" line="187"/>
         <source>Wheel Size Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="221"/>
+        <location filename="../../Gui/AthletePages.cpp" line="206"/>
         <source>Rim Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="222"/>
+        <location filename="../../Gui/AthletePages.cpp" line="207"/>
         <source>Tire Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="223"/>
+        <location filename="../../Gui/AthletePages.cpp" line="208"/>
         <source>Wheel Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="227"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34006,12 +33851,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutFilterBox</name>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="34"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="44"/>
         <source>Filter...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="64"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="95"/>
         <source>ERROR: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34019,35 +33864,118 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutImportDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="820"/>
+        <location filename="../../Train/Library.cpp" line="809"/>
         <source>Import to Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="854"/>
+        <location filename="../../Train/Library.cpp" line="843"/>
         <source>Please note, that when importing or drag and dropping videos into the library we DO NOT copy the file into the GoldenCheetah library, instead we add a REFERENCE to it. We DO copy workout and videoSync files, since they are smaller.
 
 You can remove references when managing the library via the context menu options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="868"/>
+        <location filename="../../Train/Library.cpp" line="857"/>
         <source>Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="878"/>
+        <location filename="../../Train/Library.cpp" line="867"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="880"/>
+        <location filename="../../Train/Library.cpp" line="869"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="884"/>
+        <location filename="../../Train/Library.cpp" line="873"/>
         <source>Overwite existing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WorkoutMenuProvider</name>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="271"/>
+        <source>Select Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="274"/>
+        <source>Manage Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="275"/>
+        <source>Add Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="289"/>
+        <source>Add Tag to Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="292"/>
+        <source>Filter Tags...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="310"/>
+        <source>Match all selected tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="353"/>
+        <source>Manage Workout Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="360"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="361"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="362"/>
+        <source>_index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="370"/>
+        <source>Execute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="371"/>
+        <source>Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="423"/>
+        <source>Add Workout Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="426"/>
+        <source>Name of the Filter...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="467"/>
+        <source>New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="469"/>
+        <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -34063,41 +33991,41 @@ You can remove references when managing the library via the context menu options
     <name>WorkoutPlotWindow</name>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="40"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="104"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
         <source>Ergmode specific settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="46"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
         <source>Color power zones</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="48"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="56"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="49"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="50"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="57"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="109"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="113"/>
         <source>When stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="54"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="110"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
         <source>Show tooltip</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34183,12 +34111,12 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>WorkoutWidget</name>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="1531"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="1532"/>
         <source>File save failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="2367"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="2368"/>
         <source>Intensity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34342,26 +34270,22 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="44"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="45"/>
         <source>xData</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="58"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="59"/>
         <source>Data Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="78"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="80"/>
         <source>Add</source>
-        <translation type="unfinished">追加</translation>
+        <translation type="obsolete">追加</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="79"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="81"/>
         <source>Delete</source>
-        <translation type="unfinished">削除</translation>
+        <translation type="obsolete">削除</translation>
     </message>
 </context>
 <context>
@@ -34438,32 +34362,32 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataSeriesSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="333"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="315"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="338"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="320"/>
         <source>Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="346"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="328"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="347"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="329"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Error</source>
         <translation type="unfinished">エラー</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Name is blank</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34471,48 +34395,48 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="262"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="244"/>
         <source>xData</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="269"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="251"/>
         <source>Data Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="270"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="252"/>
         <source>Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="274"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="256"/>
         <source>Series %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="281"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="263"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="282"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="264"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Error</source>
         <translation type="unfinished">エラー</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
         <source>XData name is blank</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Must have at least one data series.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34833,17 +34757,17 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="915"/>
+        <location filename="../../Gui/AthletePages.cpp" line="886"/>
         <source>Sport</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="962"/>
+        <location filename="../../Gui/AthletePages.cpp" line="933"/>
         <source>Critical Power</source>
         <translation type="unfinished">クリティカルパワー</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="963"/>
+        <location filename="../../Gui/AthletePages.cpp" line="934"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>

--- a/src/Resources/translations/gc_nl.ts
+++ b/src/Resources/translations/gc_nl.ts
@@ -108,38 +108,38 @@ Misschien is het handmatig stoppen hiervan nodig.</translation>
         <translation type="vanished">LTS gemiddelde (dagen)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="504"/>
+        <location filename="../../Gui/AthletePages.cpp" line="489"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="517"/>
-        <location filename="../../Gui/AthletePages.cpp" line="522"/>
+        <location filename="../../Gui/AthletePages.cpp" line="502"/>
+        <location filename="../../Gui/AthletePages.cpp" line="507"/>
         <source>days</source>
         <translation type="unfinished">dagen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="525"/>
+        <location filename="../../Gui/AthletePages.cpp" line="510"/>
         <source>PMC Stress Balance Today</source>
         <translation>PMC Stress Balans Vandaag</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="528"/>
+        <location filename="../../Gui/AthletePages.cpp" line="513"/>
         <source>Restore Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="517"/>
         <source>W&apos;bal tau</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="518"/>
         <source>Short Term Stress (STS) average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="534"/>
+        <location filename="../../Gui/AthletePages.cpp" line="519"/>
         <source>Long Term Stress (LTS) average</source>
         <translation type="unfinished"></translation>
     </message>
@@ -155,96 +155,96 @@ Misschien is het handmatig stoppen hiervan nodig.</translation>
 <context>
     <name>AboutRiderPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="372"/>
+        <location filename="../../Gui/AthletePages.cpp" line="357"/>
         <source>Nickname</source>
         <translation>Bijnaam</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="373"/>
+        <location filename="../../Gui/AthletePages.cpp" line="358"/>
         <source>Date of Birth</source>
         <translation>Geboortedatum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="374"/>
+        <location filename="../../Gui/AthletePages.cpp" line="359"/>
         <source>Sex</source>
         <translation>Geslacht</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="376"/>
+        <location filename="../../Gui/AthletePages.cpp" line="361"/>
         <source>Weight</source>
         <translation type="unfinished">Gewicht</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="375"/>
+        <location filename="../../Gui/AthletePages.cpp" line="360"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="279"/>
+        <location filename="../../Gui/AthletePages.cpp" line="264"/>
         <source>Male</source>
         <translation>Man</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="280"/>
+        <location filename="../../Gui/AthletePages.cpp" line="265"/>
         <source>Female</source>
         <translation>Vrouw</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> kg</source>
         <translation type="unfinished"> kg</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> lb</source>
         <translation type="unfinished"> lb</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> cm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="359"/>
+        <location filename="../../Gui/AthletePages.cpp" line="344"/>
         <source>Calculate...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="378"/>
+        <location filename="../../Gui/AthletePages.cpp" line="363"/>
         <source>Bike</source>
         <translation type="unfinished">Fietsen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="379"/>
+        <location filename="../../Gui/AthletePages.cpp" line="364"/>
         <source>Crank Length</source>
         <translation>Cranklengte</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="380"/>
+        <location filename="../../Gui/AthletePages.cpp" line="365"/>
         <source>Wheelsize</source>
         <translation>Wielmaat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="438"/>
+        <location filename="../../Gui/AthletePages.cpp" line="423"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="356"/>
+        <location filename="../../Gui/AthletePages.cpp" line="341"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="437"/>
+        <location filename="../../Gui/AthletePages.cpp" line="422"/>
         <source>Choose Picture</source>
         <translation>Kies Afbeelding</translation>
     </message>
@@ -2275,397 +2275,394 @@ Klik Volgende om verder te gaan
 <context>
     <name>AllPlotWindow</name>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="94"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="95"/>
         <source>Basic</source>
         <translation>Eenvoudig</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="109"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="110"/>
         <source>Curves</source>
         <translation>Curves</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="116"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="117"/>
         <source>User Data</source>
         <translation>Gebruikersdata</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="132"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="134"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Formula</source>
         <translation>Formule</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="144"/>
         <source>Edit</source>
-        <translation>Bewerken</translation>
+        <translation type="vanished">Bewerken</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="163"/>
         <source>Up</source>
-        <translation>Op</translation>
+        <translation type="vanished">Op</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="164"/>
         <source>Down</source>
-        <translation>Neer</translation>
+        <translation type="vanished">Neer</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="190"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="444"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="165"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
         <source>Smooth</source>
         <translation>Afvlakken</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="198"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="173"/>
         <source>Stacked</source>
         <translation>Gestapeld</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="199"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="174"/>
         <source>by series</source>
         <translation>per reeks</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="200"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="175"/>
         <source>Fullplot</source>
         <translation>Volledig Overzicht</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="201"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="176"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="239"/>
         <source>Overlay</source>
         <translation>Overlay</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="229"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="204"/>
         <source>View</source>
         <translation>Overzicht</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="206"/>
         <source>Stack</source>
         <translation>Stapel</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="210"/>
         <source>By Series</source>
         <translation>Per Reeks</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="246"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="221"/>
         <source>Stack Zoom</source>
         <translation>Stapel Zoom</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="248"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="223"/>
         <source>Full plot</source>
         <translation>Volledig Overzicht</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="227"/>
         <source>Show Interval Markers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="256"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
         <source>Interval Navigator</source>
         <translation>Interval Navigator</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="260"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
         <source>Hover intervals</source>
         <translation>Beweeg over intervallen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="268"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="243"/>
         <source>Fill Curves</source>
         <translation>Vlakken opvullen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="247"/>
         <source>Grid</source>
         <translation>Raster</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="277"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
         <source>Acceleration</source>
         <translation>Versnelling</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="279"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="254"/>
         <source>Delta Series</source>
         <translation>Delta Reeksen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="280"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="255"/>
         <source>Power %1</source>
         <translation>Vermogen %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="283"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="258"/>
         <source>Cadence %1</source>
         <translation>Cadans %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="261"/>
         <source>Torque %1</source>
         <translation>Koppel %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="289"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
         <source>Heartrate %1</source>
         <translation>Hartslag %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="295"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="270"/>
         <source>Balance</source>
         <translation>Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
         <source>Left/Right</source>
         <translation>Links/Rechts</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="274"/>
         <source>Torque Effectiveness</source>
         <translation>Koppel Effectiviteit</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="303"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="278"/>
         <source>Smoothness</source>
         <translation>Gelijkmatigheid</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="282"/>
         <source>Pedal Center Offset</source>
         <translation>Pedaal Middelpunt Offset</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="311"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
         <source>Power Phase</source>
         <translation>Vermogensfase</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="290"/>
         <source>Peak Power Phase</source>
         <translation>Piekvermogensfase</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="322"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
         <source>Vertical Oscillation</source>
         <translation>Verticale Oscillatie</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="324"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
         <source>Running</source>
         <translation>Hardlopen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="326"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="301"/>
         <source>Ground Contact Time</source>
         <translation>Grondcontacttijd</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
         <source>Cadence </source>
         <translation>Cadans </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="367"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
         <source>Cadence</source>
         <translation>Cadans</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="313"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="340"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
         <source>Moxy</source>
         <translation>Moxy</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="317"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="321"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="325"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="355"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="330"/>
         <source>Heart Rate</source>
         <translation>Hartslag</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="357"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
         <source>Data series</source>
         <translation>Data reeksen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="359"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="334"/>
         <source>Core Temperature</source>
         <translation>Kerntemperatuur</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="363"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
         <source>Speed</source>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="371"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
         <source>Altitude</source>
         <translation>Hoogte</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
         <source>Temperature</source>
         <translation>Temperatuur</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="379"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="354"/>
         <source>Headwind</source>
         <translation>Tegenwind</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="383"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="358"/>
         <source>Torque</source>
         <translation>Koppel</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="387"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="362"/>
         <source>Gear Ratio</source>
         <translation>Versnellingsratio</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="391"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="366"/>
         <source>Slope</source>
         <translation>Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="373"/>
         <source>No Alt/Slope</source>
         <translation>Geen Hoogte/Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="399"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="374"/>
         <source>0.1km|mi -  1min</source>
         <translation>0.1km|mi -  1min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="400"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
         <source>0.5km|mi -  5min</source>
         <translation>0.5km|mi -  5min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="401"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="376"/>
         <source>1.0km|mi - 10min</source>
         <translation>1.0km|mi - 10min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1528"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="377"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="1503"/>
         <source>Alt/Slope</source>
         <translation>Hoogte/Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="382"/>
         <source>Anaerobic TISS</source>
         <translation>Anaerobe TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="384"/>
         <source>Metrics</source>
         <translation>Metrieken</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="411"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="386"/>
         <source>Aerobic TISS</source>
         <translation>Aerobe TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="390"/>
         <source>Iso Power</source>
         <translation>Genormaliseerd Vermogen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="394"/>
         <source>Skiba xPower</source>
         <translation>Skiba xPower</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="423"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
         <source>Altitude Power</source>
         <translation>Hoogte Vermogen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="427"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
         <source>W&apos; balance</source>
         <translation>W&apos; Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="432"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
         <source>Power + shade</source>
         <translation>Vermogen + kleuring</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="433"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="408"/>
         <source>Power - shade</source>
         <translation>Vermogen - kleuring</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="434"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
         <source>No Power</source>
         <translation>Geen Vermogen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="435"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="410"/>
         <source>Shading</source>
         <translation>Kleuring</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="439"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="414"/>
         <source>Time</source>
         <translation>Tijd</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="440"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
         <source>Distance</source>
         <translation>Afstand</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="441"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="416"/>
         <source>Time of day</source>
         <translation>Tijdstip van de dag</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="442"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="417"/>
         <source>X Axis</source>
         <translation>X-As</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="742"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="717"/>
         <source>Intervals</source>
         <translation>Intervallen</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="2253"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="2228"/>
         <source>Selection #%1 </source>
         <translation>Selectie #%1 </translation>
     </message>
@@ -3472,51 +3469,45 @@ Klik Volgende om verder te gaan
 <context>
     <name>AutoImportPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4028"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4029"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
         <source>Browse</source>
         <translation type="vanished">Bladeren</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4040"/>
         <source>Add</source>
-        <translation>Toevoegen</translation>
+        <translation type="vanished">Toevoegen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4041"/>
         <source>Delete</source>
-        <translation>Verwijderen</translation>
+        <translation type="vanished">Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4042"/>
         <source>Up</source>
-        <translation>Op</translation>
+        <translation type="vanished">Op</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4043"/>
         <source>Down</source>
-        <translation>Neer</translation>
+        <translation type="vanished">Neer</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4054"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3779"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4059"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3784"/>
         <source>Directory</source>
         <translation>Map</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4060"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3785"/>
         <source>Import Rule</source>
         <translation>Importeer Regel</translation>
     </message>
@@ -4334,37 +4325,37 @@ Klik Volgende om verder te gaan
 <context>
     <name>BackupPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="608"/>
+        <location filename="../../Gui/AthletePages.cpp" line="593"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="601"/>
         <source>every</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="617"/>
+        <location filename="../../Gui/AthletePages.cpp" line="602"/>
         <source>times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="603"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="605"/>
         <source>Backup now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="623"/>
+        <location filename="../../Gui/AthletePages.cpp" line="608"/>
         <source>Auto Backup Folder</source>
         <translation>Auto Backup Map</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="624"/>
+        <location filename="../../Gui/AthletePages.cpp" line="609"/>
         <source>Auto Backup after closing the athlete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5188,41 +5179,33 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">Update</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1202"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1203"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1204"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1150"/>
         <source>Review...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1206"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1152"/>
         <source>Changed power estimates are available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1213"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1225"/>
         <source>Add</source>
-        <translation>Toevoegen</translation>
+        <translation type="vanished">Toevoegen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1214"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1226"/>
         <source>Delete</source>
-        <translation>Verwijderen</translation>
+        <translation type="vanished">Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1216"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1158"/>
         <source>Def</source>
         <translation>Def</translation>
     </message>
@@ -5231,232 +5214,232 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">Vanaf Datum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1218"/>
         <source>Critical Power</source>
         <translation>Critical Power</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1305"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>AeTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1306"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>FTP</source>
         <translation>FTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1307"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1221"/>
         <source>W&apos;</source>
         <translation>W&apos;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1308"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1222"/>
         <source>Pmax</source>
         <translation>Pmax</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1247"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1169"/>
         <source>Use CP for all metrics</source>
         <translation>Gebruik CP voor alle metrieken</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1240"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1162"/>
         <source>Manual</source>
         <translation type="unfinished">Handmatig</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1241"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1163"/>
         <source>Semi-Automatic (CP2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1164"/>
         <source>Semi-Automatic (CP3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1243"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1165"/>
         <source>Semi-Automatic (Extended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1170"/>
         <source>Use FTP for Coggan metrics</source>
         <translation>Gebruik FTP voor Coggan metrieken</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1273"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1279"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1285"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1342"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1618"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1631"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2283"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2289"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2310"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1187"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1193"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1199"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1211"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1537"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1545"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2180"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2186"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2194"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2207"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1205"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1547"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2201"/>
         <source>J</source>
         <translation type="unfinished">J</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1303"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1217"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2145"/>
         <source>Start Date</source>
         <translation type="unfinished">Startdatum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1309"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1223"/>
         <source>Model Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1347"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1261"/>
         <source>Short</source>
         <translation>Kort</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1262"/>
         <source>Long</source>
         <translation>Lang</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1349"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1263"/>
         <source>From Watts</source>
         <translation>Van Watts</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1598"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1512"/>
         <source>Review range starting on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1614"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1528"/>
         <source>Current</source>
         <translation type="unfinished">Huidige</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1615"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1529"/>
         <source>Estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1530"/>
         <source>Accept</source>
         <translation type="unfinished">Accepteer</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1788"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1691"/>
         <source>🗹</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1692"/>
         <source>Estimate and settings &lt;b&gt;match&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1695"/>
         <source>☐</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1696"/>
         <source>Estimate and settings &lt;b&gt;differ&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1797"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1700"/>
         <source>⏲</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1800"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1703"/>
         <source>Range is %1 days older than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1802"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1705"/>
         <source>Range is %1 days younger than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1808"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1711"/>
         <source>∅</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1712"/>
         <source>No estimate available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1902"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1805"/>
         <source>New range from estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2237"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2134"/>
         <source>The proposed value for AeTP is a very rough estimate, assuming %1 % of CP. Usually it is determined by a&lt;ul&gt;&lt;li&gt;Metabolic test&lt;/li&gt;&lt;li&gt;Lactate ramp test&lt;/li&gt;&lt;li&gt;Run / Cycling ‘conversational’ test&lt;/li&gt;&lt;li&gt;Run Decoupling test&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2239"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2136"/>
         <source>Updating FTP internally to match CP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2139"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2244"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2141"/>
         <source>Your selected model does not deliver values for PMax, using default value of %1 W instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2246"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2143"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;li&gt;PMax, assuming a default of %1 W&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2250"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2147"/>
         <source>Critical Power (CP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2252"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2149"/>
         <source>Aerobic Threshold Power (AeTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2254"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2151"/>
         <source>Functional Threshold Power (FTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2153"/>
         <source>Anaerobic Work Capacity (W&apos;)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2258"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2155"/>
         <source>Maximum Power (PMax)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2270"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2167"/>
         <source>Manual range</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5469,14 +5452,14 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">Maximum van 10 zones bereikt.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2018"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2025"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1917"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1924"/>
         <source>New</source>
         <translation>Nieuw</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2020"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1919"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1926"/>
         <source>New (%1)</source>
         <translation>Nieuw (%1)</translation>
     </message>
@@ -5929,52 +5912,44 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">Update</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3307"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3319"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3308"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3320"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3313"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3325"/>
         <source>Add</source>
-        <translation>Toevoegen</translation>
+        <translation type="vanished">Toevoegen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3314"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3326"/>
         <source>Delete</source>
-        <translation>Verwijderen</translation>
+        <translation type="vanished">Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3316"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3109"/>
         <source>Def</source>
         <translation>Def</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3359"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3506"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3272"/>
         <source>Start Date</source>
         <translation type="unfinished">Startdatum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3249"/>
         <source>New range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3507"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3273"/>
         <source>Critical Velocity (CV)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3508"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3274"/>
         <source>Aerobic Threshold (AeT)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5983,12 +5958,12 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">Vanaf Datum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3360"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3128"/>
         <source>Critical Velocity</source>
         <translation>Kritische Snelheid</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3361"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3129"/>
         <source>Aerobic Threshold</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5997,17 +5972,17 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">MMM d, yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3403"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
         <source>Short</source>
         <translation>Kort</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3404"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3172"/>
         <source>Long</source>
         <translation>Lang</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3405"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3173"/>
         <source>From</source>
         <translation>Vanaf</translation>
     </message>
@@ -6016,14 +5991,14 @@ ddd, dd MMM yyyy</translation>
         <translation type="vanished">Maximum van 10 zones bereikt.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3679"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3686"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3441"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3448"/>
         <source>New</source>
         <translation>Nieuw</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3681"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3688"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3443"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3450"/>
         <source>New (%1)</source>
         <translation>Nieuw (%1)</translation>
     </message>
@@ -7555,37 +7530,32 @@ Wil je bevestigen en GoldenCheetah herstarten?</translation>
 <context>
     <name>CredentialsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="67"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
+    </message>
+    <message>
+        <source>-</source>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="vanished">Bewerken</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">Toevoegen</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">Verwijderen</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="68"/>
-        <source>-</source>
-        <translation>-</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="69"/>
-        <source>Edit</source>
-        <translation>Bewerken</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="74"/>
-        <source>Add</source>
-        <translation>Toevoegen</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="75"/>
-        <source>Delete</source>
-        <translation>Verwijderen</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="86"/>
         <source>Service</source>
         <translation>Service</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="87"/>
+        <location filename="../../Gui/AthletePages.cpp" line="69"/>
         <source>Description</source>
         <translation>Beschrijving</translation>
     </message>
@@ -8272,7 +8242,7 @@ Wil je bevestigen en GoldenCheetah herstarten?</translation>
 <context>
     <name>DataFilterEdit</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2743"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2712"/>
         <source>Warning: sample() is slow -- update code to use samples()</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8631,7 +8601,7 @@ Wil je bevestigen en GoldenCheetah herstarten?</translation>
 <context>
     <name>DirectoryPathWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="277"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="308"/>
         <source>Browse</source>
         <translation type="unfinished">Bladeren</translation>
     </message>
@@ -8868,28 +8838,28 @@ Misschien is het (opnieuw) nodig om de FTDI of PL2303 drivers te installeren voo
 <context>
     <name>Dropbox</name>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="68"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="77"/>
         <source>Problem accessing Dropbox data</source>
         <translation>Probleem met de toegang van Dropbox data</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="130"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="139"/>
         <source>You must authorise with Dropbox first</source>
         <translation>Je moet eerst Dropbox autoriseren</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="205"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="214"/>
         <source>Parsing Error: %1</source>
         <translation>Parsing Fout: %1</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="293"/>
-        <location filename="../../Cloud/Dropbox.cpp" line="312"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="302"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="321"/>
         <source>Completed.</source>
         <translation>Voltooid.</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="297"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="306"/>
         <source>Network Error - Upload failed.</source>
         <translation>Netwerkfout - Upload mislukt.</translation>
     </message>
@@ -9034,126 +9004,126 @@ Misschien is het (opnieuw) nodig om de FTDI of PL2303 drivers te installeren voo
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1558"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1527"/>
         <source>Estimate %1 %2 Power</source>
         <translation>Schat %1 %2 Vermogen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1562"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1531"/>
         <source>Endurance Index</source>
         <translation>Endurance Index</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1532"/>
         <source>Vo2Max Estimate</source>
         <translation>Vo2Max Schatting</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1597"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1566"/>
         <source>Curve Settings</source>
         <translation>Curve Instellingen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1605"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1574"/>
         <source>Metric</source>
         <translation>Metriek</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1606"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1575"/>
         <source>Best</source>
         <translation>Beste</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1607"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1576"/>
         <source>Estimate</source>
         <translation>Schatting</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1577"/>
         <source>PMC</source>
         <translation>PMC</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1609"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1578"/>
         <source>Formula</source>
         <translation>Formule</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1610"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1579"/>
         <source>Measure</source>
         <translation>Meting</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1611"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1580"/>
         <source>Performance</source>
         <translation>Performance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1612"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1581"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1684"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1767"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1653"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1736"/>
         <source>seconds</source>
         <translation>seconden</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1685"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1768"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1737"/>
         <source>minutes</source>
         <translation>minuten</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1769"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1655"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1738"/>
         <source>hours</source>
         <translation>uren</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1723"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1816"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1692"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1785"/>
         <source>Peak</source>
         <translation>Piek</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1781"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1750"/>
         <source>Absolute</source>
         <translation>Absoluut</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1751"/>
         <source>Per Kilogram</source>
         <translation>Per Kilogram</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1813"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
         <source>Total</source>
         <translation>Totaal</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1814"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1783"/>
         <source>Running Total</source>
         <translation>Hardloop Totaal</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1815"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1784"/>
         <source>Average</source>
         <translation>Gemiddelde</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1817"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1786"/>
         <source>Low</source>
         <translation>Laag</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1820"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1789"/>
         <source>Aggregate:</source>
         <translation>Aggregeren:</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1828"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1797"/>
         <source># type in a formula to use
 # for e.g. BikeStress / Duration
 # as you type the available metrics
@@ -9166,302 +9136,302 @@ Misschien is het (opnieuw) nodig om de FTDI of PL2303 drivers te installeren voo
 </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1839"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1808"/>
         <source>Weekly Best Performances</source>
         <translation>Wekelijkse Beste Performance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1840"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1809"/>
         <source>Submaximal Weekly Best</source>
         <translation>Sub-maximaal Wekelijkse Best</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1841"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1810"/>
         <source>Performance Tests</source>
         <translation>Performance Testen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1933"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1902"/>
         <source>Short Term Stress (STS/ATL)</source>
         <translation>Short Term Stress (STS/ATL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1934"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1903"/>
         <source>Long Term Stress  (LTS/CTL)</source>
         <translation>Long Term Stress  (LTS/CTL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1935"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1904"/>
         <source>Stress Balance    (SB/TSB)</source>
         <translation>Stress Balance    (SB/TSB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1936"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1905"/>
         <source>Stress Ramp Rate  (RR)</source>
         <translation>Stress Ramp Rate  (RR)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1944"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1913"/>
         <source>Stress Type</source>
         <translation>Stress Type</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1949"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1918"/>
         <source>Negative Training Effect (NTE)</source>
         <translation>Negatief  Trainingseffect (NTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1950"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1919"/>
         <source>Positive Training Effect (PTE)</source>
         <translation>Positief Trainingseffect (PTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1951"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1920"/>
         <source>Performance (Power Index)</source>
         <translation>Performance (Power Index)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1952"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1921"/>
         <source>Predicted CP (Watts)</source>
         <translation>Voorspelde CP (Watts)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1969"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1938"/>
         <source>Curve Type</source>
         <translation>Curve Type</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1945"/>
         <source>Perf. Metric</source>
         <translation>Perf. Metriek</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2006"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1975"/>
         <source>Metadata Field</source>
         <translation>Metadata Veld</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2007"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
         <source>PMC metric</source>
         <translation>PMC Metrieken</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2032"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2001"/>
         <source>Measure Group</source>
         <translation>Meting Groep</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2009"/>
         <source>Measure Field</source>
         <translation>Meting Veld</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2029"/>
         <source>Filter</source>
         <translation>Filter</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2064"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2033"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2034"/>
         <source>Axis Label / Units</source>
         <translation>As Label / Eenheden</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2071"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
         <source>Style</source>
         <translation>Stijl</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2042"/>
         <source>Bar</source>
         <translation>Bar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2074"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2043"/>
         <source>Line</source>
         <translation>Lijn</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2075"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2044"/>
         <source>Sticks</source>
         <translation>Staven</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2076"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2045"/>
         <source>Dots</source>
         <translation>Punten</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2048"/>
         <source>Stack</source>
         <translation>Stapel</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2053"/>
         <source>Symbol</source>
         <translation>Symbool</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2086"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2055"/>
         <source>None</source>
         <translation>Geen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2087"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2056"/>
         <source>Circle</source>
         <translation>Cirkel</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2057"/>
         <source>Square</source>
         <translation>Vierkant</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2089"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2058"/>
         <source>Diamond</source>
         <translation>Diamant</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2090"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2059"/>
         <source>Triangle</source>
         <translation>Driehoek</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2091"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
         <source>Cross</source>
         <translation>Kruis</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2092"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2061"/>
         <source>Hexagon</source>
         <translation>Zeshoek</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2062"/>
         <source>Star</source>
         <translation>Ster</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
         <source>Color</source>
         <translation>Kleur</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2100"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2069"/>
         <source>Fill curve</source>
         <translation>Vlak opvullen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
         <source>Data labels</source>
         <translation>Datalabel</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2080"/>
         <source>Highlight Highest</source>
         <translation>Markeer Hoogste</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
         <source>Highlight Lowest</source>
         <translation>Markeer Laagste</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2127"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
         <source>Highlight Outliers</source>
         <translation>Markeer Uitschieters</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2135"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
         <source>Baseline</source>
         <translation>Basislijn</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2143"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2112"/>
         <source>Smooth Curve</source>
         <translation>Afvlakken Curve</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2147"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2116"/>
         <source>No trend Line</source>
         <translation>Geen trendlijn</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2148"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2117"/>
         <source>Linear Trend</source>
         <translation>Lineaire Trend</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2149"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2118"/>
         <source>Quadratic Trend</source>
         <translation>Kwadratische Trend</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2150"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
         <source>Moving Average</source>
         <translation>Voortschrijdend Gemiddelde</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2151"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2120"/>
         <source>Simple Average</source>
         <translation>Simpel Gemiddelde</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2123"/>
         <source>Ignore Zeros</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2168"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2201"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2170"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Annuleren</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2431"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2400"/>
         <source>Peak %1</source>
         <translation>Piek %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2402"/>
         <source> second </source>
         <translation> seconde </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2434"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2403"/>
         <source> minute </source>
         <translation> minuut </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2436"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2405"/>
         <source> hour </source>
         <translation> uur </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2456"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2425"/>
         <source>%1 - %2</source>
         <translation>%1 - %2</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2470"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2439"/>
         <source>Performances</source>
         <translation>Performances</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2471"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2440"/>
         <source>Power Index</source>
         <translation>Vermogensindex</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2588"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2557"/>
         <source>Performances_%1_%2_%3</source>
         <translation>Performances_%1_%2_%3</translation>
     </message>
@@ -9791,93 +9761,93 @@ Misschien is het (opnieuw) nodig om de FTDI of PL2303 drivers te installeren voo
 <context>
     <name>EditUserAxisDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1731"/>
+        <location filename="../../Charts/UserChart.cpp" line="1689"/>
         <source>Edit Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1741"/>
+        <location filename="../../Charts/UserChart.cpp" line="1699"/>
         <source>&amp;OK</source>
         <translation type="unfinished">&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1742"/>
+        <location filename="../../Charts/UserChart.cpp" line="1700"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Annuleren</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1750"/>
+        <location filename="../../Charts/UserChart.cpp" line="1708"/>
         <source>Units</source>
         <translation type="unfinished">Eenheden</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1760"/>
+        <location filename="../../Charts/UserChart.cpp" line="1718"/>
         <source>Logarithmic Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1757"/>
+        <location filename="../../Charts/UserChart.cpp" line="1715"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1761"/>
-        <location filename="../../Charts/UserChart.cpp" line="1780"/>
+        <location filename="../../Charts/UserChart.cpp" line="1719"/>
+        <location filename="../../Charts/UserChart.cpp" line="1738"/>
         <source> </source>
         <translation type="unfinished"> </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1763"/>
+        <location filename="../../Charts/UserChart.cpp" line="1721"/>
         <source>Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1774"/>
+        <location filename="../../Charts/UserChart.cpp" line="1732"/>
         <source> from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1776"/>
+        <location filename="../../Charts/UserChart.cpp" line="1734"/>
         <source> to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1779"/>
+        <location filename="../../Charts/UserChart.cpp" line="1737"/>
         <source>Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1787"/>
+        <location filename="../../Charts/UserChart.cpp" line="1745"/>
         <source>Smoothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1792"/>
+        <location filename="../../Charts/UserChart.cpp" line="1750"/>
         <source>None</source>
         <translation type="unfinished">Geen</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1793"/>
+        <location filename="../../Charts/UserChart.cpp" line="1751"/>
         <source>Day</source>
         <translation type="unfinished">Dag</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1794"/>
+        <location filename="../../Charts/UserChart.cpp" line="1752"/>
         <source>Week</source>
         <translation type="unfinished">Week</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1795"/>
+        <location filename="../../Charts/UserChart.cpp" line="1753"/>
         <source>Month</source>
         <translation type="unfinished">Maand</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1796"/>
+        <location filename="../../Charts/UserChart.cpp" line="1754"/>
         <source>Year</source>
         <translation type="unfinished">Jaar</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1798"/>
+        <location filename="../../Charts/UserChart.cpp" line="1756"/>
         <source>Group By</source>
         <translation type="unfinished">Groeperen per</translation>
     </message>
@@ -10074,158 +10044,158 @@ Misschien is het (opnieuw) nodig om de FTDI of PL2303 drivers te installeren voo
 <context>
     <name>EditUserSeriesDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1398"/>
+        <location filename="../../Charts/UserChart.cpp" line="1356"/>
         <source>Edit Data Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1414"/>
+        <location filename="../../Charts/UserChart.cpp" line="1372"/>
         <source>&amp;OK</source>
         <translation type="unfinished">&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1415"/>
+        <location filename="../../Charts/UserChart.cpp" line="1373"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Annuleren</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1422"/>
+        <location filename="../../Charts/UserChart.cpp" line="1380"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1430"/>
+        <location filename="../../Charts/UserChart.cpp" line="1388"/>
         <source>Series Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1519"/>
+        <location filename="../../Charts/UserChart.cpp" line="1477"/>
         <source>Y units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1524"/>
+        <location filename="../../Charts/UserChart.cpp" line="1482"/>
         <source>X units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1528"/>
+        <location filename="../../Charts/UserChart.cpp" line="1486"/>
         <source>Sum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1529"/>
+        <location filename="../../Charts/UserChart.cpp" line="1487"/>
         <source>Average</source>
         <translation type="unfinished">Gemiddelde</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1530"/>
+        <location filename="../../Charts/UserChart.cpp" line="1488"/>
         <source>Peak</source>
         <translation type="unfinished">Piek</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1531"/>
+        <location filename="../../Charts/UserChart.cpp" line="1489"/>
         <source>Low</source>
         <translation type="unfinished">Laag</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1532"/>
+        <location filename="../../Charts/UserChart.cpp" line="1490"/>
         <source>Running Total</source>
         <translation type="unfinished">Hardloop Totaal</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1533"/>
+        <location filename="../../Charts/UserChart.cpp" line="1491"/>
         <source>Mean Square Root</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1534"/>
+        <location filename="../../Charts/UserChart.cpp" line="1492"/>
         <source>Std Deviation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1537"/>
+        <location filename="../../Charts/UserChart.cpp" line="1495"/>
         <source>Aggregate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1541"/>
-        <location filename="../../Charts/UserChart.cpp" line="1557"/>
+        <location filename="../../Charts/UserChart.cpp" line="1499"/>
+        <location filename="../../Charts/UserChart.cpp" line="1515"/>
         <source>None</source>
         <translation type="unfinished">Geen</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1542"/>
+        <location filename="../../Charts/UserChart.cpp" line="1500"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1543"/>
+        <location filename="../../Charts/UserChart.cpp" line="1501"/>
         <source>Dashed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1544"/>
+        <location filename="../../Charts/UserChart.cpp" line="1502"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1545"/>
+        <location filename="../../Charts/UserChart.cpp" line="1503"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1546"/>
+        <location filename="../../Charts/UserChart.cpp" line="1504"/>
         <source>Fast Graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1547"/>
+        <location filename="../../Charts/UserChart.cpp" line="1505"/>
         <source>Show on Legend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1548"/>
+        <location filename="../../Charts/UserChart.cpp" line="1506"/>
         <source>Show Data Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1554"/>
+        <location filename="../../Charts/UserChart.cpp" line="1512"/>
         <source>Line Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1558"/>
+        <location filename="../../Charts/UserChart.cpp" line="1516"/>
         <source>Circle</source>
         <translation type="unfinished">Cirkel</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1559"/>
+        <location filename="../../Charts/UserChart.cpp" line="1517"/>
         <source>Rectangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1564"/>
+        <location filename="../../Charts/UserChart.cpp" line="1522"/>
         <source>Symbol</source>
         <translation type="unfinished">Symbool</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1572"/>
+        <location filename="../../Charts/UserChart.cpp" line="1530"/>
         <source>Color</source>
         <translation type="unfinished">Kleur</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1575"/>
+        <location filename="../../Charts/UserChart.cpp" line="1533"/>
         <source>Fill curve</source>
         <translation type="unfinished">Vlak opvullen</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1583"/>
+        <location filename="../../Charts/UserChart.cpp" line="1541"/>
         <source>Opacity (%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1589"/>
+        <location filename="../../Charts/UserChart.cpp" line="1547"/>
         <source>Size/Width</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10272,6 +10242,24 @@ Misschien is het (opnieuw) nodig om de FTDI of PL2303 drivers te installeren voo
         <location filename="../../Metrics/BasicRideMetrics.cpp" line="144"/>
         <source>Only useful for intervals, time the interval started</source>
         <translation>Alleen bruikbaar voor intervallen, startmoment van de interval</translation>
+    </message>
+</context>
+<context>
+    <name>ElevationChartWindow</name>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="221"/>
+        <source>Profile Distance (m)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="229"/>
+        <source>Seconds for delta slope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="237"/>
+        <source>Elevation window size (%) relative to current altitude</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10710,7 +10698,7 @@ Misschien is het (opnieuw) nodig om de FTDI of PL2303 drivers te installeren voo
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ExhaustionDialog.cpp" line="160"/>
+        <location filename="../../Charts/ExhaustionDialog.cpp" line="162"/>
         <source>Time</source>
         <translation>Tijd</translation>
     </message>
@@ -13109,42 +13097,42 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
 <context>
     <name>GcCrashDialog</name>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="78"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="74"/>
         <source>%1 Crash Recovery</source>
         <translation>%1 Crash Herstel</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="116"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="112"/>
         <source>&lt;b&gt;GoldenCheetah appears to have PREVIOUSLY crashed for this athlete. &lt;/b&gt;&lt;br&gt;&lt;br&gt;The report below gives some diagnostic information that will be useful to the developers. Feel free to post this with a short description of what was occurring when the crash happened to the &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah forums&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;We respect privacy - this log does NOT contain ids, passwords or personal information.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;When this dialog is closed the athlete will be opened.&lt;/b&gt;</source>
         <translation>&lt;b&gt;GoldenCheetah blijkt EERDER gecrasht te zijn voor deze atleet. &lt;/b&gt;&lt;br&gt;&lt;br&gt;Het rapport hieronder geeft wat diagnostische informatie welke handig is voor de ontwikkelaars. Voel je vrij om dit te posten met een korte beschrijving van wat er gebeurde terwijl de crash optrad op &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah forums&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;We respecteren privacy - deze log bevat GEEN ids, wachtwoorden of persoonlijke informatie.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;Nadat deze dialoog is gesloten wordt de atleetdata opnieuw geopend.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="141"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="137"/>
         <source>Save Crash Report...</source>
         <translation>Bewaar Crash Rapport...</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="143"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="139"/>
         <source>Close</source>
         <translation>Sluit</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="225"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="221"/>
         <source>&lt;p&gt;Build date: %1 %2&lt;br&gt;Build id: %3&lt;br&gt;Version: %4&lt;br&gt;DB Schema: %5&lt;br&gt;Metrics: %7&lt;br&gt;OS: %6&lt;br&gt;OpenGL: %10&lt;br&gt;UI: dpi scale (%8) font size (%9)&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="255"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="251"/>
         <source>&lt;table&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QT&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QWT&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;%3&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SRMIO&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;D2XX&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;ICAL&lt;/td&gt;&lt;td&gt;%9&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;USBXPRESS&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LIBUSB&lt;/td&gt;&lt;td&gt;%11&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VLC&lt;/td&gt;&lt;td&gt;%12&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VIDEO&lt;/td&gt;&lt;td&gt;%13&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SAMPLERATE&lt;/td&gt;&lt;td&gt;%14&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SSL&lt;/td&gt;&lt;td&gt;%15&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;R&lt;/td&gt;&lt;td&gt;%16&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;Python&lt;/td&gt;&lt;td&gt;%18&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LMFIT&lt;/td&gt;&lt;td&gt;7.0&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;GSL&lt;/td&gt;&lt;td&gt;%19&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Save Diagnostics</source>
         <translation>Bewaar Diagnostiek</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Text File (*.txt)</source>
         <translation>Tekst Bestand (*.txt)</translation>
     </message>
@@ -13479,167 +13467,172 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
 <context>
     <name>GcWindowRegistry</name>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
         <source>Performance</source>
         <translation>Performance</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="89"/>
         <source>Histogram</source>
         <translation>Histogram</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
         <source>Distribution</source>
         <translation>Distributie</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
         <source>Pedal Force vs Velocity</source>
         <translation>Pedaalkracht vs Snelheid</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
         <source>Heartrate vs Power</source>
         <translation>Hartslag vs Vermogen</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
         <source>Map</source>
         <translation>Kaart</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
         <source>R Chart</source>
         <translation>R Inzicht</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="98"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
         <source>R Chart </source>
         <translation>R Inzicht </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
         <source>Python Chart</source>
         <translation>Python Inzicht</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
         <source>Python Chart </source>
         <translation>Python Inzicht </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="101"/>
         <source>Calendar</source>
         <translation>Kalender</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
         <source>Navigator</source>
         <translation>Navigator</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="71"/>
         <source>Season Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="72"/>
         <source>Blank Overview </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="76"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="73"/>
         <source>User Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
         <source>Trends</source>
         <translation type="unfinished">Trends</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="78"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
         <source>TreeMap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
         <source>Power Duration </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="83"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
         <source>Activity Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="81"/>
         <source>Blank Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="85"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="82"/>
         <source>User Chart </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
         <source>Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="88"/>
         <source>Power Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
         <source>Scatter</source>
         <translation type="unfinished">Scatter</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="103"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
         <source>Aerolab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
         <source>Telemetry</source>
         <translation>Telemetrie</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
         <source>Workout</source>
         <translation>Training</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="106"/>
         <source>Realtime</source>
         <translation>Realtime</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
         <source>Pedal Stroke</source>
         <translation>Pedaalslag</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
         <source>Video Player</source>
         <translation>Videospeler</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
         <source>Workout Editor</source>
         <translation>Training Editor</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="113"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
         <source>Live Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="114"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <source>Elevation Chart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
         <source>Web page</source>
         <translation>Web pagina</translation>
     </message>
@@ -14615,8 +14608,8 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
     </message>
     <message>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="219"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
         <source>Calendar</source>
         <translation>Kalender</translation>
     </message>
@@ -14761,163 +14754,168 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="296"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="294"/>
+        <source>Show elevation profile of instant position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
         <source>Predefined and configurable set of data ranges for selection of activities to be analysed</source>
         <translation>Vooringestelde en configureerbare set van datareeksen welke geselecteerd kunnen worden om geanalyseerd te worden</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
         <source>Definition of points in time &apos;Events&apos; which are marked explicitely on time related diagrams</source>
         <translation>Definitie van punten in de tijd &apos;Gebeurtenissen&apos; welke expliciet gemarkeerd zijn op tijd gerelateerde diagrammen</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="316"/>
         <source>Simple summary view</source>
         <translation>Simpel overzicht</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
         <source>Powerful filter and search engine to determine the activities which are considered in diagram</source>
         <translation>Krachtig filter en zoek machine om te bepalen welke activiteiten in ogenschouw genomen worden in het diagram</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
         <source>Alternative access to the charts created for the main view</source>
         <translation>Alternatieve toegang to de inzichten gemaakt voor het hoofdvenster</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
         <source>Configurable list of activities</source>
         <translation>Configureerbare lijst van activiteiten</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
         <source>Display the available and add new intervals using simple query methods</source>
         <translation>Toon de beschikbare en voeg nieuwe intervallen toe met gebruik van simpele vraag methodes</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="317"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
         <source>Configurable list of training devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
         <source>Configurable list of workout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
         <source>Configurable list of video files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="325"/>
         <source>Configurable list of video sync files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="327"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
         <source>Entry field for sophisticated Searching and Filtering of activities</source>
         <translation>Invoerveld voor geavanceerd Zoeken en Filteren van activiteiten</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
         <source>Adding intervals to an activity using simple query methods</source>
         <translation>Toevoegen van intervallen aan een activiteit met gebruik van simpele vraag methodes</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
         <source>To compare Activities/Intervals in Activity View and Date Ranges in Trends View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="335"/>
         <source>Workout Control, Intensity Adjustments and Notifications Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
         <source>Athlete Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
         <source>Athlete Measures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
         <source>Auto Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
         <source>Backup</source>
         <translation type="unfinished">Backup</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="355"/>
         <source>Cloud Accounts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="356"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
         <source>General</source>
         <translation>Generiek</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
         <source>Metrics shown in &apos;Intervals&apos; and &apos;Summary&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
         <source>User/Custom Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
         <source>Create or Edit a User Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
         <source>Measures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
         <source>Train View devices configuration and preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
         <source>Train View Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
         <source>Remote Controls Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
         <source>Add/Remove Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
         <source>Add Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="394"/>
         <source>Virtual Bicycle configuration for simulation rides</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="337"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
         <source>Athlete</source>
         <translation>Atleet</translation>
     </message>
@@ -14967,53 +14965,53 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
         <source>Training Zone definition for power</source>
         <translation>Trainingszonedefinitie voor vermogen</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
         <source>Training Zone definition for heartrate</source>
         <translation>Trainingszonedefinitie voor hartslag</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
         <source>Training Zone definition for Swim and Run</source>
         <translation>Trainingszonedefinitie voor Zwemmen en Hardlopen</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
         <source>Appearance</source>
         <translation>Opmaak</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <source>Automatic Interval Detection</source>
         <translation>Automatische Intervaldetectie</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="364"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
         <source>Data Fields</source>
         <translation>Datavelden</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
         <source>Definition of coloring rules for activities</source>
         <translation>Definitie van kleurenregels van activiteiten</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
         <source>Definition of default value(s) for data fields</source>
         <translation>Definitie van standaard waarde(en) van datavelden</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
         <source>Definition of processing default parameters for the fix, adjust,... tools</source>
         <translation>Definitie van het verwerken van standaard parameters van de fix, aanpas,... tools</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
         <source>Metrics</source>
         <translation>Metrieken</translation>
     </message>
@@ -15213,47 +15211,43 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2431"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2432"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2437"/>
         <source>Add</source>
-        <translation>Toevoegen</translation>
+        <translation type="vanished">Toevoegen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2438"/>
         <source>Delete</source>
-        <translation>Verwijderen</translation>
+        <translation type="vanished">Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2447"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2332"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2458"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2343"/>
         <source>Short</source>
         <translation>Kort</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2459"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2344"/>
         <source>Long</source>
         <translation>Lang</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2460"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2345"/>
         <source>Percent of LT</source>
         <translation>Percentage van LT</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2461"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2346"/>
         <source>Trimp k</source>
         <translation>Trimp k</translation>
     </message>
@@ -15262,14 +15256,14 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
         <translation type="vanished">Maximum van 10 zones bereikt.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2506"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2513"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2390"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2397"/>
         <source>New</source>
         <translation>Nieuw</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2508"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2515"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2392"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2399"/>
         <source>New (%1)</source>
         <translation>Nieuw (%1)</translation>
     </message>
@@ -15459,17 +15453,17 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2245"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2395"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2292"/>
         <source>Lactate Threshold</source>
         <translation>Lactaatdrempel</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2396"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2293"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
@@ -17624,545 +17618,542 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
 <context>
     <name>LTMTool</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="74"/>
+        <location filename="../../Charts/LTMTool.cpp" line="75"/>
         <source>Filter</source>
         <translation>Filter</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="80"/>
+        <location filename="../../Charts/LTMTool.cpp" line="81"/>
         <source>Date range</source>
         <translation>Periode</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="84"/>
+        <location filename="../../Charts/LTMTool.cpp" line="85"/>
         <source>Days</source>
         <translation>Dagen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="85"/>
+        <location filename="../../Charts/LTMTool.cpp" line="86"/>
         <source>Weeks</source>
         <translation>Weken</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="86"/>
+        <location filename="../../Charts/LTMTool.cpp" line="87"/>
         <source>Months</source>
         <translation>Maanden</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="87"/>
+        <location filename="../../Charts/LTMTool.cpp" line="88"/>
         <source>Years</source>
         <translation>Jaren</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="88"/>
+        <location filename="../../Charts/LTMTool.cpp" line="89"/>
         <source>Time Of Day</source>
         <translation>Tijdstip Van de Dag</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="89"/>
+        <location filename="../../Charts/LTMTool.cpp" line="90"/>
         <source>All</source>
         <translation>Alles</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="91"/>
+        <location filename="../../Charts/LTMTool.cpp" line="92"/>
         <source>Group by</source>
         <translation>Groeperen per</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="94"/>
+        <location filename="../../Charts/LTMTool.cpp" line="95"/>
         <source>Data Table</source>
         <translation>Datatabel</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="98"/>
+        <location filename="../../Charts/LTMTool.cpp" line="99"/>
         <source>Show Stack</source>
         <translation>Toon Stapel</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="102"/>
+        <location filename="../../Charts/LTMTool.cpp" line="103"/>
         <source>Shade Zones</source>
         <translation>Zone-kleuring</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="105"/>
+        <location filename="../../Charts/LTMTool.cpp" line="106"/>
         <source>Show Legend</source>
         <translation>Toon Legenda</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="109"/>
         <source>Show Events</source>
         <translation>Toon Evenementen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="112"/>
         <source>Show Banister Helper</source>
         <translation>Toon Banister Helper</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="121"/>
+        <location filename="../../Charts/LTMTool.cpp" line="122"/>
         <source>Stack Zoom</source>
         <translation>Stapelzoom</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="124"/>
+        <location filename="../../Charts/LTMTool.cpp" line="125"/>
         <source>Use sidebar chart settings</source>
         <translation>Gebruik zijbalk inzicht instellingen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="146"/>
+        <location filename="../../Charts/LTMTool.cpp" line="147"/>
         <source>Charts</source>
         <translation>Inzichten</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="155"/>
         <source>Apply</source>
         <translation>Toepassen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="155"/>
+        <location filename="../../Charts/LTMTool.cpp" line="156"/>
         <source>Add Current</source>
         <translation>Huidige Toevoegen</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="268"/>
         <source>Edit</source>
-        <translation>Bewerken</translation>
+        <translation type="vanished">Bewerken</translation>
+    </message>
+    <message>
+        <source>Up</source>
+        <translation type="vanished">Op</translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation type="vanished">Neer</translation>
     </message>
     <message>
         <location filename="../../Charts/LTMTool.cpp" line="287"/>
-        <source>Up</source>
-        <translation>Op</translation>
-    </message>
-    <message>
-        <location filename="../../Charts/LTMTool.cpp" line="288"/>
-        <source>Down</source>
-        <translation>Neer</translation>
-    </message>
-    <message>
-        <location filename="../../Charts/LTMTool.cpp" line="313"/>
         <source>Basic</source>
         <translation>Eenvoudig</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="314"/>
+        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Preset</source>
         <translation>Voorinstelling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="289"/>
         <source>Curves</source>
         <translation>Curves</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="351"/>
+        <location filename="../../Charts/LTMTool.cpp" line="325"/>
         <source>Skiba Long Term Stress</source>
         <translation>Skiba Long Term Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="353"/>
-        <location filename="../../Charts/LTMTool.cpp" line="368"/>
-        <location filename="../../Charts/LTMTool.cpp" line="429"/>
-        <location filename="../../Charts/LTMTool.cpp" line="444"/>
-        <location filename="../../Charts/LTMTool.cpp" line="505"/>
-        <location filename="../../Charts/LTMTool.cpp" line="520"/>
-        <location filename="../../Charts/LTMTool.cpp" line="580"/>
-        <location filename="../../Charts/LTMTool.cpp" line="595"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1080"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1095"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1156"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1171"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1309"/>
+        <location filename="../../Charts/LTMTool.cpp" line="327"/>
+        <location filename="../../Charts/LTMTool.cpp" line="342"/>
+        <location filename="../../Charts/LTMTool.cpp" line="403"/>
+        <location filename="../../Charts/LTMTool.cpp" line="418"/>
+        <location filename="../../Charts/LTMTool.cpp" line="479"/>
+        <location filename="../../Charts/LTMTool.cpp" line="494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="554"/>
+        <location filename="../../Charts/LTMTool.cpp" line="569"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1054"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1069"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1130"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1145"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1278"/>
         <source>Stress</source>
         <translation>Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="366"/>
+        <location filename="../../Charts/LTMTool.cpp" line="340"/>
         <source>Skiba Short Term Stress</source>
         <translation>Skiba Short Term Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="381"/>
+        <location filename="../../Charts/LTMTool.cpp" line="355"/>
         <source>Skiba Stress Balance</source>
         <translation>Skiba Stress Balance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="383"/>
-        <location filename="../../Charts/LTMTool.cpp" line="459"/>
-        <location filename="../../Charts/LTMTool.cpp" line="535"/>
-        <location filename="../../Charts/LTMTool.cpp" line="610"/>
-        <location filename="../../Charts/LTMTool.cpp" line="686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="762"/>
-        <location filename="../../Charts/LTMTool.cpp" line="838"/>
-        <location filename="../../Charts/LTMTool.cpp" line="914"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1110"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1186"/>
+        <location filename="../../Charts/LTMTool.cpp" line="357"/>
+        <location filename="../../Charts/LTMTool.cpp" line="433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="509"/>
+        <location filename="../../Charts/LTMTool.cpp" line="584"/>
+        <location filename="../../Charts/LTMTool.cpp" line="660"/>
+        <location filename="../../Charts/LTMTool.cpp" line="736"/>
+        <location filename="../../Charts/LTMTool.cpp" line="812"/>
+        <location filename="../../Charts/LTMTool.cpp" line="888"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1160"/>
         <source>Stress Balance</source>
         <translation>Stress Balance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="396"/>
+        <location filename="../../Charts/LTMTool.cpp" line="370"/>
         <source>Skiba STS Ramp</source>
         <translation>Skiba STS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="398"/>
-        <location filename="../../Charts/LTMTool.cpp" line="413"/>
-        <location filename="../../Charts/LTMTool.cpp" line="474"/>
-        <location filename="../../Charts/LTMTool.cpp" line="489"/>
-        <location filename="../../Charts/LTMTool.cpp" line="550"/>
-        <location filename="../../Charts/LTMTool.cpp" line="565"/>
-        <location filename="../../Charts/LTMTool.cpp" line="625"/>
-        <location filename="../../Charts/LTMTool.cpp" line="640"/>
-        <location filename="../../Charts/LTMTool.cpp" line="701"/>
-        <location filename="../../Charts/LTMTool.cpp" line="716"/>
-        <location filename="../../Charts/LTMTool.cpp" line="777"/>
-        <location filename="../../Charts/LTMTool.cpp" line="792"/>
-        <location filename="../../Charts/LTMTool.cpp" line="853"/>
-        <location filename="../../Charts/LTMTool.cpp" line="868"/>
-        <location filename="../../Charts/LTMTool.cpp" line="929"/>
-        <location filename="../../Charts/LTMTool.cpp" line="944"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1005"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1020"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1125"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1140"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1201"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1216"/>
+        <location filename="../../Charts/LTMTool.cpp" line="372"/>
+        <location filename="../../Charts/LTMTool.cpp" line="387"/>
+        <location filename="../../Charts/LTMTool.cpp" line="448"/>
+        <location filename="../../Charts/LTMTool.cpp" line="463"/>
+        <location filename="../../Charts/LTMTool.cpp" line="524"/>
+        <location filename="../../Charts/LTMTool.cpp" line="539"/>
+        <location filename="../../Charts/LTMTool.cpp" line="599"/>
+        <location filename="../../Charts/LTMTool.cpp" line="614"/>
+        <location filename="../../Charts/LTMTool.cpp" line="675"/>
+        <location filename="../../Charts/LTMTool.cpp" line="690"/>
+        <location filename="../../Charts/LTMTool.cpp" line="751"/>
+        <location filename="../../Charts/LTMTool.cpp" line="766"/>
+        <location filename="../../Charts/LTMTool.cpp" line="827"/>
+        <location filename="../../Charts/LTMTool.cpp" line="842"/>
+        <location filename="../../Charts/LTMTool.cpp" line="903"/>
+        <location filename="../../Charts/LTMTool.cpp" line="918"/>
+        <location filename="../../Charts/LTMTool.cpp" line="979"/>
+        <location filename="../../Charts/LTMTool.cpp" line="994"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1099"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1114"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1175"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1190"/>
         <source>Ramp</source>
         <translation>Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="411"/>
+        <location filename="../../Charts/LTMTool.cpp" line="385"/>
         <source>Skiba LTS Ramp</source>
         <translation>Skiba LTS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="427"/>
+        <location filename="../../Charts/LTMTool.cpp" line="401"/>
         <source>Aerobic TISS Long Term Stress</source>
         <translation>Aerobe TISS Long Term Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="442"/>
+        <location filename="../../Charts/LTMTool.cpp" line="416"/>
         <source>Aerobic TISS Short Term Stress</source>
         <translation>Aerobe TISS Short Term Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="457"/>
+        <location filename="../../Charts/LTMTool.cpp" line="431"/>
         <source>Aerobic TISS Stress Balance</source>
         <translation>Aerobe TISS Stress Balance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="472"/>
+        <location filename="../../Charts/LTMTool.cpp" line="446"/>
         <source>Aerobic TISS STS Ramp</source>
         <translation>Aerobe TISS STS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="487"/>
+        <location filename="../../Charts/LTMTool.cpp" line="461"/>
         <source>Aerobic TISS LTS Ramp</source>
         <translation>Aerobe TISS LTS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="503"/>
+        <location filename="../../Charts/LTMTool.cpp" line="477"/>
         <source>Anaerobic TISS Long Term Stress</source>
         <translation>Anaerobe TISS Long Term Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="518"/>
+        <location filename="../../Charts/LTMTool.cpp" line="492"/>
         <source>Anaerobic TISS Short Term Stress</source>
         <translation>Anaerobe TISS Short Term Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="533"/>
+        <location filename="../../Charts/LTMTool.cpp" line="507"/>
         <source>Anaerobic TISS Stress Balance</source>
         <translation>Anaerobe TISS Stress Balance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="548"/>
+        <location filename="../../Charts/LTMTool.cpp" line="522"/>
         <source>Anaerobic TISS STS Ramp</source>
         <translation>Anaerobe TISS STS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="537"/>
         <source>Anaerobic TISS LTS Ramp</source>
         <translation>Anaerobe TISS LTS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="578"/>
+        <location filename="../../Charts/LTMTool.cpp" line="552"/>
         <source>Daniels Long Term Stress</source>
         <translation>Daniels Lange Termijn Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="593"/>
+        <location filename="../../Charts/LTMTool.cpp" line="567"/>
         <source>Daniels Short Term Stress</source>
         <translation>Daniels Korte Termijn Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="582"/>
         <source>Daniels Stress Balance</source>
         <translation>Daniels Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="623"/>
+        <location filename="../../Charts/LTMTool.cpp" line="597"/>
         <source>Daniels STS Ramp</source>
         <translation>Daniels STS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="638"/>
+        <location filename="../../Charts/LTMTool.cpp" line="612"/>
         <source>Daniels LTS Ramp</source>
         <translation>Daniels LTS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="628"/>
         <source>Work (Kj) Long Term Stress</source>
         <translation>Arbeid (Kj) Lange Termijn Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="656"/>
-        <location filename="../../Charts/LTMTool.cpp" line="671"/>
-        <location filename="../../Charts/LTMTool.cpp" line="732"/>
-        <location filename="../../Charts/LTMTool.cpp" line="747"/>
-        <location filename="../../Charts/LTMTool.cpp" line="808"/>
-        <location filename="../../Charts/LTMTool.cpp" line="823"/>
+        <location filename="../../Charts/LTMTool.cpp" line="630"/>
+        <location filename="../../Charts/LTMTool.cpp" line="645"/>
+        <location filename="../../Charts/LTMTool.cpp" line="706"/>
+        <location filename="../../Charts/LTMTool.cpp" line="721"/>
+        <location filename="../../Charts/LTMTool.cpp" line="782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="797"/>
         <source>Stress (Kj)</source>
         <translation>Stress (Kj)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="669"/>
+        <location filename="../../Charts/LTMTool.cpp" line="643"/>
         <source>Work (Kj) Short Term Stress</source>
         <translation>Arbeid (Kj) Korte Termijn Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="684"/>
+        <location filename="../../Charts/LTMTool.cpp" line="658"/>
         <source>Work (Kj) Stress Balance</source>
         <translation>Arbeid (Kj) Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="699"/>
+        <location filename="../../Charts/LTMTool.cpp" line="673"/>
         <source>Work (Kj) STS Ramp</source>
         <translation>Arbeid (Kj) STS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="714"/>
+        <location filename="../../Charts/LTMTool.cpp" line="688"/>
         <source>Work (Kj) LTS Ramp</source>
         <translation>Arbeid (Kj) LTS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="730"/>
+        <location filename="../../Charts/LTMTool.cpp" line="704"/>
         <source>W&apos; Work (Kj) Long Term Stress</source>
         <translation>W&apos; Arbeid (Kj) Lange Termijn Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="745"/>
+        <location filename="../../Charts/LTMTool.cpp" line="719"/>
         <source>W&apos; Work (Kj) Short Term Stress</source>
         <translation>W&apos; Arbeid (Kj) Korte Termijn Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="760"/>
+        <location filename="../../Charts/LTMTool.cpp" line="734"/>
         <source>W&apos; Work (Kj) Stress Balance</source>
         <translation>W&apos; Arbeid (Kj) Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="775"/>
+        <location filename="../../Charts/LTMTool.cpp" line="749"/>
         <source>W&apos; Work (Kj) STS Ramp</source>
         <translation>W&apos; Arbeid (Kj) STS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="790"/>
+        <location filename="../../Charts/LTMTool.cpp" line="764"/>
         <source>W&apos; Work (Kj) LTS Ramp</source>
         <translation>W&apos; Arbeid (Kj) LTS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="806"/>
+        <location filename="../../Charts/LTMTool.cpp" line="780"/>
         <source>Below CP Work (Kj) Long Term Stress</source>
         <translation>Onder CP Arbeid (Kj) Lange Termijn Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="821"/>
+        <location filename="../../Charts/LTMTool.cpp" line="795"/>
         <source>Below CP Work (Kj) Short Term Stress</source>
         <translation>Onder CP Arbeid (Kj) Korte Termijn Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="836"/>
+        <location filename="../../Charts/LTMTool.cpp" line="810"/>
         <source>Below CP Work (Kj) Stress Balance</source>
         <translation>Onder CP Arbeid (Kj) Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="851"/>
+        <location filename="../../Charts/LTMTool.cpp" line="825"/>
         <source>Below CP Work (Kj) STS Ramp</source>
         <translation>Onder CP Arbeid (Kj) STS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="866"/>
+        <location filename="../../Charts/LTMTool.cpp" line="840"/>
         <source>Below CP Work (Kj) LTS Ramp</source>
         <translation>Onder CP Arbeid (Kj) LTS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="882"/>
+        <location filename="../../Charts/LTMTool.cpp" line="856"/>
         <source>Distance (km|mi) Long Term Stress</source>
         <translation>Afstand (km|mi) Lange Termijn Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="884"/>
-        <location filename="../../Charts/LTMTool.cpp" line="899"/>
+        <location filename="../../Charts/LTMTool.cpp" line="858"/>
+        <location filename="../../Charts/LTMTool.cpp" line="873"/>
         <source>Stress (km|mi)</source>
         <translation>Stress (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="897"/>
+        <location filename="../../Charts/LTMTool.cpp" line="871"/>
         <source>Distance (km|mi) Short Term Stress</source>
         <translation>Afstand (km|mi) Korte Termijn Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="912"/>
+        <location filename="../../Charts/LTMTool.cpp" line="886"/>
         <source>Distance (km|mi) Stress Balance</source>
         <translation>Afstand (km|mi) Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="927"/>
+        <location filename="../../Charts/LTMTool.cpp" line="901"/>
         <source>Distance (km|mi) STS Ramp</source>
         <translation>Afstand (km|mi) STS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="942"/>
+        <location filename="../../Charts/LTMTool.cpp" line="916"/>
         <source>Distance (km|mi) LTS Ramp</source>
         <translation>Afstand (km|mi) LTS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="958"/>
+        <location filename="../../Charts/LTMTool.cpp" line="932"/>
         <source>Coggan Chronic Training Load</source>
         <translation>Coggan Chronic Training Load</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="973"/>
+        <location filename="../../Charts/LTMTool.cpp" line="947"/>
         <source>Coggan Acute Training Load</source>
         <translation>Coggan Acute Training Load</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="988"/>
+        <location filename="../../Charts/LTMTool.cpp" line="962"/>
         <source>Coggan Training Stress Balance</source>
         <translation>Coggan Training Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1003"/>
+        <location filename="../../Charts/LTMTool.cpp" line="977"/>
         <source>Coggan STS Ramp</source>
         <translation>Coggan STS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1018"/>
+        <location filename="../../Charts/LTMTool.cpp" line="992"/>
         <source>Coggan LTS Ramp</source>
         <translation>Coggan LTS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1033"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1007"/>
         <source>Coggan Expected Chronic Training Load</source>
         <translation>Coggan Verwachtte Chronic Training Load</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1048"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1022"/>
         <source>Coggan Expected Acute Training Load</source>
         <translation>Coggan Verwachtte Acute Training Load</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1063"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1037"/>
         <source>Coggan Expected Training Stress Balance</source>
         <translation>Coggan Verwachtte Training Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1053"/>
         <source>TRIMP Long Term Stress</source>
         <translation>TRIMP Lange Termijn Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1067"/>
         <source>TRIMP Short Term Stress</source>
         <translation>TRIMP Korte Termijn Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1082"/>
         <source>TRIMP Stress Balance</source>
         <translation>TRIMP Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1123"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1097"/>
         <source>TRIMP STS Ramp</source>
         <translation>TRIMP STS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1138"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1112"/>
         <source>TRIMP LTS Ramp</source>
         <translation>TRIMP LTS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1128"/>
         <source>TriScore Long Term Stress</source>
         <translation>TriScore Lange Termijn Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1169"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1143"/>
         <source>TriScore Short Term Stress</source>
         <translation>TriScore Korte Termijn Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1184"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1158"/>
         <source>TriScore Stress Balance</source>
         <translation>TriScore Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1173"/>
         <source>TriScore STS Ramp</source>
         <translation>TriScore STS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1214"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1188"/>
         <source>TriScore LTS Ramp</source>
         <translation>TriScore LTS Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1303"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1272"/>
         <source>Metric</source>
         <translation>Metriek</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1305"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1274"/>
         <source>Peak</source>
         <translation>Piek</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1307"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1276"/>
         <source>Estimate</source>
         <translation>Schatting</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1311"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1280"/>
         <source>Formula</source>
         <translation>Formule</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1282"/>
         <source>Measure</source>
         <translation>Meting</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1284"/>
         <source>Performance</source>
         <translation>Performance</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1317"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1286"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1463"/>
         <source>Chart %1</source>
         <translation>Inzicht %1</translation>
     </message>
@@ -18365,50 +18356,42 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
         <translation type="vanished">Update</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2590"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2602"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2591"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2603"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2596"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2608"/>
         <source>Add</source>
-        <translation>Toevoegen</translation>
+        <translation type="vanished">Toevoegen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2597"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2609"/>
         <source>Delete</source>
-        <translation>Verwijderen</translation>
+        <translation type="vanished">Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2599"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2467"/>
         <source>Def</source>
         <translation>Def</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2628"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2690"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2770"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2775"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2780"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2785"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2473"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2478"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2488"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2611"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2621"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2626"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2650"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2493"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2630"/>
         <source>Start Date</source>
         <translation type="unfinished">Startdatum</translation>
     </message>
@@ -18417,26 +18400,26 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
         <translation type="vanished">Vanaf Datum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2651"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2790"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2494"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2631"/>
         <source>Lactate Threshold</source>
         <translation>Lactaatdrempel</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2652"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2791"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2495"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2632"/>
         <source>Aerobic Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2653"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2496"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
         <source>Rest HR</source>
         <translation>Rust HR</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2654"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2497"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2634"/>
         <source>Max HR</source>
         <translation>Max HR</translation>
     </message>
@@ -18445,22 +18428,22 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
         <translation type="vanished">MMM d, yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2701"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2544"/>
         <source>Short</source>
         <translation>Kort</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2702"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2545"/>
         <source>Long</source>
         <translation>Lang</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2703"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2546"/>
         <source>From BPM</source>
         <translation>Van BPM</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2704"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2547"/>
         <source>Trimp k</source>
         <translation>Trimp k</translation>
     </message>
@@ -18469,14 +18452,14 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
         <translation type="vanished">Maximum van 10 zones bereikt.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2967"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2974"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2804"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2811"/>
         <source>New</source>
         <translation>Nieuw</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2969"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2976"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2806"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2813"/>
         <source>New (%1)</source>
         <translation>Nieuw (%1)</translation>
     </message>
@@ -19218,62 +19201,62 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
 <context>
     <name>Library</name>
     <message>
+        <location filename="../../Train/Library.cpp" line="126"/>
         <location filename="../../Train/Library.cpp" line="130"/>
-        <location filename="../../Train/Library.cpp" line="134"/>
         <source>Import Videos, VideoSyncs and Workouts</source>
         <translation>Importeer Videos, VideoSyncs en Trainingen</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="127"/>
         <location filename="../../Train/Library.cpp" line="131"/>
-        <location filename="../../Train/Library.cpp" line="135"/>
         <source>No supported videos, videoSyncs or workouts were found to import</source>
         <translation>Geen ondersteunde videos, videoSyncs of trainingen werden gevonden om te importeren</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="189"/>
         <location filename="../../Train/Library.cpp" line="193"/>
-        <location filename="../../Train/Library.cpp" line="197"/>
+        <location filename="../../Train/Library.cpp" line="198"/>
         <location filename="../../Train/Library.cpp" line="202"/>
-        <location filename="../../Train/Library.cpp" line="206"/>
         <source>Copy VideoSync Failed</source>
         <translation>Kopiëren VideoSync Mislukt</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="190"/>
         <location filename="../../Train/Library.cpp" line="194"/>
-        <location filename="../../Train/Library.cpp" line="198"/>
         <source>%1 already exists in videoSync library: %2</source>
         <translation>%1 bestaat al in de videoSync bibliotheek: %2</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="203"/>
+        <location filename="../../Train/Library.cpp" line="199"/>
         <source>%1 cannot be written to videoSync library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="207"/>
+        <location filename="../../Train/Library.cpp" line="203"/>
         <source>%1 cannot be written to videoSync library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="253"/>
+        <location filename="../../Train/Library.cpp" line="249"/>
         <source>%1 cannot be written to workout library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="257"/>
+        <location filename="../../Train/Library.cpp" line="253"/>
         <source>%1 cannot be written to workout library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="239"/>
         <location filename="../../Train/Library.cpp" line="243"/>
-        <location filename="../../Train/Library.cpp" line="247"/>
+        <location filename="../../Train/Library.cpp" line="248"/>
         <location filename="../../Train/Library.cpp" line="252"/>
-        <location filename="../../Train/Library.cpp" line="256"/>
         <source>Copy Workout Failed</source>
         <translation>Kopiëren Training Mislukt</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="240"/>
         <location filename="../../Train/Library.cpp" line="244"/>
-        <location filename="../../Train/Library.cpp" line="248"/>
         <source>%1 already exists in workout library: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19281,89 +19264,89 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
 <context>
     <name>LibrarySearchDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="330"/>
+        <location filename="../../Train/Library.cpp" line="326"/>
         <source>Search for Workouts, Syncs and Media</source>
         <translation>Zoek naar Trainingen, Syncs en Media</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="337"/>
+        <location filename="../../Train/Library.cpp" line="333"/>
         <source>Workout files (.erg, .mrc, .zwo etc)</source>
         <translation>Trainingsbestanden (.erg, .mrc, zwo etc.)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="339"/>
+        <location filename="../../Train/Library.cpp" line="335"/>
         <source>Video files (.mp4, .avi etc)</source>
         <translation>Videobestanden (.mp4, .avi etc.)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="341"/>
+        <location filename="../../Train/Library.cpp" line="337"/>
         <source>VideoSync files (.rlv, .tts etc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="359"/>
+        <location filename="../../Train/Library.cpp" line="353"/>
         <source>Search Path</source>
         <translation>Zoekpad</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="379"/>
+        <location filename="../../Train/Library.cpp" line="373"/>
         <source>Video references</source>
         <translation>Videoreferenties</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="391"/>
+        <location filename="../../Train/Library.cpp" line="385"/>
         <source>Searching...</source>
         <translation>Zoeken...</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="394"/>
+        <location filename="../../Train/Library.cpp" line="388"/>
         <source>Videos</source>
         <translation>Videos</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="396"/>
+        <location filename="../../Train/Library.cpp" line="390"/>
         <source>Workouts</source>
         <translation>Trainingen</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="398"/>
+        <location filename="../../Train/Library.cpp" line="392"/>
         <source>VideoSyncs</source>
         <translation>VideoSyncs</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="407"/>
-        <location filename="../../Train/Library.cpp" line="494"/>
+        <location filename="../../Train/Library.cpp" line="401"/>
+        <location filename="../../Train/Library.cpp" line="484"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="409"/>
+        <location filename="../../Train/Library.cpp" line="403"/>
         <source>Search</source>
         <translation>Zoeken</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="412"/>
+        <location filename="../../Train/Library.cpp" line="406"/>
         <source>Files to search for:</source>
         <translation>Zoek naar deze bestanden:</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="475"/>
+        <location filename="../../Train/Library.cpp" line="466"/>
         <source>Abort Search</source>
         <translation>Annuleer Zoeken</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="515"/>
-        <location filename="../../Train/Library.cpp" line="559"/>
+        <location filename="../../Train/Library.cpp" line="504"/>
+        <location filename="../../Train/Library.cpp" line="548"/>
         <source>Save</source>
         <translation>Bewaar</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="557"/>
+        <location filename="../../Train/Library.cpp" line="546"/>
         <source>Search completed.</source>
         <translation>Zoeken voltooid.</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="645"/>
+        <location filename="../../Train/Library.cpp" line="634"/>
         <source>Select Directory</source>
         <translation>Selecteer Map</translation>
     </message>
@@ -19371,12 +19354,12 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
 <context>
     <name>ListEditWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="623"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="654"/>
         <source>New</source>
         <translation type="unfinished">Nieuw</translation>
     </message>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="625"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="656"/>
         <source>New (%1)</source>
         <translation type="unfinished">Nieuw (%1)</translation>
     </message>
@@ -19389,7 +19372,12 @@ Koppelaanpassing - dit definieert een absolute waarde in ponden per vierkante in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="90"/>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="85"/>
+        <source>Initial Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="98"/>
         <source>Apply changes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -20103,15 +20091,15 @@ staat met op het display, &quot;PC Link&quot;</translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Activity Import</source>
         <translation>Activiteit Import</translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Closing of athlete window not possible while background activity import is in progress...</source>
         <translation>Sluiten van het atleet venster is niet mogelijk terwijl een achtergrond import-activiteit bezig is...</translation>
     </message>
@@ -20126,145 +20114,145 @@ staat met op het display, &quot;PC Link&quot;</translation>
         <translation>Wil je doorgaan?</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Chart Import</source>
         <translation>Inzicht Importeren</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Imported %1 metric charts</source>
         <translation>%1 metrieken overzichten geïmporteerd</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>Import Images Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>You can only import images on the activities view with an activity selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>Import Images to Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>%1 images imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
         <source>Select Activity</source>
         <translation>Selecteer Activiteit</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>No activity selected!</source>
         <translation>Geen activiteit geselecteerd!</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1724"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1734"/>
         <source>Export Activity</source>
         <translation>Exporteer Activiteit</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1777"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1787"/>
         <source>Export Failed</source>
         <translation>Exporteren Mislukt</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1778"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1788"/>
         <source>Failed to export activity, please check permissions</source>
         <translation>Exporteren van activiteit is mislukt, controleer de toegang permissie alsjeblieft</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1799"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2369"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1809"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2379"/>
         <source>Import from File</source>
         <translation>Importeer vanuit Bestand</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1814"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1824"/>
         <source>No Activity To Save</source>
         <translation>Geen Activiteit Om te Bewaren</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1815"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1825"/>
         <source>There is no currently selected activity to save.</source>
         <translation>Er is nu geen activiteit geselecteerd om te bewaren.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
         <location filename="../../Gui/MainWindow.cpp" line="1886"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Split Activity</source>
         <translation>Splits Activiteit</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
         <source>No activity selected</source>
         <translation>Geen Activiteit geselecteerd</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
         <source>Current activity contains no data to split</source>
         <translation>Huidige activiteit bevat geen data om te splitsen</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Current activity contains no data to merge</source>
         <translation>Huidige activiteit bevat geen data om samen te voegen</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>Delete Activity</source>
         <translation>Activiteit Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1904"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1914"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation>Ben je zeker van het verwijderen van activiteit:</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1906"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1916"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2165"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2175"/>
         <source>&amp;New Athlete...</source>
         <translation>&amp;Nieuwe Atleet...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2342"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2352"/>
         <source>Refresh in Progress</source>
         <translation>Bezig met Verversen</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Export Metrics</source>
         <translation>Exporteer Metrieken</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation>Komma-gescheiden Variabelen (*.csv)</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2399"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2420"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2409"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2430"/>
         <source>Workout Directory Invalid</source>
         <translation>Training Map Ongeldig</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2400"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2421"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2410"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2431"/>
         <source>The workout directory is not configured, or the directory selected no longer exists.
 
 Please check your preference settings.</source>
@@ -20273,19 +20261,19 @@ Please check your preference settings.</source>
 Controleer je voorkeur instellingen alsjeblieft.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2611"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2621"/>
         <source>Loading activities: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>CloudDB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>Current athlete is not registered as curator - please contact the GoldenCheetah team</source>
         <translation>Huidige atleet is niet geregistreerd as curator - neem contact op met het GoldenCheetah team alsjeblieft</translation>
     </message>
@@ -21201,23 +21189,23 @@ Controleer je voorkeur instellingen alsjeblieft.</translation>
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="656"/>
+        <location filename="../../Gui/AthletePages.cpp" line="641"/>
         <source>From Date - Time</source>
         <translation type="unfinished">Vanaf Datum - Tijd</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="780"/>
+        <location filename="../../Gui/AthletePages.cpp" line="751"/>
         <source>Start Date</source>
         <translation type="unfinished">Startdatum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="893"/>
+        <location filename="../../Gui/AthletePages.cpp" line="864"/>
         <source>MMM d, yyyy - hh:mm:ss</source>
         <translation type="unfinished">MMM d, jjjj - hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="659"/>
-        <location filename="../../Gui/AthletePages.cpp" line="807"/>
+        <location filename="../../Gui/AthletePages.cpp" line="644"/>
+        <location filename="../../Gui/AthletePages.cpp" line="778"/>
         <source>Comment</source>
         <translation type="unfinished">Commentaar</translation>
     </message>
@@ -21226,32 +21214,28 @@ Controleer je voorkeur instellingen alsjeblieft.</translation>
         <translation type="obsolete">Update</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="662"/>
         <source>+</source>
-        <translation type="unfinished">+</translation>
+        <translation type="obsolete">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="663"/>
         <source>-</source>
-        <translation type="unfinished">-</translation>
+        <translation type="obsolete">-</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="obsolete">Toevoegen</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="obsolete">Verwijderen</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="668"/>
-        <source>Add</source>
-        <translation type="unfinished">Toevoegen</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="669"/>
-        <source>Delete</source>
-        <translation type="unfinished">Verwijderen</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="698"/>
         <source>Source</source>
         <translation type="unfinished">Bron</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="699"/>
+        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Original Source</source>
         <translation type="unfinished">Originele Bron</translation>
     </message>
@@ -21943,17 +21927,17 @@ Geen ritten gevonden om te importeren.
 <context>
     <name>MultiDeviceDialog</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3048"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3060"/>
         <source>Multiple Device Configuration</source>
         <translation>Meerdere Apparaten Configuratie</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3103"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3115"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3106"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3118"/>
         <source>Apply</source>
         <translation type="unfinished">Toepassen</translation>
     </message>
@@ -22966,42 +22950,38 @@ Geen ritten gevonden om te importeren.
 <context>
     <name>PaceSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3154"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3155"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3160"/>
         <source>Add</source>
-        <translation>Toevoegen</translation>
+        <translation type="vanished">Toevoegen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3161"/>
         <source>Delete</source>
-        <translation>Verwijderen</translation>
+        <translation type="vanished">Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3176"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2987"/>
         <source>Short</source>
         <translation>Kort</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3177"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2988"/>
         <source>Long</source>
         <translation>Lang</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3178"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2989"/>
         <source>Percent of CV</source>
         <translation>Percentage van CV</translation>
     </message>
@@ -23010,14 +22990,14 @@ Geen ritten gevonden om te importeren.
         <translation type="vanished">Maximum van 10 zones bereikt.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3220"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3227"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3037"/>
         <source>New</source>
         <translation>Nieuw</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3222"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3229"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3032"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3039"/>
         <source>New (%1)</source>
         <translation>Nieuw (%1)</translation>
     </message>
@@ -23217,27 +23197,27 @@ Geen ritten gevonden om te importeren.
 <context>
     <name>PaceZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3082"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2905"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3084"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2907"/>
         <source>Run</source>
         <translation>Hardlopen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3085"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2908"/>
         <source>Swim</source>
         <translation>Zwemmen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3126"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2949"/>
         <source>Critical Velocity</source>
         <translation>Kritische Snelheid</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2950"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
@@ -25384,78 +25364,75 @@ Wil je doorgaan?</translation>
 <context>
     <name>PerspectiveDialog</name>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="34"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="35"/>
         <source>Manage Perspectives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="43"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="44"/>
         <source>Perspectives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="60"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="61"/>
         <source>Charts</source>
         <translation type="unfinished">Inzichten</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Edit</source>
-        <translation type="unfinished">Bewerken</translation>
+        <translation type="obsolete">Bewerken</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="83"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="78"/>
         <source>Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="84"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="77"/>
         <source>Export</source>
         <translation type="unfinished">Exporteer</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="90"/>
         <source>Add</source>
-        <translation type="unfinished">Toevoegen</translation>
+        <translation type="obsolete">Toevoegen</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="91"/>
         <source>Delete</source>
-        <translation type="unfinished">Verwijderen</translation>
+        <translation type="obsolete">Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="98"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Drag charts to move to a perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="287"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="256"/>
         <source>Export Persepctive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
         <source>Export Perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>No perspective file selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
-        <source>Select Perspective file to export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
         <source>GoldenCheetah Perspective Files (*.gchartset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
+        <source>Select Perspective file to import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>Import Perspective</source>
         <translation type="unfinished"></translation>
     </message>
@@ -26615,307 +26592,307 @@ Python is uitgeschakeld in de voorkeursinstellingen.</translation>
 <context>
     <name>RealtimeData</name>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="621"/>
+        <location filename="../../Train/RealtimeData.cpp" line="623"/>
         <source>None</source>
         <translation>Geen</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="624"/>
+        <location filename="../../Train/RealtimeData.cpp" line="626"/>
         <source>Time</source>
         <translation>Tijd</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="627"/>
+        <location filename="../../Train/RealtimeData.cpp" line="629"/>
         <source>Lap</source>
         <translation>Ronde</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="630"/>
+        <location filename="../../Train/RealtimeData.cpp" line="632"/>
         <source>Lap Time</source>
         <translation>Rondetijd</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="633"/>
+        <location filename="../../Train/RealtimeData.cpp" line="635"/>
         <source>Lap Time Remaining</source>
         <translation>Resterende Rondetijd</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="636"/>
+        <location filename="../../Train/RealtimeData.cpp" line="638"/>
         <source>Section Time Remaining</source>
         <translation>Resterende Sectietijd</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="639"/>
+        <location filename="../../Train/RealtimeData.cpp" line="641"/>
         <source>BikeStress</source>
         <translation>BikeStress</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="645"/>
+        <location filename="../../Train/RealtimeData.cpp" line="647"/>
         <source>kJoules</source>
         <translation>kJoules</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="648"/>
+        <location filename="../../Train/RealtimeData.cpp" line="650"/>
         <source>W&apos; bal</source>
         <translation>W&apos; bal</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="651"/>
+        <location filename="../../Train/RealtimeData.cpp" line="653"/>
         <source>XPower</source>
         <translation>XPower</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="654"/>
+        <location filename="../../Train/RealtimeData.cpp" line="656"/>
         <source>Iso Power</source>
         <translation>Genormaliseerd Vermogen</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="657"/>
+        <location filename="../../Train/RealtimeData.cpp" line="659"/>
         <source>Intensity Factor</source>
         <translation>Intensity Factor</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="660"/>
+        <location filename="../../Train/RealtimeData.cpp" line="662"/>
         <source>Relative Intensity</source>
         <translation>Relative Intensity</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="663"/>
+        <location filename="../../Train/RealtimeData.cpp" line="665"/>
         <source>Skiba Variability Index</source>
         <translation>Skiba Variability Index</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="666"/>
+        <location filename="../../Train/RealtimeData.cpp" line="668"/>
         <source>Variability Index</source>
         <translation>Variability Index</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="669"/>
+        <location filename="../../Train/RealtimeData.cpp" line="671"/>
         <source>Distance</source>
         <translation>Afstand</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="672"/>
+        <location filename="../../Train/RealtimeData.cpp" line="674"/>
         <source>Route Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="675"/>
+        <location filename="../../Train/RealtimeData.cpp" line="677"/>
         <source>Distance Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="678"/>
+        <location filename="../../Train/RealtimeData.cpp" line="680"/>
         <source>Alternate Power</source>
         <translation>Alternatief Vermogen</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="681"/>
+        <location filename="../../Train/RealtimeData.cpp" line="683"/>
         <source>Power</source>
         <translation>Vermogen</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="684"/>
+        <location filename="../../Train/RealtimeData.cpp" line="686"/>
         <source>Speed</source>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="687"/>
+        <location filename="../../Train/RealtimeData.cpp" line="689"/>
         <source>Virtual Speed</source>
         <translation>Virtuele Snelheid</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="690"/>
+        <location filename="../../Train/RealtimeData.cpp" line="692"/>
         <source>Cadence</source>
         <translation>Cadans</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="693"/>
+        <location filename="../../Train/RealtimeData.cpp" line="695"/>
         <source>Heart Rate</source>
         <translation>Hartslag</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="696"/>
+        <location filename="../../Train/RealtimeData.cpp" line="698"/>
         <source>Target Power</source>
         <translation>Doelvermogen</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="699"/>
+        <location filename="../../Train/RealtimeData.cpp" line="701"/>
         <source>Average Power</source>
         <translation>Gemiddelde Vermogen</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="702"/>
+        <location filename="../../Train/RealtimeData.cpp" line="704"/>
         <source>Average Speed</source>
         <translation>Gemiddelde Snelheid</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="705"/>
+        <location filename="../../Train/RealtimeData.cpp" line="707"/>
         <source>Average Heartrate</source>
         <translation>Gemiddelde Hartslag</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="708"/>
+        <location filename="../../Train/RealtimeData.cpp" line="710"/>
         <source>Average Cadence</source>
         <translation>Gemiddelde Cadans</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="711"/>
+        <location filename="../../Train/RealtimeData.cpp" line="713"/>
         <source>Lap Power</source>
         <translation>Ronde Vermogen</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="714"/>
+        <location filename="../../Train/RealtimeData.cpp" line="716"/>
         <source>Lap Speed</source>
         <translation>Ronde Snelheid</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="717"/>
+        <location filename="../../Train/RealtimeData.cpp" line="719"/>
         <source>Lap Heartrate</source>
         <translation>Ronde Hartslag</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="720"/>
+        <location filename="../../Train/RealtimeData.cpp" line="722"/>
         <source>Lap Cadence</source>
         <translation>Ronde Cadans</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="723"/>
+        <location filename="../../Train/RealtimeData.cpp" line="725"/>
         <source>Left/Right Balance</source>
         <translation>Left/Right Balans</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="726"/>
+        <location filename="../../Train/RealtimeData.cpp" line="728"/>
         <source>Total Hb Mass</source>
         <translation>Totale Hb Massa</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="729"/>
+        <location filename="../../Train/RealtimeData.cpp" line="731"/>
         <source>Hb O2 Saturation</source>
         <translation>Hb O2 Verzadiging</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="732"/>
+        <location filename="../../Train/RealtimeData.cpp" line="734"/>
         <source>Deoxy Hb</source>
         <translation>Deoxy Hb</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="735"/>
+        <location filename="../../Train/RealtimeData.cpp" line="737"/>
         <source>Oxy Hb</source>
         <translation>Oxy Hb</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="738"/>
+        <location filename="../../Train/RealtimeData.cpp" line="740"/>
         <source>Left Torque Effectiveness</source>
         <translation>Linker Koppel Effectiviteit</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="741"/>
+        <location filename="../../Train/RealtimeData.cpp" line="743"/>
         <source>Right Torque Effectiveness</source>
         <translation>Rechter Koppel Effectiviteit</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="744"/>
+        <location filename="../../Train/RealtimeData.cpp" line="746"/>
         <source>Left Pedal Smoothness</source>
         <translation>Linker Pedaal Gelijkmatigheid</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="747"/>
+        <location filename="../../Train/RealtimeData.cpp" line="749"/>
         <source>Right Pedal Smoothness</source>
         <translation>Rechter Pedaal Gelijkmatigheid</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="750"/>
+        <location filename="../../Train/RealtimeData.cpp" line="752"/>
         <source>Right Power Phase Start</source>
         <translation type="unfinished">Rechter Vermogensfase Start</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="753"/>
+        <location filename="../../Train/RealtimeData.cpp" line="755"/>
         <source>Right Power Phase End</source>
         <translation type="unfinished">Rechter Vermogensfase Eind</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="756"/>
+        <location filename="../../Train/RealtimeData.cpp" line="758"/>
         <source>Right Power Phase Peak Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="759"/>
+        <location filename="../../Train/RealtimeData.cpp" line="761"/>
         <source>Right Power Phase Peak End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="762"/>
+        <location filename="../../Train/RealtimeData.cpp" line="764"/>
         <source>Slope</source>
         <translation>Helling</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="765"/>
+        <location filename="../../Train/RealtimeData.cpp" line="767"/>
         <source>Lap Distance</source>
         <translation>Rondeafstand</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="768"/>
+        <location filename="../../Train/RealtimeData.cpp" line="770"/>
         <source>Lap Distance Remaining</source>
         <translation>Resterende Rondeafstand</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="771"/>
+        <location filename="../../Train/RealtimeData.cpp" line="773"/>
         <source>Latitude</source>
         <translation>Breedtegraad</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="774"/>
+        <location filename="../../Train/RealtimeData.cpp" line="776"/>
         <source>Longitude</source>
         <translation>Lengtegraad</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="777"/>
+        <location filename="../../Train/RealtimeData.cpp" line="779"/>
         <source>Altitude</source>
         <translation>Hoogte</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="780"/>
+        <location filename="../../Train/RealtimeData.cpp" line="782"/>
         <source>Respiratory Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="783"/>
+        <location filename="../../Train/RealtimeData.cpp" line="785"/>
         <source>Ventilation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="786"/>
+        <location filename="../../Train/RealtimeData.cpp" line="788"/>
         <source>VO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="789"/>
+        <location filename="../../Train/RealtimeData.cpp" line="791"/>
         <source>VCO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="792"/>
+        <location filename="../../Train/RealtimeData.cpp" line="794"/>
         <source>Respiratory Exchange Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="795"/>
+        <location filename="../../Train/RealtimeData.cpp" line="797"/>
         <source>Tidal Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="798"/>
+        <location filename="../../Train/RealtimeData.cpp" line="800"/>
         <source>Fraction O2 Expired</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="801"/>
+        <location filename="../../Train/RealtimeData.cpp" line="803"/>
         <source>Temperature</source>
         <translation type="unfinished">Temperatuur</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="804"/>
+        <location filename="../../Train/RealtimeData.cpp" line="806"/>
         <source>CoreTemp</source>
         <translation type="unfinished"></translation>
     </message>
@@ -27011,22 +26988,22 @@ Python is uitgeschakeld in de voorkeursinstellingen.</translation>
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Series</source>
         <translation>Reeksen</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Value</source>
         <translation>Waarde</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="172"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
         <source>Power</source>
         <translation>Vermogen</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="176"/>
         <source>Heart Rate</source>
         <translation>Hartslag</translation>
     </message>
@@ -29327,317 +29304,317 @@ eigen formaat. Zullen we dat doen?
 <context>
     <name>ScatterPlot</name>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="113"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
         <source>Power (watts)</source>
         <translation>Vermogen (Watts)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
         <source>Cadence (rpm)</source>
         <translation>Cadans (rpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="116"/>
         <source>Heartrate (bpm)</source>
         <translation>Hartslag (bpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="118"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="119"/>
         <source>Speed (kph)</source>
         <translation>Snelheid (kph)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="120"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="121"/>
         <source>Speed (mph)</source>
         <translation>Snelheid (mph)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="124"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="125"/>
         <source>Altitude (meters)</source>
         <translation>Hoogte (meters)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="126"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="127"/>
         <source>Altitude (feet)</source>
         <translation>Hoogte (voet)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="128"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
         <source>Torque (N)</source>
         <translation>Koppel (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="130"/>
         <source>Elapsed Time (secs)</source>
         <translation>Verstreken Tijd (secs)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="132"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="133"/>
         <source>Elapsed Distance (km)</source>
         <translation>Verstreken Afstand (km)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="134"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="135"/>
         <source>Elapsed Distance (mi)</source>
         <translation>Verstreken Afstand (mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="136"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
         <source>Interval Number</source>
         <translation>Interval Nummer</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
         <source>Latitude (degree offset)</source>
         <translation>Breedtegraad (graden offset)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
         <source>Longitude (degree offset)</source>
         <translation>Lengtegraad (graden offset)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
         <source>Circumferential Pedal Velocity (m/s)</source>
         <translation>Pedaal Omtreksnelheid (m/s)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="141"/>
         <source>Average Effective Pedal Force (N)</source>
         <translation>Gemiddelde Effectieve Pedaalkracht (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="144"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
         <source>Time at X/Y (%)</source>
         <translation>Tijd bij X/Y (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
         <source>Power Zone</source>
         <translation>Vermogenszone</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
         <source>Headwind (kph)</source>
         <translation>Tegenwind (kph)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
         <source>Slope (gradient)</source>
         <translation>Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
         <source>Temperature (C)</source>
         <translation>Temperatuur (C)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
         <source>L/R Balance</source>
         <translation>L/R Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
         <source>Torque Efficiency</source>
         <translation>Koppel Efficiëntie</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
         <source>Pedal Smoothness</source>
         <translation>Pedaal Gelijkmatigheid</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
         <source>Running Vertical Oscillation</source>
         <translation>Hardlopen Verticale Oscillatie</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
         <source>Running Ground Contact Time</source>
         <translation>Hardlopen Grondcontacttijd</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
         <source>Running Cadence</source>
         <translation>Hardlopen Cadans</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
         <source>Gear Ratio</source>
         <translation>Versnellingsratio</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
         <source>Muscle Oxygen</source>
         <translation>Spier Zuurstofgehalte</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
         <source>Haemoglobin Mass</source>
         <translation>Hemoglobine Massa</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
         <source>Deoxygenated Haemoglobin</source>
         <translation>Zuurstofarm Hemoglobine</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="160"/>
         <source>Oxygenated Haemoglobin</source>
         <translation>Zuurstofrijk Hemoglobine</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="161"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="162"/>
         <source>Unknown</source>
         <translation>Onbekend</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="165"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
         <source>Power</source>
         <translation>Vermogen</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
         <source>Cadence</source>
         <translation>Cadans</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
         <source>Heartrate</source>
         <translation>Hartslag</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
         <source>Speed</source>
         <translation>Snelheid</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
         <source>Altitude</source>
         <translation>Hoogte</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
         <source>Pedal Force</source>
         <translation>Pedaalkracht</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
         <source>Time</source>
         <translation>Tijd</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
         <source>Distance</source>
         <translation>Afstand</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
         <source>Interval</source>
         <translation>Interval</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
         <source>Latitude</source>
         <translation>Breedtegraad</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
         <source>Longitude</source>
         <translation>Lengtegraad</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
         <source>Time at X/Y</source>
         <translation>Tijd bij X/Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
         <source>Zone</source>
         <translation>Zone</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
         <source>CPV</source>
         <translation>CPV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
         <source>AEPF</source>
         <translation>AEPF</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
         <source>Headwind</source>
         <translation>Tegenwind</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
         <source>Slope</source>
         <translation>Helling</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
         <source>Temp</source>
         <translation>Temp</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
         <source>Balance</source>
         <translation>Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
         <source>TE</source>
         <translation>TE</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
         <source>PS</source>
         <translation>PS</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
         <source>RV</source>
         <translation>RV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
         <source>GCT</source>
         <translation>GCT</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
         <source>Run Cad</source>
         <translation>Hardloop Cad</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
         <source>Gear</source>
         <translation>Uitrusting</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="194"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="195"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="196"/>
         <source>None</source>
         <translation>Geen</translation>
     </message>
@@ -29875,42 +29852,38 @@ eigen formaat. Zullen we dat doen?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1006"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1007"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1012"/>
         <source>Add</source>
-        <translation>Toevoegen</translation>
+        <translation type="vanished">Toevoegen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1013"/>
         <source>Delete</source>
-        <translation>Verwijderen</translation>
+        <translation type="vanished">Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1023"/>
+        <location filename="../../Gui/AthletePages.cpp" line="982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="988"/>
         <source>Short</source>
         <translation>Kort</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="989"/>
         <source>Long</source>
         <translation>Lang</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1031"/>
+        <location filename="../../Gui/AthletePages.cpp" line="990"/>
         <source>Percent of CP</source>
         <translation>Percentage van CP</translation>
     </message>
@@ -29919,14 +29892,14 @@ eigen formaat. Zullen we dat doen?
         <translation type="vanished">Maximum van 10 zones bereikt.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1069"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1076"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1034"/>
         <source>New</source>
         <translation>Nieuw</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1071"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1078"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1036"/>
         <source>New (%1)</source>
         <translation>Nieuw (%1)</translation>
     </message>
@@ -30099,64 +30072,64 @@ eigen formaat. Zullen we dat doen?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3804"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3835"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3583"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3805"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3836"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3553"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3584"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3806"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3837"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3554"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3585"/>
         <source>From</source>
         <translation>Vanaf</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3807"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3838"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3555"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3586"/>
         <source>To</source>
         <translation>Tot</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3557"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3810"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3558"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3821"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3569"/>
         <source>Add</source>
         <translation>Toevoegen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3822"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3570"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3823"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3571"/>
         <source>Up</source>
         <translation>Op</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3824"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3572"/>
         <source>Down</source>
         <translation>Neer</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3870"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3872"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3963"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3965"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3711"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3713"/>
         <source>ddd MMM d, yyyy</source>
         <translation>ddd MMM d, yyyy</translation>
     </message>
@@ -32464,25 +32437,25 @@ tab.</source>
 <context>
     <name>TrainSidebar</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="253"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="257"/>
         <source>Save workout data</source>
         <translation>Bewaar Trainingsdata</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="259"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="263"/>
         <source>Devices</source>
         <translation>Apparaten</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="262"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="267"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="311"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="321"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="271"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="315"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="325"/>
         <source>Menu</source>
         <translation>Menu</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="270"/>
         <source>Workouts</source>
         <translation>Trainingen</translation>
     </message>
@@ -32491,227 +32464,227 @@ tab.</source>
         <translation type="obsolete">Filter...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="303"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="307"/>
         <source>Workout Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="310"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="314"/>
         <source>Media</source>
         <translation>Media</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="320"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="324"/>
         <source>VideoSync</source>
         <translation>VideoSync</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="506"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
         <source>Import Workout from File</source>
         <translation>Training Importeren vanuit Bestand</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="507"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="511"/>
         <source>Get Workouts from TrainerDay</source>
         <translation>Trainingen Ophalen vanuit de TrainerDay</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="508"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="512"/>
         <source>Get Workouts from Strava Routes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="509"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="513"/>
         <source>Create Workout via Wizard</source>
         <translation>Training Creëeren met Assistent</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="514"/>
         <source>Scan for Workouts</source>
         <translation>Trainingen Zoeken</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="534"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="538"/>
         <source>Delete selected Workout</source>
         <translation>Geselecteerde Training Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="541"/>
         <source>Delete %1 selected Workouts</source>
         <translation>%1 Geselecteerde Trainingen Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Train mode active</source>
         <translation>Train modus actief</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Please stop the train mode before closing the window or application.</source>
         <translation>Stop de train modus voordat je het scherm of applicatie verlaat alsjeblieft.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="621"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="625"/>
         <source>Import Video from File</source>
         <translation>Video Importeren vanuit Bestand</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="622"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="626"/>
         <source>Scan for Videos</source>
         <translation>Videos Zoeken</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="635"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="639"/>
         <source>Remove reference to selected video</source>
         <translation>Verwijder referentie naar geselecteerde video</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="650"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="654"/>
         <source>Import VideoSync from File</source>
         <translation>Importeer VideoSync vanuit Bestand</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="651"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="655"/>
         <source>Scan for VideoSyncs</source>
         <translation>Zoek naar VideoSyncs</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="668"/>
         <source>Delete selected VideoSync</source>
         <translation>Geselecteerde VideoSync Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1064"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1068"/>
         <source>Are you sure you want to remove the reference to this video?</source>
         <translation>Ben je zeker van het verwijderen van de referentie naar deze video?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1066"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1128"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1204"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1070"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1132"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1208"/>
         <source>Remove</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1099"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1103"/>
         <source>Are you sure you want to delete this VideoSync?</source>
         <translation>Ben je zeker van het verwijderen van deze VideoSync?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1101"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1173"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3183"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1105"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1177"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3195"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1126"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1130"/>
         <source>The VideoSync file is either not valid or not existing and will be removed from the library.</source>
         <translation>Het VideoSync bestand is niet geldig of bestaat niet en zal daarom verwijderd worden uit de bibliotheek.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1160"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1164"/>
         <source>Are you sure you want to delete this Workout?</source>
         <translation>Ben je zeker van het verwijderen van deze Training?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1163"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1167"/>
         <source>Are you sure you want to delete this %1 workouts?</source>
         <translation>Ben je zeker van het verwijderen van deze %1 Trainingen?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1202"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1206"/>
         <source>The Workout file is either not valid or not existing and will be removed from the library.</source>
         <translation>Het Trainingsbestand is niet geldig of bestaat niet en zal daarom verwijderd worden uit de bibliotheek.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1309"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1313"/>
         <source>Resuming..</source>
         <translation>Hervatten..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1336"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1340"/>
         <source>Paused..</source>
         <translation>Gepauzeerd..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1347"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1351"/>
         <source>Starting in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1465"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1469"/>
         <source>Starting..</source>
         <translation>Gestart..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1673"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1677"/>
         <source>Stopped..</source>
         <translation>Gestopt..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1763"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1769"/>
         <source>Connected..</source>
         <translation>Verbonden..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1787"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1793"/>
         <source>Disconnected..</source>
         <translation>Verbroken..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2198"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2210"/>
         <source>New lap..</source>
         <translation>Nieuwe ronde..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2225"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2237"/>
         <source>Recalibrating steering..</source>
         <translation>Sturen herkalibreren..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>No Devices Configured</source>
         <translation>Geen Apparaten zijn Ingesteld</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>Please configure a device in Preferences.</source>
         <translation>Stel een apparaat in bij Voorkeuren alsjeblieft.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2483"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2495"/>
         <source>Exiting calibration..</source>
         <translation>Kalibratie verlaten..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2498"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2510"/>
         <source>Calibration not supported for this device.</source>
         <translation>Kalibratie niet ondersteund van dit apparaat.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2505"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2517"/>
         <source>Calibrating...
 Press F3 on Controller when done.</source>
         <translation>Kalibreren...
 Druk F3 op de Controller als het voltooid is.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2521"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2525"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2594"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2645"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2649"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2533"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2606"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2657"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2661"/>
         <source>Requesting calibration..</source>
         <translation>Kalibratie aanvragen..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2532"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2544"/>
         <source>Calibrating...</source>
         <translation>Kalibreren...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2536"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2548"/>
         <source>Calibrating...
 Current speed %1 kph
 Increase speed to %2 kph</source>
@@ -32720,14 +32693,14 @@ Huidige snelheid %1 kph
 Breng snelheid op %2 kph</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2540"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2552"/>
         <source>Calibrating...
 Stop pedalling until speed drops to 0</source>
         <translation>Kalibreren...
 Stop met trappen totdat de snelheid tot 0 is gekomen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2545"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2557"/>
         <source>Calibration completed successfully!
 Spindown %1 ms
 Zero Offset %2</source>
@@ -32736,30 +32709,30 @@ Uitrollen %1 ms
 Nul Offset %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2553"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2620"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2672"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2565"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2632"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2684"/>
         <source>Calibration failed!</source>
         <translation>Kalibratie mislukt!</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2573"/>
         <source>Calibration Failed: Loosen Roller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2569"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2581"/>
         <source>Calibration Failed: Tighten Roller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2588"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2639"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2600"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2651"/>
         <source>Unclip or stop pedalling to begin calibration..</source>
         <translation>Klik-uit of stop met trappen om te beginnen met kalibreren..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2607"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2619"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Torque %1</source>
@@ -32768,7 +32741,7 @@ Klik-uit of stop met trappen totdat het proces is geëindigd..
 Koppel %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2612"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2624"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Torque %2</source>
@@ -32777,7 +32750,7 @@ Uitrollen %1 ms
 Nul Offset %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2659"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2671"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Zero Offset %1</source>
@@ -32786,7 +32759,7 @@ Klik-uit of stop met trappen totdat het proces is geëindigd..
 Nul Offset  %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2676"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Slope %2</source>
@@ -32795,85 +32768,85 @@ Uitrollen %1 ms
 Helling %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2693"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2705"/>
         <source>Give the pedal a kick to start calibration...
 The motor will run until calibration is complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2695"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
         <source>Allow wheel speed to settle, DO NOT PEDAL...
 The motor will run until calibration is complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2700"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2712"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Gathering enough samples to calculate average: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2719"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Waiting for value to stabilize (max %1s): %2 (%3W @ %4kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2722"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
         <source>Calibration completed successfully!
 Final calibration value %1 (%2W @ %3kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2746"/>
         <source>Calibration failed! Do not pedal while calibration is taking place.
 Allow wheel to run freely.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2780"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2792"/>
         <source>Fast forward..</source>
         <translation>Snel vooruit..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2813"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2825"/>
         <source>Rewind..</source>
         <translation>Achteruit..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2843"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2855"/>
         <source>Next Lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2876"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2888"/>
         <source>Back Lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2902"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2914"/>
         <source>Increasing intensity..</source>
         <translation>Verhoog intensiteit..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2928"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2940"/>
         <source>Decreasing intensity..</source>
         <translation>Verlaag intensiteit..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3135"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3153"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3147"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3165"/>
         <source>Add Device</source>
         <translation>Apparaat Toevoegen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3140"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3158"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3152"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3170"/>
         <source>Delete Device</source>
         <translation>Apparaat Verwijderen</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3181"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3193"/>
         <source>Are you sure you want to delete this device?</source>
         <translation>Ben je zeker van het verwijderen van dit apparaat?</translation>
     </message>
@@ -33190,7 +33163,7 @@ Allow wheel to run freely.</source>
 <context>
     <name>UniqueLabelEditDelegate</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="77"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="108"/>
         <source>The given value &quot;%1&quot; is not unique</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33206,171 +33179,167 @@ Allow wheel to run freely.</source>
 <context>
     <name>UserChartSettings</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="772"/>
+        <location filename="../../Charts/UserChart.cpp" line="773"/>
         <source>Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="782"/>
+        <location filename="../../Charts/UserChart.cpp" line="783"/>
         <source>Sub-title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="785"/>
+        <location filename="../../Charts/UserChart.cpp" line="786"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="791"/>
+        <location filename="../../Charts/UserChart.cpp" line="792"/>
         <source>Line Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="792"/>
+        <location filename="../../Charts/UserChart.cpp" line="793"/>
         <source>Scatter Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="793"/>
+        <location filename="../../Charts/UserChart.cpp" line="794"/>
         <source>Bar Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="794"/>
+        <location filename="../../Charts/UserChart.cpp" line="795"/>
         <source>Stacked Bar Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="795"/>
+        <location filename="../../Charts/UserChart.cpp" line="796"/>
         <source>Stacked Percent Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="796"/>
+        <location filename="../../Charts/UserChart.cpp" line="797"/>
         <source>Pie Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="800"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="801"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="804"/>
+        <location filename="../../Charts/UserChart.cpp" line="805"/>
         <source>Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="805"/>
+        <location filename="../../Charts/UserChart.cpp" line="806"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="808"/>
+        <location filename="../../Charts/UserChart.cpp" line="809"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="812"/>
+        <location filename="../../Charts/UserChart.cpp" line="813"/>
         <source>None</source>
         <translation type="unfinished">Geen</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="813"/>
+        <location filename="../../Charts/UserChart.cpp" line="814"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="814"/>
+        <location filename="../../Charts/UserChart.cpp" line="815"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="815"/>
+        <location filename="../../Charts/UserChart.cpp" line="816"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="816"/>
+        <location filename="../../Charts/UserChart.cpp" line="817"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="820"/>
+        <location filename="../../Charts/UserChart.cpp" line="821"/>
         <source>Legend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="829"/>
+        <location filename="../../Charts/UserChart.cpp" line="830"/>
         <source>Font scaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="831"/>
-        <location filename="../../Charts/UserChart.cpp" line="833"/>
+        <location filename="../../Charts/UserChart.cpp" line="832"/>
+        <location filename="../../Charts/UserChart.cpp" line="834"/>
         <source>Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="836"/>
+        <location filename="../../Charts/UserChart.cpp" line="837"/>
         <source>Animate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="838"/>
+        <location filename="../../Charts/UserChart.cpp" line="839"/>
         <source>Single series per plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="841"/>
+        <location filename="../../Charts/UserChart.cpp" line="842"/>
         <source>Refresh for intervals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="848"/>
+        <location filename="../../Charts/UserChart.cpp" line="849"/>
         <source>Series</source>
         <translation type="unfinished">Reeksen</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Name</source>
         <translation type="unfinished">Naam</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Y Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="870"/>
-        <location filename="../../Charts/UserChart.cpp" line="932"/>
         <source>Edit</source>
-        <translation type="unfinished">Bewerken</translation>
+        <translation type="obsolete">Bewerken</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="889"/>
         <source>Up</source>
-        <translation type="unfinished">Op</translation>
+        <translation type="obsolete">Op</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="890"/>
         <source>Down</source>
-        <translation type="unfinished">Neer</translation>
+        <translation type="obsolete">Neer</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="911"/>
+        <location filename="../../Charts/UserChart.cpp" line="885"/>
         <source>Axes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34036,72 +34005,72 @@ Allow wheel to run freely.</source>
 <context>
     <name>VideoWindow</name>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> kph</source>
         <translation> kph</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="119"/>
+        <location filename="../../Train/VideoWindow.cpp" line="144"/>
         <source>Meters layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="127"/>
+        <location filename="../../Train/VideoWindow.cpp" line="152"/>
         <source>Reset Meters layout to default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> m</source>
         <translation type="unfinished"> m</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> feet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="625"/>
+        <location filename="../../Train/VideoWindow.cpp" line="681"/>
         <source>w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="629"/>
+        <location filename="../../Train/VideoWindow.cpp" line="685"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> km</source>
         <translation type="unfinished"> km</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> mi</source>
         <translation type="unfinished"> mi</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="673"/>
+        <location filename="../../Train/VideoWindow.cpp" line="729"/>
         <source>Calibration required</source>
         <translation>Calibratie nodig</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="678"/>
+        <location filename="../../Train/VideoWindow.cpp" line="734"/>
         <source>Configuration required</source>
         <translation>Instellingen nodig</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="683"/>
+        <location filename="../../Train/VideoWindow.cpp" line="739"/>
         <source>brake fault</source>
         <translation>rem fout</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="688"/>
+        <location filename="../../Train/VideoWindow.cpp" line="744"/>
         <source>Ready</source>
         <translation>Klaar</translation>
     </message>
@@ -34536,27 +34505,27 @@ Allow wheel to run freely.</source>
 <context>
     <name>WheelSizeCalculator</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="202"/>
+        <location filename="../../Gui/AthletePages.cpp" line="187"/>
         <source>Wheel Size Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="221"/>
+        <location filename="../../Gui/AthletePages.cpp" line="206"/>
         <source>Rim Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="222"/>
+        <location filename="../../Gui/AthletePages.cpp" line="207"/>
         <source>Tire Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="223"/>
+        <location filename="../../Gui/AthletePages.cpp" line="208"/>
         <source>Wheel Size</source>
         <translation type="unfinished">Wielmaat</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="227"/>
         <source>mm</source>
         <translation type="unfinished">mm</translation>
     </message>
@@ -34668,12 +34637,12 @@ Allow wheel to run freely.</source>
 <context>
     <name>WorkoutFilterBox</name>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="34"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="44"/>
         <source>Filter...</source>
         <translation type="unfinished">Filter...</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="64"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="95"/>
         <source>ERROR: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34681,12 +34650,12 @@ Allow wheel to run freely.</source>
 <context>
     <name>WorkoutImportDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="820"/>
+        <location filename="../../Train/Library.cpp" line="809"/>
         <source>Import to Library</source>
         <translation>Importeer in Bibliotheek</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="854"/>
+        <location filename="../../Train/Library.cpp" line="843"/>
         <source>Please note, that when importing or drag and dropping videos into the library we DO NOT copy the file into the GoldenCheetah library, instead we add a REFERENCE to it. We DO copy workout and videoSync files, since they are smaller.
 
 You can remove references when managing the library via the context menu options</source>
@@ -34695,24 +34664,107 @@ You can remove references when managing the library via the context menu options
 Je kunt referenties verwijderen als je de bibliotheek beheert via de contextmenu opties</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="868"/>
+        <location filename="../../Train/Library.cpp" line="857"/>
         <source>Files</source>
         <translation>Bestanden</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="878"/>
+        <location filename="../../Train/Library.cpp" line="867"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="880"/>
+        <location filename="../../Train/Library.cpp" line="869"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="884"/>
+        <location filename="../../Train/Library.cpp" line="873"/>
         <source>Overwite existing files</source>
         <translation>Overschrijf bestaande bestanden</translation>
+    </message>
+</context>
+<context>
+    <name>WorkoutMenuProvider</name>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="271"/>
+        <source>Select Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="274"/>
+        <source>Manage Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="275"/>
+        <source>Add Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="289"/>
+        <source>Add Tag to Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="292"/>
+        <source>Filter Tags...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="310"/>
+        <source>Match all selected tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="353"/>
+        <source>Manage Workout Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="360"/>
+        <source>Name</source>
+        <translation type="unfinished">Naam</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="361"/>
+        <source>Filter</source>
+        <translation type="unfinished">Filter</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="362"/>
+        <source>_index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="370"/>
+        <source>Execute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="371"/>
+        <source>Update</source>
+        <translation type="unfinished">Update</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="423"/>
+        <source>Add Workout Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="426"/>
+        <source>Name of the Filter...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="467"/>
+        <source>New</source>
+        <translation type="unfinished">Nieuw</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="469"/>
+        <source>New (%1)</source>
+        <translation type="unfinished">Nieuw (%1)</translation>
     </message>
 </context>
 <context>
@@ -34727,41 +34779,41 @@ Je kunt referenties verwijderen als je de bibliotheek beheert via de contextmenu
     <name>WorkoutPlotWindow</name>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="40"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="104"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
         <source>Ergmode specific settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="46"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
         <source>Color power zones</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="48"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="56"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="49"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="50"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="57"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="109"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="113"/>
         <source>When stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="54"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="110"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
         <source>Show tooltip</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34855,12 +34907,12 @@ Je kunt referenties verwijderen als je de bibliotheek beheert via de contextmenu
 <context>
     <name>WorkoutWidget</name>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="1531"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="1532"/>
         <source>File save failed.</source>
         <translation>Bestand Bewaren mislukt.</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="2367"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="2368"/>
         <source>Intensity</source>
         <translation>Intensiteit</translation>
     </message>
@@ -35014,26 +35066,22 @@ Je kunt referenties verwijderen als je de bibliotheek beheert via de contextmenu
 <context>
     <name>XDataDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="44"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="45"/>
         <source>xData</source>
         <translation>xData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="58"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="59"/>
         <source>Data Series</source>
         <translation>Datareeksen</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="78"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="80"/>
         <source>Add</source>
-        <translation>Toevoegen</translation>
+        <translation type="vanished">Toevoegen</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="79"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="81"/>
         <source>Delete</source>
-        <translation>Verwijderen</translation>
+        <translation type="vanished">Verwijderen</translation>
     </message>
 </context>
 <context>
@@ -35110,32 +35158,32 @@ Je kunt referenties verwijderen als je de bibliotheek beheert via de contextmenu
 <context>
     <name>XDataSeriesSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="333"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="315"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="338"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="320"/>
         <source>Units</source>
         <translation>Eenheden</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="346"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="328"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="347"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="329"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Name is blank</source>
         <translation>Naam is leeg</translation>
     </message>
@@ -35143,48 +35191,48 @@ Je kunt referenties verwijderen als je de bibliotheek beheert via de contextmenu
 <context>
     <name>XDataSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="262"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="244"/>
         <source>xData</source>
         <translation>xData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="269"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="251"/>
         <source>Data Series</source>
         <translation>Datareeksen</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="270"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="252"/>
         <source>Units</source>
         <translation>Eenheden</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="274"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="256"/>
         <source>Series %1</source>
         <translation>Series %1</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="281"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="263"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="282"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="264"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
         <source>XData name is blank</source>
         <translation>XData naam is leeg</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Must have at least one data series.</source>
         <translation>Heb minimaal één datareeks nodig.</translation>
     </message>
@@ -35505,17 +35553,17 @@ Je kunt referenties verwijderen als je de bibliotheek beheert via de contextmenu
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="915"/>
+        <location filename="../../Gui/AthletePages.cpp" line="886"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="962"/>
+        <location filename="../../Gui/AthletePages.cpp" line="933"/>
         <source>Critical Power</source>
         <translation>Critical Power</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="963"/>
+        <location filename="../../Gui/AthletePages.cpp" line="934"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>

--- a/src/Resources/translations/gc_pt-br.ts
+++ b/src/Resources/translations/gc_pt-br.ts
@@ -91,38 +91,38 @@ It might be necessary to manually disable it.</source>
 <context>
     <name>AboutModelPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="504"/>
+        <location filename="../../Gui/AthletePages.cpp" line="489"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="517"/>
-        <location filename="../../Gui/AthletePages.cpp" line="522"/>
+        <location filename="../../Gui/AthletePages.cpp" line="502"/>
+        <location filename="../../Gui/AthletePages.cpp" line="507"/>
         <source>days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="525"/>
+        <location filename="../../Gui/AthletePages.cpp" line="510"/>
         <source>PMC Stress Balance Today</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="528"/>
+        <location filename="../../Gui/AthletePages.cpp" line="513"/>
         <source>Restore Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="517"/>
         <source>W&apos;bal tau</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="518"/>
         <source>Short Term Stress (STS) average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="534"/>
+        <location filename="../../Gui/AthletePages.cpp" line="519"/>
         <source>Long Term Stress (LTS) average</source>
         <translation type="unfinished"></translation>
     </message>
@@ -138,96 +138,96 @@ It might be necessary to manually disable it.</source>
 <context>
     <name>AboutRiderPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="372"/>
+        <location filename="../../Gui/AthletePages.cpp" line="357"/>
         <source>Nickname</source>
         <translation type="unfinished">Apelido</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="373"/>
+        <location filename="../../Gui/AthletePages.cpp" line="358"/>
         <source>Date of Birth</source>
         <translation type="unfinished">Data de Nascimento</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="374"/>
+        <location filename="../../Gui/AthletePages.cpp" line="359"/>
         <source>Sex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="376"/>
+        <location filename="../../Gui/AthletePages.cpp" line="361"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="375"/>
+        <location filename="../../Gui/AthletePages.cpp" line="360"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="279"/>
+        <location filename="../../Gui/AthletePages.cpp" line="264"/>
         <source>Male</source>
         <translation type="unfinished">Masculino</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="280"/>
+        <location filename="../../Gui/AthletePages.cpp" line="265"/>
         <source>Female</source>
         <translation type="unfinished">Feminino</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> kg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> lb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> cm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="359"/>
+        <location filename="../../Gui/AthletePages.cpp" line="344"/>
         <source>Calculate...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="378"/>
+        <location filename="../../Gui/AthletePages.cpp" line="363"/>
         <source>Bike</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="379"/>
+        <location filename="../../Gui/AthletePages.cpp" line="364"/>
         <source>Crank Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="380"/>
+        <location filename="../../Gui/AthletePages.cpp" line="365"/>
         <source>Wheelsize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="438"/>
+        <location filename="../../Gui/AthletePages.cpp" line="423"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="356"/>
+        <location filename="../../Gui/AthletePages.cpp" line="341"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="437"/>
+        <location filename="../../Gui/AthletePages.cpp" line="422"/>
         <source>Choose Picture</source>
         <translation type="unfinished">Escolher Foto</translation>
     </message>
@@ -2220,397 +2220,382 @@ Press Next to Continue
 <context>
     <name>AllPlotWindow</name>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="190"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="444"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="165"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
         <source>Smooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="198"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="173"/>
         <source>Stacked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="199"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="174"/>
         <source>by series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="200"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="175"/>
         <source>Fullplot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="201"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="176"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="239"/>
         <source>Overlay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="229"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="204"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="206"/>
         <source>Stack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="210"/>
         <source>By Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="246"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="221"/>
         <source>Stack Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="248"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="223"/>
         <source>Full plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="227"/>
         <source>Show Interval Markers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="256"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
         <source>Interval Navigator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="260"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
         <source>Hover intervals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="268"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="243"/>
         <source>Fill Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="247"/>
         <source>Grid</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="277"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
         <source>Acceleration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="279"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="254"/>
         <source>Delta Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="280"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="255"/>
         <source>Power %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="283"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="258"/>
         <source>Cadence %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="261"/>
         <source>Torque %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="289"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
         <source>Heartrate %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="295"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="270"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="274"/>
         <source>Torque Effectiveness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="303"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="278"/>
         <source>Smoothness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="282"/>
         <source>Pedal Center Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="311"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
         <source>Power Phase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="290"/>
         <source>Peak Power Phase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="322"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
         <source>Vertical Oscillation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="324"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
         <source>Running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="326"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="301"/>
         <source>Ground Contact Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
         <source>Cadence </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="313"/>
         <source>SmO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="340"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
         <source>Moxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="317"/>
         <source>tHb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="321"/>
         <source>O2Hb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="325"/>
         <source>HHb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="355"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="330"/>
         <source>Heart Rate</source>
         <translation>Frequência Cardíaca</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="357"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
         <source>Data series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="359"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="334"/>
         <source>Core Temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="363"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="367"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
         <source>Cadence</source>
         <translation>Cadência</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="94"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="95"/>
         <source>Basic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="109"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="110"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="116"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="117"/>
         <source>User Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="132"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="134"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="144"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="163"/>
-        <source>Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="164"/>
-        <source>Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="371"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
         <source>Altitude</source>
         <translation>Altitude</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
         <source>Temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="379"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="354"/>
         <source>Headwind</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="383"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="358"/>
         <source>Torque</source>
         <translation type="unfinished">Torque</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="387"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="362"/>
         <source>Gear Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="391"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="366"/>
         <source>Slope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="373"/>
         <source>No Alt/Slope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="399"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="374"/>
         <source>0.1km|mi -  1min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="400"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
         <source>0.5km|mi -  5min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="401"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="376"/>
         <source>1.0km|mi - 10min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1528"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="377"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="1503"/>
         <source>Alt/Slope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="382"/>
         <source>Anaerobic TISS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="384"/>
         <source>Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="411"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="386"/>
         <source>Aerobic TISS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="390"/>
         <source>Iso Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="394"/>
         <source>Skiba xPower</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="423"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
         <source>Altitude Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="427"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
         <source>W&apos; balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="441"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="416"/>
         <source>Time of day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="742"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="717"/>
         <source>Intervals</source>
         <translation type="unfinished">Intervalos</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="2253"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="2228"/>
         <source>Selection #%1 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="432"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
         <source>Power + shade</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="433"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="408"/>
         <source>Power - shade</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="434"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
         <source>No Power</source>
         <translation>Sem Potência</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="435"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="410"/>
         <source>Shading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="439"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="414"/>
         <source>Time</source>
         <translation type="unfinished">Tempo</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="440"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
         <source>Distance</source>
         <translation type="unfinished">Distância</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="442"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="417"/>
         <source>X Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3416,47 +3401,25 @@ Press Next to Continue
 <context>
     <name>AutoImportPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4028"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4029"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4040"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4041"/>
         <source>Delete</source>
-        <translation type="unfinished">Excluir</translation>
+        <translation type="obsolete">Excluir</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4042"/>
-        <source>Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4043"/>
-        <source>Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4054"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3779"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4059"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3784"/>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4060"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3785"/>
         <source>Import Rule</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4270,37 +4233,37 @@ Press Next to Continue
 <context>
     <name>BackupPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="608"/>
+        <location filename="../../Gui/AthletePages.cpp" line="593"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="601"/>
         <source>every</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="617"/>
+        <location filename="../../Gui/AthletePages.cpp" line="602"/>
         <source>times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="603"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="605"/>
         <source>Backup now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="623"/>
+        <location filename="../../Gui/AthletePages.cpp" line="608"/>
         <source>Auto Backup Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="624"/>
+        <location filename="../../Gui/AthletePages.cpp" line="609"/>
         <source>Auto Backup after closing the athlete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5098,283 +5061,267 @@ Let&apos;s get you setup.</source>
 <context>
     <name>CPPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1202"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1203"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1204"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1150"/>
         <source>Review...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1206"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1152"/>
         <source>Changed power estimates are available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1213"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1225"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1214"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1226"/>
         <source>Delete</source>
-        <translation type="unfinished">Excluir</translation>
+        <translation type="obsolete">Excluir</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1216"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1158"/>
         <source>Def</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1218"/>
         <source>Critical Power</source>
         <translation>Potência Crítica</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1305"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>AeTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1306"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>FTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1307"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1221"/>
         <source>W&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1308"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1222"/>
         <source>Pmax</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1347"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1261"/>
         <source>Short</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1247"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1169"/>
         <source>Use CP for all metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1240"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1162"/>
         <source>Manual</source>
         <translation type="unfinished">Manual</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1241"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1163"/>
         <source>Semi-Automatic (CP2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1164"/>
         <source>Semi-Automatic (CP3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1243"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1165"/>
         <source>Semi-Automatic (Extended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1170"/>
         <source>Use FTP for Coggan metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1273"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1279"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1285"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1342"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1618"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1631"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2283"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2289"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2310"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1187"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1193"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1199"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1211"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1537"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1545"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2180"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2186"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2194"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2207"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1205"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1547"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2201"/>
         <source>J</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1303"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1217"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2145"/>
         <source>Start Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1309"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1223"/>
         <source>Model Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1262"/>
         <source>Long</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1349"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1263"/>
         <source>From Watts</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1598"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1512"/>
         <source>Review range starting on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1614"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1528"/>
         <source>Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1615"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1529"/>
         <source>Estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1530"/>
         <source>Accept</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1788"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1691"/>
         <source>🗹</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1692"/>
         <source>Estimate and settings &lt;b&gt;match&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1695"/>
         <source>☐</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1696"/>
         <source>Estimate and settings &lt;b&gt;differ&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1797"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1700"/>
         <source>⏲</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1800"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1703"/>
         <source>Range is %1 days older than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1802"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1705"/>
         <source>Range is %1 days younger than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1808"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1711"/>
         <source>∅</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1712"/>
         <source>No estimate available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1902"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1805"/>
         <source>New range from estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2237"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2134"/>
         <source>The proposed value for AeTP is a very rough estimate, assuming %1 % of CP. Usually it is determined by a&lt;ul&gt;&lt;li&gt;Metabolic test&lt;/li&gt;&lt;li&gt;Lactate ramp test&lt;/li&gt;&lt;li&gt;Run / Cycling ‘conversational’ test&lt;/li&gt;&lt;li&gt;Run Decoupling test&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2239"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2136"/>
         <source>Updating FTP internally to match CP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2139"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2244"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2141"/>
         <source>Your selected model does not deliver values for PMax, using default value of %1 W instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2246"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2143"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;li&gt;PMax, assuming a default of %1 W&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2250"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2147"/>
         <source>Critical Power (CP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2252"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2149"/>
         <source>Aerobic Threshold Power (AeTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2254"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2151"/>
         <source>Functional Threshold Power (FTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2153"/>
         <source>Anaerobic Work Capacity (W&apos;)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2258"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2155"/>
         <source>Maximum Power (PMax)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2270"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2167"/>
         <source>Manual range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2018"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2025"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1917"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1924"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2020"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1919"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1926"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5818,89 +5765,73 @@ ddd, dd MMM yyyy</source>
 <context>
     <name>CVPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3307"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3319"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3308"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3320"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3313"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3325"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3314"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3326"/>
         <source>Delete</source>
-        <translation type="unfinished">Excluir</translation>
+        <translation type="obsolete">Excluir</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3316"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3109"/>
         <source>Def</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3359"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3506"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3272"/>
         <source>Start Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3249"/>
         <source>New range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3507"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3273"/>
         <source>Critical Velocity (CV)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3508"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3274"/>
         <source>Aerobic Threshold (AeT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3360"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3128"/>
         <source>Critical Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3361"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3129"/>
         <source>Aerobic Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3403"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
         <source>Short</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3404"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3172"/>
         <source>Long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3405"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3173"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3679"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3686"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3441"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3448"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3681"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3688"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3443"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3450"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7424,37 +7355,20 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>CredentialsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="67"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
+        <source>Add</source>
+        <translation type="obsolete">Adicionar</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="obsolete">Excluir</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="68"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="69"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="74"/>
-        <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="75"/>
-        <source>Delete</source>
-        <translation type="unfinished">Excluir</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="86"/>
         <source>Service</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="87"/>
+        <location filename="../../Gui/AthletePages.cpp" line="69"/>
         <source>Description</source>
         <translation type="unfinished">Descrição</translation>
     </message>
@@ -8129,7 +8043,7 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>DataFilterEdit</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2743"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2712"/>
         <source>Warning: sample() is slow -- update code to use samples()</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8464,7 +8378,7 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>DirectoryPathWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="277"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="308"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8695,28 +8609,28 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>Dropbox</name>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="68"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="77"/>
         <source>Problem accessing Dropbox data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="130"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="139"/>
         <source>You must authorise with Dropbox first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="205"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="214"/>
         <source>Parsing Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="293"/>
-        <location filename="../../Cloud/Dropbox.cpp" line="312"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="302"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="321"/>
         <source>Completed.</source>
         <translation type="unfinished">Concluído.</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="297"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="306"/>
         <source>Network Error - Upload failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8857,136 +8771,136 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2064"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2033"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2034"/>
         <source>Axis Label / Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1597"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1566"/>
         <source>Curve Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1558"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1527"/>
         <source>Estimate %1 %2 Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1562"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1531"/>
         <source>Endurance Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1532"/>
         <source>Vo2Max Estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1605"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1574"/>
         <source>Metric</source>
         <translation type="unfinished">Métrico</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1606"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1575"/>
         <source>Best</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1607"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1576"/>
         <source>Estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1577"/>
         <source>PMC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1609"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1578"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1610"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1579"/>
         <source>Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1611"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1580"/>
         <source>Performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1612"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1581"/>
         <source>Banister</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1684"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1767"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1653"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1736"/>
         <source>seconds</source>
         <translation type="unfinished">segundos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1685"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1768"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1737"/>
         <source>minutes</source>
         <translation type="unfinished">minutos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1769"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1655"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1738"/>
         <source>hours</source>
         <translation type="unfinished">horas</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1723"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1816"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1692"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1785"/>
         <source>Peak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1781"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1750"/>
         <source>Absolute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1751"/>
         <source>Per Kilogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1813"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
         <source>Total</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1814"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1783"/>
         <source>Running Total</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1815"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1784"/>
         <source>Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1817"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1786"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1820"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1789"/>
         <source>Aggregate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1828"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1797"/>
         <source># type in a formula to use
 # for e.g. BikeStress / Duration
 # as you type the available metrics
@@ -8995,292 +8909,292 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1839"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1808"/>
         <source>Weekly Best Performances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1840"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1809"/>
         <source>Submaximal Weekly Best</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1841"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1810"/>
         <source>Performance Tests</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1933"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1902"/>
         <source>Short Term Stress (STS/ATL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1934"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1903"/>
         <source>Long Term Stress  (LTS/CTL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1935"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1904"/>
         <source>Stress Balance    (SB/TSB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1936"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1905"/>
         <source>Stress Ramp Rate  (RR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1944"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1913"/>
         <source>Stress Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1949"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1918"/>
         <source>Negative Training Effect (NTE)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1950"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1919"/>
         <source>Positive Training Effect (PTE)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1951"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1920"/>
         <source>Performance (Power Index)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1952"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1921"/>
         <source>Predicted CP (Watts)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1969"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1938"/>
         <source>Curve Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1945"/>
         <source>Perf. Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2006"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1975"/>
         <source>Metadata Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2007"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
         <source>PMC metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2032"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2001"/>
         <source>Measure Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2009"/>
         <source>Measure Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2029"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2071"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2042"/>
         <source>Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2074"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2043"/>
         <source>Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2075"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2044"/>
         <source>Sticks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2076"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2045"/>
         <source>Dots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2048"/>
         <source>Stack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2053"/>
         <source>Symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2086"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2055"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2087"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2056"/>
         <source>Circle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2057"/>
         <source>Square</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2089"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2058"/>
         <source>Diamond</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2090"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2059"/>
         <source>Triangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2091"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
         <source>Cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2092"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2061"/>
         <source>Hexagon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2062"/>
         <source>Star</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2100"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2069"/>
         <source>Fill curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
         <source>Data labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2080"/>
         <source>Highlight Highest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
         <source>Highlight Lowest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2127"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
         <source>Highlight Outliers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2135"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
         <source>Baseline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2143"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2112"/>
         <source>Smooth Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2147"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2116"/>
         <source>No trend Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2148"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2117"/>
         <source>Linear Trend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2149"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2118"/>
         <source>Quadratic Trend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2150"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
         <source>Moving Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2151"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2120"/>
         <source>Simple Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2123"/>
         <source>Ignore Zeros</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2168"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2201"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2170"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2431"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2400"/>
         <source>Peak %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2402"/>
         <source> second </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2434"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2403"/>
         <source> minute </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2436"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2405"/>
         <source> hour </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2456"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2425"/>
         <source>%1 - %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2470"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2439"/>
         <source>Performances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2471"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2440"/>
         <source>Power Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2588"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2557"/>
         <source>Performances_%1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9602,93 +9516,93 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditUserAxisDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1731"/>
+        <location filename="../../Charts/UserChart.cpp" line="1689"/>
         <source>Edit Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1741"/>
+        <location filename="../../Charts/UserChart.cpp" line="1699"/>
         <source>&amp;OK</source>
         <translation type="unfinished">&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1742"/>
+        <location filename="../../Charts/UserChart.cpp" line="1700"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1750"/>
+        <location filename="../../Charts/UserChart.cpp" line="1708"/>
         <source>Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1760"/>
+        <location filename="../../Charts/UserChart.cpp" line="1718"/>
         <source>Logarithmic Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1757"/>
+        <location filename="../../Charts/UserChart.cpp" line="1715"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1761"/>
-        <location filename="../../Charts/UserChart.cpp" line="1780"/>
+        <location filename="../../Charts/UserChart.cpp" line="1719"/>
+        <location filename="../../Charts/UserChart.cpp" line="1738"/>
         <source> </source>
         <translation type="unfinished"> </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1763"/>
+        <location filename="../../Charts/UserChart.cpp" line="1721"/>
         <source>Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1774"/>
+        <location filename="../../Charts/UserChart.cpp" line="1732"/>
         <source> from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1776"/>
+        <location filename="../../Charts/UserChart.cpp" line="1734"/>
         <source> to </source>
         <translation type="unfinished"> para </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1779"/>
+        <location filename="../../Charts/UserChart.cpp" line="1737"/>
         <source>Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1787"/>
+        <location filename="../../Charts/UserChart.cpp" line="1745"/>
         <source>Smoothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1792"/>
+        <location filename="../../Charts/UserChart.cpp" line="1750"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1793"/>
+        <location filename="../../Charts/UserChart.cpp" line="1751"/>
         <source>Day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1794"/>
+        <location filename="../../Charts/UserChart.cpp" line="1752"/>
         <source>Week</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1795"/>
+        <location filename="../../Charts/UserChart.cpp" line="1753"/>
         <source>Month</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1796"/>
+        <location filename="../../Charts/UserChart.cpp" line="1754"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1798"/>
+        <location filename="../../Charts/UserChart.cpp" line="1756"/>
         <source>Group By</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9881,158 +9795,158 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditUserSeriesDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1398"/>
+        <location filename="../../Charts/UserChart.cpp" line="1356"/>
         <source>Edit Data Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1414"/>
+        <location filename="../../Charts/UserChart.cpp" line="1372"/>
         <source>&amp;OK</source>
         <translation type="unfinished">&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1415"/>
+        <location filename="../../Charts/UserChart.cpp" line="1373"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1422"/>
+        <location filename="../../Charts/UserChart.cpp" line="1380"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1430"/>
+        <location filename="../../Charts/UserChart.cpp" line="1388"/>
         <source>Series Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1519"/>
+        <location filename="../../Charts/UserChart.cpp" line="1477"/>
         <source>Y units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1524"/>
+        <location filename="../../Charts/UserChart.cpp" line="1482"/>
         <source>X units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1528"/>
+        <location filename="../../Charts/UserChart.cpp" line="1486"/>
         <source>Sum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1529"/>
+        <location filename="../../Charts/UserChart.cpp" line="1487"/>
         <source>Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1530"/>
+        <location filename="../../Charts/UserChart.cpp" line="1488"/>
         <source>Peak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1531"/>
+        <location filename="../../Charts/UserChart.cpp" line="1489"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1532"/>
+        <location filename="../../Charts/UserChart.cpp" line="1490"/>
         <source>Running Total</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1533"/>
+        <location filename="../../Charts/UserChart.cpp" line="1491"/>
         <source>Mean Square Root</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1534"/>
+        <location filename="../../Charts/UserChart.cpp" line="1492"/>
         <source>Std Deviation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1537"/>
+        <location filename="../../Charts/UserChart.cpp" line="1495"/>
         <source>Aggregate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1541"/>
-        <location filename="../../Charts/UserChart.cpp" line="1557"/>
+        <location filename="../../Charts/UserChart.cpp" line="1499"/>
+        <location filename="../../Charts/UserChart.cpp" line="1515"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1542"/>
+        <location filename="../../Charts/UserChart.cpp" line="1500"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1543"/>
+        <location filename="../../Charts/UserChart.cpp" line="1501"/>
         <source>Dashed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1544"/>
+        <location filename="../../Charts/UserChart.cpp" line="1502"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1545"/>
+        <location filename="../../Charts/UserChart.cpp" line="1503"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1546"/>
+        <location filename="../../Charts/UserChart.cpp" line="1504"/>
         <source>Fast Graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1547"/>
+        <location filename="../../Charts/UserChart.cpp" line="1505"/>
         <source>Show on Legend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1548"/>
+        <location filename="../../Charts/UserChart.cpp" line="1506"/>
         <source>Show Data Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1554"/>
+        <location filename="../../Charts/UserChart.cpp" line="1512"/>
         <source>Line Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1558"/>
+        <location filename="../../Charts/UserChart.cpp" line="1516"/>
         <source>Circle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1559"/>
+        <location filename="../../Charts/UserChart.cpp" line="1517"/>
         <source>Rectangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1564"/>
+        <location filename="../../Charts/UserChart.cpp" line="1522"/>
         <source>Symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1572"/>
+        <location filename="../../Charts/UserChart.cpp" line="1530"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1575"/>
+        <location filename="../../Charts/UserChart.cpp" line="1533"/>
         <source>Fill curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1583"/>
+        <location filename="../../Charts/UserChart.cpp" line="1541"/>
         <source>Opacity (%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1589"/>
+        <location filename="../../Charts/UserChart.cpp" line="1547"/>
         <source>Size/Width</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10078,6 +9992,24 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
     <message>
         <location filename="../../Metrics/BasicRideMetrics.cpp" line="144"/>
         <source>Only useful for intervals, time the interval started</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ElevationChartWindow</name>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="221"/>
+        <source>Profile Distance (m)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="229"/>
+        <source>Seconds for delta slope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="237"/>
+        <source>Elevation window size (%) relative to current altitude</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10513,7 +10445,7 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ExhaustionDialog.cpp" line="160"/>
+        <location filename="../../Charts/ExhaustionDialog.cpp" line="162"/>
         <source>Time</source>
         <translation type="unfinished">Tempo</translation>
     </message>
@@ -12685,42 +12617,42 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>GcCrashDialog</name>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="78"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="74"/>
         <source>%1 Crash Recovery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="116"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="112"/>
         <source>&lt;b&gt;GoldenCheetah appears to have PREVIOUSLY crashed for this athlete. &lt;/b&gt;&lt;br&gt;&lt;br&gt;The report below gives some diagnostic information that will be useful to the developers. Feel free to post this with a short description of what was occurring when the crash happened to the &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah forums&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;We respect privacy - this log does NOT contain ids, passwords or personal information.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;When this dialog is closed the athlete will be opened.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="141"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="137"/>
         <source>Save Crash Report...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="143"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="139"/>
         <source>Close</source>
         <translation type="unfinished">Fechar</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="225"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="221"/>
         <source>&lt;p&gt;Build date: %1 %2&lt;br&gt;Build id: %3&lt;br&gt;Version: %4&lt;br&gt;DB Schema: %5&lt;br&gt;Metrics: %7&lt;br&gt;OS: %6&lt;br&gt;OpenGL: %10&lt;br&gt;UI: dpi scale (%8) font size (%9)&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="255"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="251"/>
         <source>&lt;table&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QT&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QWT&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;%3&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SRMIO&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;D2XX&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;ICAL&lt;/td&gt;&lt;td&gt;%9&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;USBXPRESS&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LIBUSB&lt;/td&gt;&lt;td&gt;%11&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VLC&lt;/td&gt;&lt;td&gt;%12&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VIDEO&lt;/td&gt;&lt;td&gt;%13&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SAMPLERATE&lt;/td&gt;&lt;td&gt;%14&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SSL&lt;/td&gt;&lt;td&gt;%15&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;R&lt;/td&gt;&lt;td&gt;%16&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;Python&lt;/td&gt;&lt;td&gt;%18&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LMFIT&lt;/td&gt;&lt;td&gt;7.0&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;GSL&lt;/td&gt;&lt;td&gt;%19&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Save Diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Text File (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13055,167 +12987,172 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>GcWindowRegistry</name>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
         <source>Performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="89"/>
         <source>Histogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
         <source>Distribution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
         <source>Pedal Force vs Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
         <source>Heartrate vs Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
         <source>Python Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
         <source>Python Chart </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="101"/>
         <source>Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
         <source>Navigator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="76"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="73"/>
         <source>User Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
         <source>Trends</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="78"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
         <source>TreeMap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
         <source>Power Duration </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="83"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
         <source>Activity Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="81"/>
         <source>Blank Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="85"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="82"/>
         <source>User Chart </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
         <source>Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="88"/>
         <source>Power Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
         <source>Scatter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="103"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
         <source>Aerolab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
         <source>Workout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="106"/>
         <source>Realtime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
         <source>Pedal Stroke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="113"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
         <source>Live Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="114"/>
-        <source>Web page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
-        <source>Map</source>
-        <translation type="unfinished">Mapa</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
-        <source>Season Overview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
-        <source>Blank Overview </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
-        <source>R Chart</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="98"/>
-        <source>R Chart </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
-        <source>Video Player</source>
+        <source>Elevation Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
+        <source>Web page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <source>Map</source>
+        <translation type="unfinished">Mapa</translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="71"/>
+        <source>Season Overview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="72"/>
+        <source>Blank Overview </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <source>R Chart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <source>R Chart </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <source>Video Player</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
         <source>Workout Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14308,142 +14245,147 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="296"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="294"/>
+        <source>Show elevation profile of instant position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
         <source>Predefined and configurable set of data ranges for selection of activities to be analysed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
         <source>Powerful filter and search engine to determine the activities which are considered in diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
         <source>Configurable list of activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="317"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
         <source>Configurable list of training devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
         <source>Configurable list of workout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
         <source>Configurable list of video files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="325"/>
         <source>Configurable list of video sync files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="327"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
         <source>Entry field for sophisticated Searching and Filtering of activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
         <source>Adding intervals to an activity using simple query methods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
         <source>To compare Activities/Intervals in Activity View and Date Ranges in Trends View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="335"/>
         <source>Workout Control, Intensity Adjustments and Notifications Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
         <source>Athlete Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
         <source>Athlete Measures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
         <source>Auto Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
         <source>Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="355"/>
         <source>Cloud Accounts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <source>Automatic Interval Detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
         <source>Definition of coloring rules for activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
         <source>Metrics shown in &apos;Intervals&apos; and &apos;Summary&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
         <source>User/Custom Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
         <source>Create or Edit a User Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
         <source>Measures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
         <source>Train View devices configuration and preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
         <source>Train View Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
         <source>Remote Controls Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
         <source>Add/Remove Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
         <source>Add Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="394"/>
         <source>Virtual Bicycle configuration for simulation rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14477,8 +14419,8 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
     </message>
     <message>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="219"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
         <source>Calendar</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14513,74 +14455,74 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
         <source>Definition of points in time &apos;Events&apos; which are marked explicitely on time related diagrams</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="316"/>
         <source>Simple summary view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
         <source>Alternative access to the charts created for the main view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
         <source>Display the available and add new intervals using simple query methods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="356"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="337"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
         <source>Athlete</source>
         <translation type="unfinished">Atleta</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
         <source>Training Zone definition for power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
         <source>Training Zone definition for heartrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
         <source>Training Zone definition for Swim and Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="364"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
         <source>Data Fields</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
         <source>Definition of default value(s) for data fields</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
         <source>Definition of processing default parameters for the fix, adjust,... tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
         <source>Metrics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14780,61 +14722,49 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2437"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2438"/>
         <source>Delete</source>
-        <translation type="unfinished">Excluir</translation>
+        <translation type="obsolete">Excluir</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2431"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2432"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2447"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2332"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2458"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2343"/>
         <source>Short</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2459"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2344"/>
         <source>Long</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2460"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2345"/>
         <source>Percent of LT</source>
         <translatorcomment>いまいち</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2461"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2346"/>
         <source>Trimp k</source>
         <translatorcomment>でいいのかな？</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2506"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2513"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2390"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2397"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2508"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2515"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2392"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2399"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15024,17 +14954,17 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2245"/>
         <source>Sport</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2395"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2292"/>
         <source>Lactate Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2396"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2293"/>
         <source>Default</source>
         <translation type="unfinished">Padrão</translation>
     </message>
@@ -17166,545 +17096,530 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>LTMTool</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1303"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1272"/>
         <source>Metric</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="74"/>
+        <location filename="../../Charts/LTMTool.cpp" line="75"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="80"/>
+        <location filename="../../Charts/LTMTool.cpp" line="81"/>
         <source>Date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="84"/>
+        <location filename="../../Charts/LTMTool.cpp" line="85"/>
         <source>Days</source>
         <translation type="unfinished">Dias</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="85"/>
+        <location filename="../../Charts/LTMTool.cpp" line="86"/>
         <source>Weeks</source>
         <translation type="unfinished">Semanas</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="86"/>
+        <location filename="../../Charts/LTMTool.cpp" line="87"/>
         <source>Months</source>
         <translation type="unfinished">Meses</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="87"/>
+        <location filename="../../Charts/LTMTool.cpp" line="88"/>
         <source>Years</source>
         <translation type="unfinished">Anos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="88"/>
+        <location filename="../../Charts/LTMTool.cpp" line="89"/>
         <source>Time Of Day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="89"/>
+        <location filename="../../Charts/LTMTool.cpp" line="90"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="91"/>
+        <location filename="../../Charts/LTMTool.cpp" line="92"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="102"/>
+        <location filename="../../Charts/LTMTool.cpp" line="103"/>
         <source>Shade Zones</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="105"/>
+        <location filename="../../Charts/LTMTool.cpp" line="106"/>
         <source>Show Legend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="109"/>
         <source>Show Events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="351"/>
+        <location filename="../../Charts/LTMTool.cpp" line="325"/>
         <source>Skiba Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="353"/>
-        <location filename="../../Charts/LTMTool.cpp" line="368"/>
-        <location filename="../../Charts/LTMTool.cpp" line="429"/>
-        <location filename="../../Charts/LTMTool.cpp" line="444"/>
-        <location filename="../../Charts/LTMTool.cpp" line="505"/>
-        <location filename="../../Charts/LTMTool.cpp" line="520"/>
-        <location filename="../../Charts/LTMTool.cpp" line="580"/>
-        <location filename="../../Charts/LTMTool.cpp" line="595"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1080"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1095"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1156"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1171"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1309"/>
+        <location filename="../../Charts/LTMTool.cpp" line="327"/>
+        <location filename="../../Charts/LTMTool.cpp" line="342"/>
+        <location filename="../../Charts/LTMTool.cpp" line="403"/>
+        <location filename="../../Charts/LTMTool.cpp" line="418"/>
+        <location filename="../../Charts/LTMTool.cpp" line="479"/>
+        <location filename="../../Charts/LTMTool.cpp" line="494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="554"/>
+        <location filename="../../Charts/LTMTool.cpp" line="569"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1054"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1069"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1130"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1145"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1278"/>
         <source>Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="366"/>
+        <location filename="../../Charts/LTMTool.cpp" line="340"/>
         <source>Skiba Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="381"/>
+        <location filename="../../Charts/LTMTool.cpp" line="355"/>
         <source>Skiba Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="383"/>
-        <location filename="../../Charts/LTMTool.cpp" line="459"/>
-        <location filename="../../Charts/LTMTool.cpp" line="535"/>
-        <location filename="../../Charts/LTMTool.cpp" line="610"/>
-        <location filename="../../Charts/LTMTool.cpp" line="686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="762"/>
-        <location filename="../../Charts/LTMTool.cpp" line="838"/>
-        <location filename="../../Charts/LTMTool.cpp" line="914"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1110"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1186"/>
+        <location filename="../../Charts/LTMTool.cpp" line="357"/>
+        <location filename="../../Charts/LTMTool.cpp" line="433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="509"/>
+        <location filename="../../Charts/LTMTool.cpp" line="584"/>
+        <location filename="../../Charts/LTMTool.cpp" line="660"/>
+        <location filename="../../Charts/LTMTool.cpp" line="736"/>
+        <location filename="../../Charts/LTMTool.cpp" line="812"/>
+        <location filename="../../Charts/LTMTool.cpp" line="888"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1160"/>
         <source>Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="396"/>
+        <location filename="../../Charts/LTMTool.cpp" line="370"/>
         <source>Skiba STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="398"/>
-        <location filename="../../Charts/LTMTool.cpp" line="413"/>
-        <location filename="../../Charts/LTMTool.cpp" line="474"/>
-        <location filename="../../Charts/LTMTool.cpp" line="489"/>
-        <location filename="../../Charts/LTMTool.cpp" line="550"/>
-        <location filename="../../Charts/LTMTool.cpp" line="565"/>
-        <location filename="../../Charts/LTMTool.cpp" line="625"/>
-        <location filename="../../Charts/LTMTool.cpp" line="640"/>
-        <location filename="../../Charts/LTMTool.cpp" line="701"/>
-        <location filename="../../Charts/LTMTool.cpp" line="716"/>
-        <location filename="../../Charts/LTMTool.cpp" line="777"/>
-        <location filename="../../Charts/LTMTool.cpp" line="792"/>
-        <location filename="../../Charts/LTMTool.cpp" line="853"/>
-        <location filename="../../Charts/LTMTool.cpp" line="868"/>
-        <location filename="../../Charts/LTMTool.cpp" line="929"/>
-        <location filename="../../Charts/LTMTool.cpp" line="944"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1005"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1020"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1125"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1140"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1201"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1216"/>
+        <location filename="../../Charts/LTMTool.cpp" line="372"/>
+        <location filename="../../Charts/LTMTool.cpp" line="387"/>
+        <location filename="../../Charts/LTMTool.cpp" line="448"/>
+        <location filename="../../Charts/LTMTool.cpp" line="463"/>
+        <location filename="../../Charts/LTMTool.cpp" line="524"/>
+        <location filename="../../Charts/LTMTool.cpp" line="539"/>
+        <location filename="../../Charts/LTMTool.cpp" line="599"/>
+        <location filename="../../Charts/LTMTool.cpp" line="614"/>
+        <location filename="../../Charts/LTMTool.cpp" line="675"/>
+        <location filename="../../Charts/LTMTool.cpp" line="690"/>
+        <location filename="../../Charts/LTMTool.cpp" line="751"/>
+        <location filename="../../Charts/LTMTool.cpp" line="766"/>
+        <location filename="../../Charts/LTMTool.cpp" line="827"/>
+        <location filename="../../Charts/LTMTool.cpp" line="842"/>
+        <location filename="../../Charts/LTMTool.cpp" line="903"/>
+        <location filename="../../Charts/LTMTool.cpp" line="918"/>
+        <location filename="../../Charts/LTMTool.cpp" line="979"/>
+        <location filename="../../Charts/LTMTool.cpp" line="994"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1099"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1114"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1175"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1190"/>
         <source>Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="411"/>
+        <location filename="../../Charts/LTMTool.cpp" line="385"/>
         <source>Skiba LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="427"/>
+        <location filename="../../Charts/LTMTool.cpp" line="401"/>
         <source>Aerobic TISS Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="442"/>
+        <location filename="../../Charts/LTMTool.cpp" line="416"/>
         <source>Aerobic TISS Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="457"/>
+        <location filename="../../Charts/LTMTool.cpp" line="431"/>
         <source>Aerobic TISS Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="472"/>
+        <location filename="../../Charts/LTMTool.cpp" line="446"/>
         <source>Aerobic TISS STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="487"/>
+        <location filename="../../Charts/LTMTool.cpp" line="461"/>
         <source>Aerobic TISS LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="503"/>
+        <location filename="../../Charts/LTMTool.cpp" line="477"/>
         <source>Anaerobic TISS Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="518"/>
+        <location filename="../../Charts/LTMTool.cpp" line="492"/>
         <source>Anaerobic TISS Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="533"/>
+        <location filename="../../Charts/LTMTool.cpp" line="507"/>
         <source>Anaerobic TISS Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="548"/>
+        <location filename="../../Charts/LTMTool.cpp" line="522"/>
         <source>Anaerobic TISS STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="537"/>
         <source>Anaerobic TISS LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="578"/>
+        <location filename="../../Charts/LTMTool.cpp" line="552"/>
         <source>Daniels Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="593"/>
+        <location filename="../../Charts/LTMTool.cpp" line="567"/>
         <source>Daniels Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="582"/>
         <source>Daniels Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="623"/>
+        <location filename="../../Charts/LTMTool.cpp" line="597"/>
         <source>Daniels STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="638"/>
+        <location filename="../../Charts/LTMTool.cpp" line="612"/>
         <source>Daniels LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="628"/>
         <source>Work (Kj) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="656"/>
-        <location filename="../../Charts/LTMTool.cpp" line="671"/>
-        <location filename="../../Charts/LTMTool.cpp" line="732"/>
-        <location filename="../../Charts/LTMTool.cpp" line="747"/>
-        <location filename="../../Charts/LTMTool.cpp" line="808"/>
-        <location filename="../../Charts/LTMTool.cpp" line="823"/>
+        <location filename="../../Charts/LTMTool.cpp" line="630"/>
+        <location filename="../../Charts/LTMTool.cpp" line="645"/>
+        <location filename="../../Charts/LTMTool.cpp" line="706"/>
+        <location filename="../../Charts/LTMTool.cpp" line="721"/>
+        <location filename="../../Charts/LTMTool.cpp" line="782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="797"/>
         <source>Stress (Kj)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="669"/>
+        <location filename="../../Charts/LTMTool.cpp" line="643"/>
         <source>Work (Kj) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="684"/>
+        <location filename="../../Charts/LTMTool.cpp" line="658"/>
         <source>Work (Kj) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="699"/>
+        <location filename="../../Charts/LTMTool.cpp" line="673"/>
         <source>Work (Kj) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="714"/>
+        <location filename="../../Charts/LTMTool.cpp" line="688"/>
         <source>Work (Kj) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="730"/>
+        <location filename="../../Charts/LTMTool.cpp" line="704"/>
         <source>W&apos; Work (Kj) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="745"/>
+        <location filename="../../Charts/LTMTool.cpp" line="719"/>
         <source>W&apos; Work (Kj) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="760"/>
+        <location filename="../../Charts/LTMTool.cpp" line="734"/>
         <source>W&apos; Work (Kj) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="775"/>
+        <location filename="../../Charts/LTMTool.cpp" line="749"/>
         <source>W&apos; Work (Kj) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="790"/>
+        <location filename="../../Charts/LTMTool.cpp" line="764"/>
         <source>W&apos; Work (Kj) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="806"/>
+        <location filename="../../Charts/LTMTool.cpp" line="780"/>
         <source>Below CP Work (Kj) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="821"/>
+        <location filename="../../Charts/LTMTool.cpp" line="795"/>
         <source>Below CP Work (Kj) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="836"/>
+        <location filename="../../Charts/LTMTool.cpp" line="810"/>
         <source>Below CP Work (Kj) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="851"/>
+        <location filename="../../Charts/LTMTool.cpp" line="825"/>
         <source>Below CP Work (Kj) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="866"/>
+        <location filename="../../Charts/LTMTool.cpp" line="840"/>
         <source>Below CP Work (Kj) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="882"/>
+        <location filename="../../Charts/LTMTool.cpp" line="856"/>
         <source>Distance (km|mi) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="884"/>
-        <location filename="../../Charts/LTMTool.cpp" line="899"/>
+        <location filename="../../Charts/LTMTool.cpp" line="858"/>
+        <location filename="../../Charts/LTMTool.cpp" line="873"/>
         <source>Stress (km|mi)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="897"/>
+        <location filename="../../Charts/LTMTool.cpp" line="871"/>
         <source>Distance (km|mi) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="912"/>
+        <location filename="../../Charts/LTMTool.cpp" line="886"/>
         <source>Distance (km|mi) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="927"/>
+        <location filename="../../Charts/LTMTool.cpp" line="901"/>
         <source>Distance (km|mi) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="942"/>
+        <location filename="../../Charts/LTMTool.cpp" line="916"/>
         <source>Distance (km|mi) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="958"/>
+        <location filename="../../Charts/LTMTool.cpp" line="932"/>
         <source>Coggan Chronic Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="973"/>
+        <location filename="../../Charts/LTMTool.cpp" line="947"/>
         <source>Coggan Acute Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="988"/>
+        <location filename="../../Charts/LTMTool.cpp" line="962"/>
         <source>Coggan Training Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1003"/>
+        <location filename="../../Charts/LTMTool.cpp" line="977"/>
         <source>Coggan STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1018"/>
+        <location filename="../../Charts/LTMTool.cpp" line="992"/>
         <source>Coggan LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1033"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1007"/>
         <source>Coggan Expected Chronic Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1048"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1022"/>
         <source>Coggan Expected Acute Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1063"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1037"/>
         <source>Coggan Expected Training Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1053"/>
         <source>TRIMP Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1067"/>
         <source>TRIMP Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1082"/>
         <source>TRIMP Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1123"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1097"/>
         <source>TRIMP STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1138"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1112"/>
         <source>TRIMP LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="268"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/LTMTool.cpp" line="124"/>
+        <location filename="../../Charts/LTMTool.cpp" line="125"/>
         <source>Use sidebar chart settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Basic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="314"/>
+        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Preset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1307"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1276"/>
         <source>Estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1311"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1280"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1282"/>
         <source>Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1284"/>
         <source>Performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1317"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1286"/>
         <source>Banister</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1463"/>
         <source>Chart %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="94"/>
+        <location filename="../../Charts/LTMTool.cpp" line="95"/>
         <source>Data Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="98"/>
+        <location filename="../../Charts/LTMTool.cpp" line="99"/>
         <source>Show Stack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="121"/>
+        <location filename="../../Charts/LTMTool.cpp" line="122"/>
         <source>Stack Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="155"/>
+        <location filename="../../Charts/LTMTool.cpp" line="156"/>
         <source>Add Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="146"/>
+        <location filename="../../Charts/LTMTool.cpp" line="147"/>
         <source>Charts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="112"/>
         <source>Show Banister Helper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="155"/>
         <source>Apply</source>
         <translation type="unfinished">Aplicar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="287"/>
-        <source>Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/LTMTool.cpp" line="288"/>
-        <source>Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/LTMTool.cpp" line="315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="289"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1128"/>
         <source>TriScore Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1169"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1143"/>
         <source>TriScore Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1184"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1158"/>
         <source>TriScore Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1173"/>
         <source>TriScore STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1214"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1188"/>
         <source>TriScore LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1305"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1274"/>
         <source>Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17903,106 +17818,90 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>LTPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2590"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2602"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2591"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2603"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2596"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2608"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2597"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2609"/>
         <source>Delete</source>
-        <translation type="unfinished">Excluir</translation>
+        <translation type="obsolete">Excluir</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2599"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2467"/>
         <source>Def</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2628"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2690"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2770"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2775"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2780"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2785"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2473"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2478"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2488"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2611"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2621"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2626"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2650"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2493"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2630"/>
         <source>Start Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2651"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2790"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2494"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2631"/>
         <source>Lactate Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2652"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2791"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2495"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2632"/>
         <source>Aerobic Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2967"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2974"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2804"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2811"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2969"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2976"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2806"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2813"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2653"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2496"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
         <source>Rest HR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2654"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2497"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2634"/>
         <source>Max HR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2701"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2544"/>
         <source>Short</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2702"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2545"/>
         <source>Long</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2703"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2546"/>
         <source>From BPM</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2704"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2547"/>
         <source>Trimp k</source>
         <translation></translation>
     </message>
@@ -18743,62 +18642,62 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>Library</name>
     <message>
+        <location filename="../../Train/Library.cpp" line="126"/>
         <location filename="../../Train/Library.cpp" line="130"/>
-        <location filename="../../Train/Library.cpp" line="134"/>
         <source>Import Videos, VideoSyncs and Workouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="127"/>
         <location filename="../../Train/Library.cpp" line="131"/>
-        <location filename="../../Train/Library.cpp" line="135"/>
         <source>No supported videos, videoSyncs or workouts were found to import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="189"/>
         <location filename="../../Train/Library.cpp" line="193"/>
-        <location filename="../../Train/Library.cpp" line="197"/>
+        <location filename="../../Train/Library.cpp" line="198"/>
         <location filename="../../Train/Library.cpp" line="202"/>
-        <location filename="../../Train/Library.cpp" line="206"/>
         <source>Copy VideoSync Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="190"/>
         <location filename="../../Train/Library.cpp" line="194"/>
-        <location filename="../../Train/Library.cpp" line="198"/>
         <source>%1 already exists in videoSync library: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="203"/>
+        <location filename="../../Train/Library.cpp" line="199"/>
         <source>%1 cannot be written to videoSync library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="207"/>
+        <location filename="../../Train/Library.cpp" line="203"/>
         <source>%1 cannot be written to videoSync library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="253"/>
+        <location filename="../../Train/Library.cpp" line="249"/>
         <source>%1 cannot be written to workout library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="257"/>
+        <location filename="../../Train/Library.cpp" line="253"/>
         <source>%1 cannot be written to workout library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="239"/>
         <location filename="../../Train/Library.cpp" line="243"/>
-        <location filename="../../Train/Library.cpp" line="247"/>
+        <location filename="../../Train/Library.cpp" line="248"/>
         <location filename="../../Train/Library.cpp" line="252"/>
-        <location filename="../../Train/Library.cpp" line="256"/>
         <source>Copy Workout Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="240"/>
         <location filename="../../Train/Library.cpp" line="244"/>
-        <location filename="../../Train/Library.cpp" line="248"/>
         <source>%1 already exists in workout library: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18806,89 +18705,89 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>LibrarySearchDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="330"/>
+        <location filename="../../Train/Library.cpp" line="326"/>
         <source>Search for Workouts, Syncs and Media</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="337"/>
+        <location filename="../../Train/Library.cpp" line="333"/>
         <source>Workout files (.erg, .mrc, .zwo etc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="339"/>
+        <location filename="../../Train/Library.cpp" line="335"/>
         <source>Video files (.mp4, .avi etc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="341"/>
+        <location filename="../../Train/Library.cpp" line="337"/>
         <source>VideoSync files (.rlv, .tts etc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="359"/>
+        <location filename="../../Train/Library.cpp" line="353"/>
         <source>Search Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="379"/>
+        <location filename="../../Train/Library.cpp" line="373"/>
         <source>Video references</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="391"/>
+        <location filename="../../Train/Library.cpp" line="385"/>
         <source>Searching...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="394"/>
+        <location filename="../../Train/Library.cpp" line="388"/>
         <source>Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="396"/>
+        <location filename="../../Train/Library.cpp" line="390"/>
         <source>Workouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="398"/>
+        <location filename="../../Train/Library.cpp" line="392"/>
         <source>VideoSyncs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="407"/>
-        <location filename="../../Train/Library.cpp" line="494"/>
+        <location filename="../../Train/Library.cpp" line="401"/>
+        <location filename="../../Train/Library.cpp" line="484"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="409"/>
+        <location filename="../../Train/Library.cpp" line="403"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="412"/>
+        <location filename="../../Train/Library.cpp" line="406"/>
         <source>Files to search for:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="475"/>
+        <location filename="../../Train/Library.cpp" line="466"/>
         <source>Abort Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="515"/>
-        <location filename="../../Train/Library.cpp" line="559"/>
+        <location filename="../../Train/Library.cpp" line="504"/>
+        <location filename="../../Train/Library.cpp" line="548"/>
         <source>Save</source>
         <translation type="unfinished">Salvar</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="557"/>
+        <location filename="../../Train/Library.cpp" line="546"/>
         <source>Search completed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="645"/>
+        <location filename="../../Train/Library.cpp" line="634"/>
         <source>Select Directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18896,12 +18795,12 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>ListEditWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="623"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="654"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="625"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="656"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18914,7 +18813,12 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="90"/>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="85"/>
+        <source>Initial Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="98"/>
         <source>Apply changes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19133,7 +19037,7 @@ on and that its display says, &quot;PC Link&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>Delete Activity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19305,109 +19209,109 @@ on and that its display says, &quot;PC Link&quot;</source>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Activity Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Closing of athlete window not possible while background activity import is in progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Chart Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>Import Images Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>You can only import images on the activities view with an activity selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>Import Images to Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>%1 images imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1778"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1788"/>
         <source>Failed to export activity, please check permissions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1814"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1824"/>
         <source>No Activity To Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1815"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1825"/>
         <source>There is no currently selected activity to save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
         <location filename="../../Gui/MainWindow.cpp" line="1886"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Split Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
         <source>No activity selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
         <source>Current activity contains no data to split</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Current activity contains no data to merge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1904"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1914"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2400"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2421"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2410"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2431"/>
         <source>The workout directory is not configured, or the directory selected no longer exists.
 
 Please check your preference settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2611"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2621"/>
         <source>Loading activities: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>CloudDB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>Current athlete is not registered as curator - please contact the GoldenCheetah team</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19584,28 +19488,28 @@ Please check your preference settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Imported %1 metric charts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
         <source>Select Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>No activity selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1724"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1734"/>
         <source>Export Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1777"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1787"/>
         <source>Export Failed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19755,7 +19659,7 @@ Please check your preference settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2165"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2175"/>
         <source>&amp;New Athlete...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19780,34 +19684,34 @@ Please check your preference settings.</source>
         <translation>Sobre o GoldenCheet&amp;ah</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1799"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2369"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1809"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2379"/>
         <source>Import from File</source>
         <translation>Importar de Arquivo</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2342"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2352"/>
         <source>Refresh in Progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Export Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2399"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2420"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2409"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2430"/>
         <source>Workout Directory Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1906"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1916"/>
         <source>Delete</source>
         <translation>Excluir</translation>
     </message>
@@ -20699,55 +20603,43 @@ Please check your preference settings.</source>
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="656"/>
+        <location filename="../../Gui/AthletePages.cpp" line="641"/>
         <source>From Date - Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="780"/>
+        <location filename="../../Gui/AthletePages.cpp" line="751"/>
         <source>Start Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="893"/>
+        <location filename="../../Gui/AthletePages.cpp" line="864"/>
         <source>MMM d, yyyy - hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="659"/>
-        <location filename="../../Gui/AthletePages.cpp" line="807"/>
+        <location filename="../../Gui/AthletePages.cpp" line="644"/>
+        <location filename="../../Gui/AthletePages.cpp" line="778"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="662"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="663"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Delete</source>
-        <translation type="unfinished">Excluir</translation>
+        <translation type="obsolete">Excluir</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="698"/>
+        <location filename="../../Gui/AthletePages.cpp" line="668"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="699"/>
+        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Original Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="668"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
 </context>
 <context>
@@ -21412,17 +21304,17 @@ No rides found to import.
 <context>
     <name>MultiDeviceDialog</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3048"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3060"/>
         <source>Multiple Device Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3103"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3115"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3106"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3118"/>
         <source>Apply</source>
         <translation type="unfinished">Aplicar</translation>
     </message>
@@ -22343,54 +22235,42 @@ No rides found to import.
 <context>
     <name>PaceSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3154"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3155"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3160"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3161"/>
         <source>Delete</source>
-        <translation type="unfinished">Excluir</translation>
+        <translation type="obsolete">Excluir</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3176"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2987"/>
         <source>Short</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3177"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2988"/>
         <source>Long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3178"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2989"/>
         <source>Percent of CV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3220"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3227"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3037"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3222"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3229"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3032"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3039"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -22590,27 +22470,27 @@ No rides found to import.
 <context>
     <name>PaceZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3082"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2905"/>
         <source>Sport</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3084"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2907"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3085"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2908"/>
         <source>Swim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3126"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2949"/>
         <source>Critical Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2950"/>
         <source>Default</source>
         <translation type="unfinished">Padrão</translation>
     </message>
@@ -24754,78 +24634,71 @@ Você deseja continuar?</translation>
 <context>
     <name>PerspectiveDialog</name>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="34"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="35"/>
         <source>Manage Perspectives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="43"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="44"/>
         <source>Perspectives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="60"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="61"/>
         <source>Charts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="83"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="78"/>
         <source>Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="84"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="77"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="90"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="91"/>
         <source>Delete</source>
-        <translation type="unfinished">Excluir</translation>
+        <translation type="obsolete">Excluir</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="98"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Drag charts to move to a perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="287"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="256"/>
         <source>Export Persepctive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
         <source>Export Perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>No perspective file selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
-        <source>Select Perspective file to export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
         <source>GoldenCheetah Perspective Files (*.gchartset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
+        <source>Select Perspective file to import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>Import Perspective</source>
         <translation type="unfinished"></translation>
     </message>
@@ -25975,307 +25848,307 @@ Python disabled in preferences.</source>
 <context>
     <name>RealtimeData</name>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="621"/>
+        <location filename="../../Train/RealtimeData.cpp" line="623"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="624"/>
+        <location filename="../../Train/RealtimeData.cpp" line="626"/>
         <source>Time</source>
         <translation type="unfinished">Tempo</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="627"/>
+        <location filename="../../Train/RealtimeData.cpp" line="629"/>
         <source>Lap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="630"/>
+        <location filename="../../Train/RealtimeData.cpp" line="632"/>
         <source>Lap Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="633"/>
+        <location filename="../../Train/RealtimeData.cpp" line="635"/>
         <source>Lap Time Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="636"/>
+        <location filename="../../Train/RealtimeData.cpp" line="638"/>
         <source>Section Time Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="639"/>
+        <location filename="../../Train/RealtimeData.cpp" line="641"/>
         <source>BikeStress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="645"/>
+        <location filename="../../Train/RealtimeData.cpp" line="647"/>
         <source>kJoules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="648"/>
+        <location filename="../../Train/RealtimeData.cpp" line="650"/>
         <source>W&apos; bal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="651"/>
+        <location filename="../../Train/RealtimeData.cpp" line="653"/>
         <source>XPower</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="654"/>
+        <location filename="../../Train/RealtimeData.cpp" line="656"/>
         <source>Iso Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="657"/>
+        <location filename="../../Train/RealtimeData.cpp" line="659"/>
         <source>Intensity Factor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="660"/>
+        <location filename="../../Train/RealtimeData.cpp" line="662"/>
         <source>Relative Intensity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="663"/>
+        <location filename="../../Train/RealtimeData.cpp" line="665"/>
         <source>Skiba Variability Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="666"/>
+        <location filename="../../Train/RealtimeData.cpp" line="668"/>
         <source>Variability Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="669"/>
+        <location filename="../../Train/RealtimeData.cpp" line="671"/>
         <source>Distance</source>
         <translation type="unfinished">Distância</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="672"/>
+        <location filename="../../Train/RealtimeData.cpp" line="674"/>
         <source>Route Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="675"/>
+        <location filename="../../Train/RealtimeData.cpp" line="677"/>
         <source>Distance Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="678"/>
+        <location filename="../../Train/RealtimeData.cpp" line="680"/>
         <source>Alternate Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="681"/>
+        <location filename="../../Train/RealtimeData.cpp" line="683"/>
         <source>Power</source>
         <translation type="unfinished">Potência</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="684"/>
+        <location filename="../../Train/RealtimeData.cpp" line="686"/>
         <source>Speed</source>
         <translation type="unfinished">Velocidade</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="687"/>
+        <location filename="../../Train/RealtimeData.cpp" line="689"/>
         <source>Virtual Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="690"/>
+        <location filename="../../Train/RealtimeData.cpp" line="692"/>
         <source>Cadence</source>
         <translation type="unfinished">Cadência</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="693"/>
+        <location filename="../../Train/RealtimeData.cpp" line="695"/>
         <source>Heart Rate</source>
         <translation type="unfinished">Frequência Cardíaca</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="696"/>
+        <location filename="../../Train/RealtimeData.cpp" line="698"/>
         <source>Target Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="699"/>
+        <location filename="../../Train/RealtimeData.cpp" line="701"/>
         <source>Average Power</source>
         <translation type="unfinished">Potência Média</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="702"/>
+        <location filename="../../Train/RealtimeData.cpp" line="704"/>
         <source>Average Speed</source>
         <translation type="unfinished">Velocidade Média</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="705"/>
+        <location filename="../../Train/RealtimeData.cpp" line="707"/>
         <source>Average Heartrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="708"/>
+        <location filename="../../Train/RealtimeData.cpp" line="710"/>
         <source>Average Cadence</source>
         <translation type="unfinished">Cadência Média</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="711"/>
+        <location filename="../../Train/RealtimeData.cpp" line="713"/>
         <source>Lap Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="714"/>
+        <location filename="../../Train/RealtimeData.cpp" line="716"/>
         <source>Lap Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="717"/>
+        <location filename="../../Train/RealtimeData.cpp" line="719"/>
         <source>Lap Heartrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="720"/>
+        <location filename="../../Train/RealtimeData.cpp" line="722"/>
         <source>Lap Cadence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="723"/>
+        <location filename="../../Train/RealtimeData.cpp" line="725"/>
         <source>Left/Right Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="726"/>
+        <location filename="../../Train/RealtimeData.cpp" line="728"/>
         <source>Total Hb Mass</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="729"/>
+        <location filename="../../Train/RealtimeData.cpp" line="731"/>
         <source>Hb O2 Saturation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="732"/>
+        <location filename="../../Train/RealtimeData.cpp" line="734"/>
         <source>Deoxy Hb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="735"/>
+        <location filename="../../Train/RealtimeData.cpp" line="737"/>
         <source>Oxy Hb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="738"/>
+        <location filename="../../Train/RealtimeData.cpp" line="740"/>
         <source>Left Torque Effectiveness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="741"/>
+        <location filename="../../Train/RealtimeData.cpp" line="743"/>
         <source>Right Torque Effectiveness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="744"/>
+        <location filename="../../Train/RealtimeData.cpp" line="746"/>
         <source>Left Pedal Smoothness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="747"/>
+        <location filename="../../Train/RealtimeData.cpp" line="749"/>
         <source>Right Pedal Smoothness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="750"/>
+        <location filename="../../Train/RealtimeData.cpp" line="752"/>
         <source>Right Power Phase Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="753"/>
+        <location filename="../../Train/RealtimeData.cpp" line="755"/>
         <source>Right Power Phase End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="756"/>
+        <location filename="../../Train/RealtimeData.cpp" line="758"/>
         <source>Right Power Phase Peak Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="759"/>
+        <location filename="../../Train/RealtimeData.cpp" line="761"/>
         <source>Right Power Phase Peak End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="762"/>
+        <location filename="../../Train/RealtimeData.cpp" line="764"/>
         <source>Slope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="765"/>
+        <location filename="../../Train/RealtimeData.cpp" line="767"/>
         <source>Lap Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="768"/>
+        <location filename="../../Train/RealtimeData.cpp" line="770"/>
         <source>Lap Distance Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="771"/>
+        <location filename="../../Train/RealtimeData.cpp" line="773"/>
         <source>Latitude</source>
         <translation type="unfinished">Latitude</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="774"/>
+        <location filename="../../Train/RealtimeData.cpp" line="776"/>
         <source>Longitude</source>
         <translation type="unfinished">Longitude</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="777"/>
+        <location filename="../../Train/RealtimeData.cpp" line="779"/>
         <source>Altitude</source>
         <translation type="unfinished">Altitude</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="780"/>
+        <location filename="../../Train/RealtimeData.cpp" line="782"/>
         <source>Respiratory Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="783"/>
+        <location filename="../../Train/RealtimeData.cpp" line="785"/>
         <source>Ventilation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="786"/>
+        <location filename="../../Train/RealtimeData.cpp" line="788"/>
         <source>VO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="789"/>
+        <location filename="../../Train/RealtimeData.cpp" line="791"/>
         <source>VCO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="792"/>
+        <location filename="../../Train/RealtimeData.cpp" line="794"/>
         <source>Respiratory Exchange Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="795"/>
+        <location filename="../../Train/RealtimeData.cpp" line="797"/>
         <source>Tidal Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="798"/>
+        <location filename="../../Train/RealtimeData.cpp" line="800"/>
         <source>Fraction O2 Expired</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="801"/>
+        <location filename="../../Train/RealtimeData.cpp" line="803"/>
         <source>Temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="804"/>
+        <location filename="../../Train/RealtimeData.cpp" line="806"/>
         <source>CoreTemp</source>
         <translation type="unfinished"></translation>
     </message>
@@ -26371,22 +26244,22 @@ Python disabled in preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Value</source>
         <translation type="unfinished">Valor</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="172"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
         <source>Power</source>
         <translation type="unfinished">Potência</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="176"/>
         <source>Heart Rate</source>
         <translation type="unfinished">Frequência Cardíaca</translation>
     </message>
@@ -28679,317 +28552,317 @@ native format. Should we do so?
 <context>
     <name>ScatterPlot</name>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="113"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
         <source>Power (watts)</source>
         <translation type="unfinished">Potência (watts)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
         <source>Cadence (rpm)</source>
         <translation type="unfinished">Cadência (rpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="116"/>
         <source>Heartrate (bpm)</source>
         <translation type="unfinished">Frequência Cardíaca (bpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="118"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="119"/>
         <source>Speed (kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="120"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="121"/>
         <source>Speed (mph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="124"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="125"/>
         <source>Altitude (meters)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="126"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="127"/>
         <source>Altitude (feet)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="128"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
         <source>Torque (N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="130"/>
         <source>Elapsed Time (secs)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="132"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="133"/>
         <source>Elapsed Distance (km)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="134"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="135"/>
         <source>Elapsed Distance (mi)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="136"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
         <source>Interval Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
         <source>Latitude (degree offset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
         <source>Longitude (degree offset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
         <source>Circumferential Pedal Velocity (m/s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="141"/>
         <source>Average Effective Pedal Force (N)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="144"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
         <source>Time at X/Y (%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
         <source>Power Zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
         <source>Headwind (kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
         <source>Slope (gradient)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
         <source>Temperature (C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
         <source>L/R Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
         <source>Torque Efficiency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
         <source>Pedal Smoothness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
         <source>Running Vertical Oscillation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
         <source>Running Ground Contact Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
         <source>Running Cadence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
         <source>Gear Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
         <source>Muscle Oxygen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
         <source>Haemoglobin Mass</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
         <source>Deoxygenated Haemoglobin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="160"/>
         <source>Oxygenated Haemoglobin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="161"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="162"/>
         <source>Unknown</source>
         <translation type="unfinished">Desconhecido</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="165"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
         <source>Power</source>
         <translation type="unfinished">Potência</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
         <source>Cadence</source>
         <translation type="unfinished">Cadência</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
         <source>Heartrate</source>
         <translation type="unfinished">Frequência Cardíaca</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
         <source>Speed</source>
         <translation type="unfinished">Velocidade</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
         <source>Altitude</source>
         <translation type="unfinished">Altitude</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
         <source>Pedal Force</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
         <source>Time</source>
         <translation type="unfinished">Tempo</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
         <source>Distance</source>
         <translation type="unfinished">Distância</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
         <source>Interval</source>
         <translation type="unfinished">Intervalo</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
         <source>Latitude</source>
         <translation type="unfinished">Latitude</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
         <source>Longitude</source>
         <translation type="unfinished">Longitude</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
         <source>Time at X/Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
         <source>Zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
         <source>CPV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
         <source>AEPF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
         <source>Headwind</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
         <source>Slope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
         <source>Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
         <source>TE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
         <source>PS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
         <source>GCT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
         <source>Run Cad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
         <source>Gear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
         <source>SmO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
         <source>tHb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
         <source>O2Hb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="194"/>
         <source>HHb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="195"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="196"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -29227,54 +29100,42 @@ native format. Should we do so?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1012"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1013"/>
         <source>Delete</source>
-        <translation type="unfinished">Excluir</translation>
+        <translation type="obsolete">Excluir</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1006"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1007"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1023"/>
+        <location filename="../../Gui/AthletePages.cpp" line="982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="988"/>
         <source>Short</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="989"/>
         <source>Long</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1031"/>
+        <location filename="../../Gui/AthletePages.cpp" line="990"/>
         <source>Percent of CP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1069"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1076"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1034"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1071"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1078"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1036"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -29447,64 +29308,64 @@ native format. Should we do so?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3821"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3569"/>
         <source>Add</source>
         <translation type="unfinished">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3822"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3570"/>
         <source>Delete</source>
         <translation type="unfinished">Excluir</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3823"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3571"/>
         <source>Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3824"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3572"/>
         <source>Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3870"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3872"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3963"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3965"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3711"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3713"/>
         <source>ddd MMM d, yyyy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3557"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3810"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3558"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3804"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3835"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3583"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3805"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3836"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3553"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3584"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3806"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3837"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3554"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3585"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3807"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3838"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3555"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3586"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
@@ -31778,398 +31639,398 @@ tab.</source>
 <context>
     <name>TrainSidebar</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="253"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="257"/>
         <source>Save workout data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="259"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="263"/>
         <source>Devices</source>
         <translation type="unfinished">Dispositivos</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="262"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="267"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="311"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="321"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="271"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="315"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="325"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="270"/>
         <source>Workouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="303"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="307"/>
         <source>Workout Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="310"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="314"/>
         <source>Media</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="320"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="324"/>
         <source>VideoSync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="506"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
         <source>Import Workout from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="507"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="511"/>
         <source>Get Workouts from TrainerDay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="509"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="513"/>
         <source>Create Workout via Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="514"/>
         <source>Scan for Workouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="534"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="538"/>
         <source>Delete selected Workout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="541"/>
         <source>Delete %1 selected Workouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Train mode active</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Please stop the train mode before closing the window or application.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="635"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="639"/>
         <source>Remove reference to selected video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="650"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="654"/>
         <source>Import VideoSync from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="651"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="655"/>
         <source>Scan for VideoSyncs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="668"/>
         <source>Delete selected VideoSync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1064"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1068"/>
         <source>Are you sure you want to remove the reference to this video?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1066"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1128"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1204"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1070"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1132"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1208"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1099"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1103"/>
         <source>Are you sure you want to delete this VideoSync?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1126"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1130"/>
         <source>The VideoSync file is either not valid or not existing and will be removed from the library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1160"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1164"/>
         <source>Are you sure you want to delete this Workout?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1163"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1167"/>
         <source>Are you sure you want to delete this %1 workouts?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1202"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1206"/>
         <source>The Workout file is either not valid or not existing and will be removed from the library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1347"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1351"/>
         <source>Starting in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2225"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2237"/>
         <source>Recalibrating steering..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2521"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2525"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2594"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2645"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2649"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2533"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2606"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2657"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2661"/>
         <source>Requesting calibration..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2532"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2544"/>
         <source>Calibrating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2536"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2548"/>
         <source>Calibrating...
 Current speed %1 kph
 Increase speed to %2 kph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2540"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2552"/>
         <source>Calibrating...
 Stop pedalling until speed drops to 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2545"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2557"/>
         <source>Calibration completed successfully!
 Spindown %1 ms
 Zero Offset %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2553"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2620"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2672"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2565"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2632"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2684"/>
         <source>Calibration failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2573"/>
         <source>Calibration Failed: Loosen Roller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2569"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2581"/>
         <source>Calibration Failed: Tighten Roller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2588"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2639"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2600"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2651"/>
         <source>Unclip or stop pedalling to begin calibration..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2607"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2619"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Torque %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2612"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2624"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Torque %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2659"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2671"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Zero Offset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2676"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Slope %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2693"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2705"/>
         <source>Give the pedal a kick to start calibration...
 The motor will run until calibration is complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2695"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
         <source>Allow wheel speed to settle, DO NOT PEDAL...
 The motor will run until calibration is complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2700"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2712"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Gathering enough samples to calculate average: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2719"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Waiting for value to stabilize (max %1s): %2 (%3W @ %4kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2722"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
         <source>Calibration completed successfully!
 Final calibration value %1 (%2W @ %3kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2746"/>
         <source>Calibration failed! Do not pedal while calibration is taking place.
 Allow wheel to run freely.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2780"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2792"/>
         <source>Fast forward..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2813"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2825"/>
         <source>Rewind..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2843"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2855"/>
         <source>Next Lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2876"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2888"/>
         <source>Back Lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2902"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2914"/>
         <source>Increasing intensity..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2928"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2940"/>
         <source>Decreasing intensity..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="621"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="625"/>
         <source>Import Video from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="508"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="512"/>
         <source>Get Workouts from Strava Routes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="622"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="626"/>
         <source>Scan for Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1101"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1173"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3183"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1105"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1177"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3195"/>
         <source>Delete</source>
         <translation type="unfinished">Excluir</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1309"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1313"/>
         <source>Resuming..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1336"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1340"/>
         <source>Paused..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1465"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1469"/>
         <source>Starting..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1673"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1677"/>
         <source>Stopped..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1763"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1769"/>
         <source>Connected..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1787"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1793"/>
         <source>Disconnected..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2198"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2210"/>
         <source>New lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>No Devices Configured</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>Please configure a device in Preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2483"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2495"/>
         <source>Exiting calibration..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2498"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2510"/>
         <source>Calibration not supported for this device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2505"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2517"/>
         <source>Calibrating...
 Press F3 on Controller when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3135"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3153"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3147"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3165"/>
         <source>Add Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3140"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3158"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3152"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3170"/>
         <source>Delete Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3181"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3193"/>
         <source>Are you sure you want to delete this device?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -32486,7 +32347,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>UniqueLabelEditDelegate</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="77"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="108"/>
         <source>The given value &quot;%1&quot; is not unique</source>
         <translation type="unfinished"></translation>
     </message>
@@ -32502,171 +32363,155 @@ Press F3 on Controller when done.</source>
 <context>
     <name>UserChartSettings</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="772"/>
+        <location filename="../../Charts/UserChart.cpp" line="773"/>
         <source>Chart</source>
         <translation type="unfinished">Gráfico</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="782"/>
+        <location filename="../../Charts/UserChart.cpp" line="783"/>
         <source>Sub-title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="785"/>
+        <location filename="../../Charts/UserChart.cpp" line="786"/>
         <source>Description</source>
         <translation type="unfinished">Descrição</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="791"/>
+        <location filename="../../Charts/UserChart.cpp" line="792"/>
         <source>Line Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="792"/>
+        <location filename="../../Charts/UserChart.cpp" line="793"/>
         <source>Scatter Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="793"/>
+        <location filename="../../Charts/UserChart.cpp" line="794"/>
         <source>Bar Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="794"/>
+        <location filename="../../Charts/UserChart.cpp" line="795"/>
         <source>Stacked Bar Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="795"/>
+        <location filename="../../Charts/UserChart.cpp" line="796"/>
         <source>Stacked Percent Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="796"/>
+        <location filename="../../Charts/UserChart.cpp" line="797"/>
         <source>Pie Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="800"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="801"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="804"/>
+        <location filename="../../Charts/UserChart.cpp" line="805"/>
         <source>Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="805"/>
+        <location filename="../../Charts/UserChart.cpp" line="806"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="808"/>
+        <location filename="../../Charts/UserChart.cpp" line="809"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="812"/>
+        <location filename="../../Charts/UserChart.cpp" line="813"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="813"/>
+        <location filename="../../Charts/UserChart.cpp" line="814"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="814"/>
+        <location filename="../../Charts/UserChart.cpp" line="815"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="815"/>
+        <location filename="../../Charts/UserChart.cpp" line="816"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="816"/>
+        <location filename="../../Charts/UserChart.cpp" line="817"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="820"/>
+        <location filename="../../Charts/UserChart.cpp" line="821"/>
         <source>Legend</source>
         <translation type="unfinished">Legenda</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="829"/>
+        <location filename="../../Charts/UserChart.cpp" line="830"/>
         <source>Font scaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="831"/>
-        <location filename="../../Charts/UserChart.cpp" line="833"/>
+        <location filename="../../Charts/UserChart.cpp" line="832"/>
+        <location filename="../../Charts/UserChart.cpp" line="834"/>
         <source>Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="836"/>
+        <location filename="../../Charts/UserChart.cpp" line="837"/>
         <source>Animate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="838"/>
+        <location filename="../../Charts/UserChart.cpp" line="839"/>
         <source>Single series per plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="841"/>
+        <location filename="../../Charts/UserChart.cpp" line="842"/>
         <source>Refresh for intervals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="848"/>
+        <location filename="../../Charts/UserChart.cpp" line="849"/>
         <source>Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Y Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="870"/>
-        <location filename="../../Charts/UserChart.cpp" line="932"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/UserChart.cpp" line="889"/>
-        <source>Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/UserChart.cpp" line="890"/>
-        <source>Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/UserChart.cpp" line="911"/>
+        <location filename="../../Charts/UserChart.cpp" line="885"/>
         <source>Axes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33332,72 +33177,72 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VideoWindow</name>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> kph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="119"/>
+        <location filename="../../Train/VideoWindow.cpp" line="144"/>
         <source>Meters layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="127"/>
+        <location filename="../../Train/VideoWindow.cpp" line="152"/>
         <source>Reset Meters layout to default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> feet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="625"/>
+        <location filename="../../Train/VideoWindow.cpp" line="681"/>
         <source>w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="629"/>
+        <location filename="../../Train/VideoWindow.cpp" line="685"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> km</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> mi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="673"/>
+        <location filename="../../Train/VideoWindow.cpp" line="729"/>
         <source>Calibration required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="678"/>
+        <location filename="../../Train/VideoWindow.cpp" line="734"/>
         <source>Configuration required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="683"/>
+        <location filename="../../Train/VideoWindow.cpp" line="739"/>
         <source>brake fault</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="688"/>
+        <location filename="../../Train/VideoWindow.cpp" line="744"/>
         <source>Ready</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33832,27 +33677,27 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WheelSizeCalculator</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="202"/>
+        <location filename="../../Gui/AthletePages.cpp" line="187"/>
         <source>Wheel Size Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="221"/>
+        <location filename="../../Gui/AthletePages.cpp" line="206"/>
         <source>Rim Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="222"/>
+        <location filename="../../Gui/AthletePages.cpp" line="207"/>
         <source>Tire Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="223"/>
+        <location filename="../../Gui/AthletePages.cpp" line="208"/>
         <source>Wheel Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="227"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33964,12 +33809,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutFilterBox</name>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="34"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="44"/>
         <source>Filter...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="64"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="95"/>
         <source>ERROR: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33977,35 +33822,118 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutImportDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="820"/>
+        <location filename="../../Train/Library.cpp" line="809"/>
         <source>Import to Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="854"/>
+        <location filename="../../Train/Library.cpp" line="843"/>
         <source>Please note, that when importing or drag and dropping videos into the library we DO NOT copy the file into the GoldenCheetah library, instead we add a REFERENCE to it. We DO copy workout and videoSync files, since they are smaller.
 
 You can remove references when managing the library via the context menu options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="868"/>
+        <location filename="../../Train/Library.cpp" line="857"/>
         <source>Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="878"/>
+        <location filename="../../Train/Library.cpp" line="867"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="880"/>
+        <location filename="../../Train/Library.cpp" line="869"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="884"/>
+        <location filename="../../Train/Library.cpp" line="873"/>
         <source>Overwite existing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WorkoutMenuProvider</name>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="271"/>
+        <source>Select Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="274"/>
+        <source>Manage Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="275"/>
+        <source>Add Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="289"/>
+        <source>Add Tag to Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="292"/>
+        <source>Filter Tags...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="310"/>
+        <source>Match all selected tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="353"/>
+        <source>Manage Workout Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="360"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="361"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="362"/>
+        <source>_index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="370"/>
+        <source>Execute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="371"/>
+        <source>Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="423"/>
+        <source>Add Workout Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="426"/>
+        <source>Name of the Filter...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="467"/>
+        <source>New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="469"/>
+        <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -34021,41 +33949,41 @@ You can remove references when managing the library via the context menu options
     <name>WorkoutPlotWindow</name>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="40"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="104"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
         <source>Ergmode specific settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="46"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
         <source>Color power zones</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="48"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="56"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="49"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="50"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="57"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="109"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="113"/>
         <source>When stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="54"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="110"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
         <source>Show tooltip</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34141,12 +34069,12 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>WorkoutWidget</name>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="1531"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="1532"/>
         <source>File save failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="2367"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="2368"/>
         <source>Intensity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34300,26 +34228,22 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="44"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="45"/>
         <source>xData</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="58"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="59"/>
         <source>Data Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="78"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="80"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="79"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="81"/>
         <source>Delete</source>
-        <translation type="unfinished">Excluir</translation>
+        <translation type="obsolete">Excluir</translation>
     </message>
 </context>
 <context>
@@ -34396,32 +34320,32 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataSeriesSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="333"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="315"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="338"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="320"/>
         <source>Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="346"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="328"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="347"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="329"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Name is blank</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34429,48 +34353,48 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="262"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="244"/>
         <source>xData</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="269"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="251"/>
         <source>Data Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="270"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="252"/>
         <source>Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="274"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="256"/>
         <source>Series %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="281"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="263"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="282"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="264"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
         <source>XData name is blank</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Must have at least one data series.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34791,17 +34715,17 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="915"/>
+        <location filename="../../Gui/AthletePages.cpp" line="886"/>
         <source>Sport</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="962"/>
+        <location filename="../../Gui/AthletePages.cpp" line="933"/>
         <source>Critical Power</source>
         <translation type="unfinished">Potência Crítica</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="963"/>
+        <location filename="../../Gui/AthletePages.cpp" line="934"/>
         <source>Default</source>
         <translation type="unfinished">Padrão</translation>
     </message>

--- a/src/Resources/translations/gc_pt.ts
+++ b/src/Resources/translations/gc_pt.ts
@@ -99,38 +99,38 @@ It might be necessary to manually disable it.</source>
         <translation type="obsolete">TLP média</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="504"/>
+        <location filename="../../Gui/AthletePages.cpp" line="489"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="517"/>
-        <location filename="../../Gui/AthletePages.cpp" line="522"/>
+        <location filename="../../Gui/AthletePages.cpp" line="502"/>
+        <location filename="../../Gui/AthletePages.cpp" line="507"/>
         <source>days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="525"/>
+        <location filename="../../Gui/AthletePages.cpp" line="510"/>
         <source>PMC Stress Balance Today</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="528"/>
+        <location filename="../../Gui/AthletePages.cpp" line="513"/>
         <source>Restore Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="517"/>
         <source>W&apos;bal tau</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="518"/>
         <source>Short Term Stress (STS) average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="534"/>
+        <location filename="../../Gui/AthletePages.cpp" line="519"/>
         <source>Long Term Stress (LTS) average</source>
         <translation type="unfinished"></translation>
     </message>
@@ -146,96 +146,96 @@ It might be necessary to manually disable it.</source>
 <context>
     <name>AboutRiderPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="372"/>
+        <location filename="../../Gui/AthletePages.cpp" line="357"/>
         <source>Nickname</source>
         <translation type="unfinished">Alcunha</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="373"/>
+        <location filename="../../Gui/AthletePages.cpp" line="358"/>
         <source>Date of Birth</source>
         <translation type="unfinished">Data de nascimento</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="374"/>
+        <location filename="../../Gui/AthletePages.cpp" line="359"/>
         <source>Sex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="376"/>
+        <location filename="../../Gui/AthletePages.cpp" line="361"/>
         <source>Weight</source>
         <translation type="unfinished">Peso</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="375"/>
+        <location filename="../../Gui/AthletePages.cpp" line="360"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="279"/>
+        <location filename="../../Gui/AthletePages.cpp" line="264"/>
         <source>Male</source>
         <translation type="unfinished">Masculino</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="280"/>
+        <location filename="../../Gui/AthletePages.cpp" line="265"/>
         <source>Female</source>
         <translation type="unfinished">Feminino</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> kg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> lb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> cm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="359"/>
+        <location filename="../../Gui/AthletePages.cpp" line="344"/>
         <source>Calculate...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="378"/>
+        <location filename="../../Gui/AthletePages.cpp" line="363"/>
         <source>Bike</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="379"/>
+        <location filename="../../Gui/AthletePages.cpp" line="364"/>
         <source>Crank Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="380"/>
+        <location filename="../../Gui/AthletePages.cpp" line="365"/>
         <source>Wheelsize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="438"/>
+        <location filename="../../Gui/AthletePages.cpp" line="423"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="356"/>
+        <location filename="../../Gui/AthletePages.cpp" line="341"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="437"/>
+        <location filename="../../Gui/AthletePages.cpp" line="422"/>
         <source>Choose Picture</source>
         <translation type="unfinished">Escolhe imagem</translation>
     </message>
@@ -2228,397 +2228,382 @@ Press Next to Continue
 <context>
     <name>AllPlotWindow</name>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="190"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="444"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="165"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
         <source>Smooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="198"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="173"/>
         <source>Stacked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="199"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="174"/>
         <source>by series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="200"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="175"/>
         <source>Fullplot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="201"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="176"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="239"/>
         <source>Overlay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="229"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="204"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="206"/>
         <source>Stack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="210"/>
         <source>By Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="246"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="221"/>
         <source>Stack Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="248"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="223"/>
         <source>Full plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="227"/>
         <source>Show Interval Markers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="256"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
         <source>Interval Navigator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="260"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
         <source>Hover intervals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="268"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="243"/>
         <source>Fill Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="247"/>
         <source>Grid</source>
         <translation>Grade</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="277"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
         <source>Acceleration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="279"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="254"/>
         <source>Delta Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="280"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="255"/>
         <source>Power %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="283"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="258"/>
         <source>Cadence %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="261"/>
         <source>Torque %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="289"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
         <source>Heartrate %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="295"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="270"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
         <source>Left/Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="274"/>
         <source>Torque Effectiveness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="303"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="278"/>
         <source>Smoothness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="282"/>
         <source>Pedal Center Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="311"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
         <source>Power Phase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="290"/>
         <source>Peak Power Phase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="322"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
         <source>Vertical Oscillation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="324"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
         <source>Running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="326"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="301"/>
         <source>Ground Contact Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
         <source>Cadence </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="313"/>
         <source>SmO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="340"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
         <source>Moxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="317"/>
         <source>tHb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="321"/>
         <source>O2Hb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="325"/>
         <source>HHb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="355"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="330"/>
         <source>Heart Rate</source>
         <translation>Frequência Cardíaca</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="357"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
         <source>Data series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="359"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="334"/>
         <source>Core Temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="363"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
         <source>Speed</source>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="367"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
         <source>Cadence</source>
         <translation>Cadência</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="94"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="95"/>
         <source>Basic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="109"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="110"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="116"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="117"/>
         <source>User Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="132"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="134"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="144"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="163"/>
-        <source>Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="164"/>
-        <source>Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="371"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
         <source>Altitude</source>
         <translation>Altitude</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
         <source>Temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="379"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="354"/>
         <source>Headwind</source>
         <translation type="unfinished">Vento de frente</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="383"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="358"/>
         <source>Torque</source>
         <translation type="unfinished">Torque</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="387"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="362"/>
         <source>Gear Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="391"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="366"/>
         <source>Slope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="373"/>
         <source>No Alt/Slope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="399"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="374"/>
         <source>0.1km|mi -  1min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="400"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
         <source>0.5km|mi -  5min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="401"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="376"/>
         <source>1.0km|mi - 10min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1528"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="377"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="1503"/>
         <source>Alt/Slope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="382"/>
         <source>Anaerobic TISS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="384"/>
         <source>Metrics</source>
         <translation type="unfinished">Métrica</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="411"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="386"/>
         <source>Aerobic TISS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="390"/>
         <source>Iso Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="394"/>
         <source>Skiba xPower</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="423"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
         <source>Altitude Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="427"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
         <source>W&apos; balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="441"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="416"/>
         <source>Time of day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="742"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="717"/>
         <source>Intervals</source>
         <translation type="unfinished">Intervalos</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="2253"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="2228"/>
         <source>Selection #%1 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="432"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
         <source>Power + shade</source>
         <translation>Potência + tom</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="433"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="408"/>
         <source>Power - shade</source>
         <translation>Portência - tom</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="434"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
         <source>No Power</source>
         <translation>Sem Potência</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="435"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="410"/>
         <source>Shading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="439"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="414"/>
         <source>Time</source>
         <translation type="unfinished">Tempo</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="440"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
         <source>Distance</source>
         <translation type="unfinished">Distância</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="442"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="417"/>
         <source>X Axis</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3424,51 +3409,29 @@ Press Next to Continue
 <context>
     <name>AutoImportPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4028"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4029"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Browse</source>
         <translation type="obsolete">Navegar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4040"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4041"/>
         <source>Delete</source>
-        <translation type="unfinished">Apagar</translation>
+        <translation type="obsolete">Apagar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4042"/>
-        <source>Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4043"/>
-        <source>Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4054"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3779"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4059"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3784"/>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4060"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3785"/>
         <source>Import Rule</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4282,37 +4245,37 @@ Press Next to Continue
 <context>
     <name>BackupPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="608"/>
+        <location filename="../../Gui/AthletePages.cpp" line="593"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="601"/>
         <source>every</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="617"/>
+        <location filename="../../Gui/AthletePages.cpp" line="602"/>
         <source>times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="603"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="605"/>
         <source>Backup now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="623"/>
+        <location filename="../../Gui/AthletePages.cpp" line="608"/>
         <source>Auto Backup Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="624"/>
+        <location filename="../../Gui/AthletePages.cpp" line="609"/>
         <source>Auto Backup after closing the athlete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5114,41 +5077,25 @@ Let&apos;s get you setup.</source>
 <context>
     <name>CPPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1202"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1203"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1204"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1150"/>
         <source>Review...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1206"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1152"/>
         <source>Changed power estimates are available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1213"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1225"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1214"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1226"/>
         <source>Delete</source>
-        <translation type="unfinished">Apagar</translation>
+        <translation type="obsolete">Apagar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1216"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1158"/>
         <source>Def</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5157,244 +5104,244 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">Desde do data</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1218"/>
         <source>Critical Power</source>
         <translation>Potência Crítica</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1305"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>AeTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1306"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>FTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1307"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1221"/>
         <source>W&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1308"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1222"/>
         <source>Pmax</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1347"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1261"/>
         <source>Short</source>
         <translation>Curto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1247"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1169"/>
         <source>Use CP for all metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1240"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1162"/>
         <source>Manual</source>
         <translation type="unfinished">Manual</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1241"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1163"/>
         <source>Semi-Automatic (CP2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1164"/>
         <source>Semi-Automatic (CP3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1243"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1165"/>
         <source>Semi-Automatic (Extended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1170"/>
         <source>Use FTP for Coggan metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1273"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1279"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1285"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1342"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1618"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1631"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2283"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2289"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2310"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1187"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1193"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1199"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1211"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1537"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1545"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2180"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2186"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2194"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2207"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1205"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1547"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2201"/>
         <source>J</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1303"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1217"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2145"/>
         <source>Start Date</source>
         <translation type="unfinished">Data de início</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1309"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1223"/>
         <source>Model Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1262"/>
         <source>Long</source>
         <translation>Comprido</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1349"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1263"/>
         <source>From Watts</source>
         <translation>De watts</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1598"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1512"/>
         <source>Review range starting on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1614"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1528"/>
         <source>Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1615"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1529"/>
         <source>Estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1530"/>
         <source>Accept</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1788"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1691"/>
         <source>🗹</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1692"/>
         <source>Estimate and settings &lt;b&gt;match&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1695"/>
         <source>☐</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1696"/>
         <source>Estimate and settings &lt;b&gt;differ&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1797"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1700"/>
         <source>⏲</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1800"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1703"/>
         <source>Range is %1 days older than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1802"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1705"/>
         <source>Range is %1 days younger than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1808"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1711"/>
         <source>∅</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1712"/>
         <source>No estimate available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1902"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1805"/>
         <source>New range from estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2237"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2134"/>
         <source>The proposed value for AeTP is a very rough estimate, assuming %1 % of CP. Usually it is determined by a&lt;ul&gt;&lt;li&gt;Metabolic test&lt;/li&gt;&lt;li&gt;Lactate ramp test&lt;/li&gt;&lt;li&gt;Run / Cycling ‘conversational’ test&lt;/li&gt;&lt;li&gt;Run Decoupling test&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2239"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2136"/>
         <source>Updating FTP internally to match CP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2139"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2244"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2141"/>
         <source>Your selected model does not deliver values for PMax, using default value of %1 W instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2246"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2143"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;li&gt;PMax, assuming a default of %1 W&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2250"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2147"/>
         <source>Critical Power (CP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2252"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2149"/>
         <source>Aerobic Threshold Power (AeTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2254"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2151"/>
         <source>Functional Threshold Power (FTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2153"/>
         <source>Anaerobic Work Capacity (W&apos;)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2258"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2155"/>
         <source>Maximum Power (PMax)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2270"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2167"/>
         <source>Manual range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2018"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2025"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1917"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1924"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2020"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1919"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1926"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5838,52 +5785,36 @@ ddd, dd MMM yyyy</source>
 <context>
     <name>CVPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3307"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3319"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3308"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3320"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3313"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3325"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3314"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3326"/>
         <source>Delete</source>
-        <translation type="unfinished">Apagar</translation>
+        <translation type="obsolete">Apagar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3316"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3109"/>
         <source>Def</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3359"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3506"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3272"/>
         <source>Start Date</source>
         <translation type="unfinished">Data de início</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3249"/>
         <source>New range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3507"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3273"/>
         <source>Critical Velocity (CV)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3508"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3274"/>
         <source>Aerobic Threshold (AeT)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5892,39 +5823,39 @@ ddd, dd MMM yyyy</source>
         <translation type="obsolete">Desde do data</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3360"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3128"/>
         <source>Critical Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3361"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3129"/>
         <source>Aerobic Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3403"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
         <source>Short</source>
         <translation type="unfinished">Curto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3404"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3172"/>
         <source>Long</source>
         <translation type="unfinished">Comprido</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3405"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3173"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3679"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3686"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3441"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3448"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3681"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3688"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3443"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3450"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7448,37 +7379,20 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>CredentialsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="67"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
+        <source>Add</source>
+        <translation type="obsolete">Adicionar</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="obsolete">Apagar</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="68"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="69"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="74"/>
-        <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="75"/>
-        <source>Delete</source>
-        <translation type="unfinished">Apagar</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="86"/>
         <source>Service</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="87"/>
+        <location filename="../../Gui/AthletePages.cpp" line="69"/>
         <source>Description</source>
         <translation type="unfinished">Descrição</translation>
     </message>
@@ -8153,7 +8067,7 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>DataFilterEdit</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2743"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2712"/>
         <source>Warning: sample() is slow -- update code to use samples()</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8488,7 +8402,7 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>DirectoryPathWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="277"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="308"/>
         <source>Browse</source>
         <translation type="unfinished">Navegar</translation>
     </message>
@@ -8723,28 +8637,28 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>Dropbox</name>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="68"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="77"/>
         <source>Problem accessing Dropbox data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="130"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="139"/>
         <source>You must authorise with Dropbox first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="205"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="214"/>
         <source>Parsing Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="293"/>
-        <location filename="../../Cloud/Dropbox.cpp" line="312"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="302"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="321"/>
         <source>Completed.</source>
         <translation type="unfinished">Concluído.</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="297"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="306"/>
         <source>Network Error - Upload failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8885,136 +8799,136 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2064"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2033"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2034"/>
         <source>Axis Label / Units</source>
         <translation type="unfinished">Titúlos/unidades dos eixos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1597"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1566"/>
         <source>Curve Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1558"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1527"/>
         <source>Estimate %1 %2 Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1562"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1531"/>
         <source>Endurance Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1532"/>
         <source>Vo2Max Estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1605"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1574"/>
         <source>Metric</source>
         <translation type="unfinished">Métrico</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1606"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1575"/>
         <source>Best</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1607"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1576"/>
         <source>Estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1577"/>
         <source>PMC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1609"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1578"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1610"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1579"/>
         <source>Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1611"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1580"/>
         <source>Performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1612"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1581"/>
         <source>Banister</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1684"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1767"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1653"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1736"/>
         <source>seconds</source>
         <translation type="unfinished">segundos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1685"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1768"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1737"/>
         <source>minutes</source>
         <translation type="unfinished">minutos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1769"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1655"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1738"/>
         <source>hours</source>
         <translation type="unfinished">horas</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1723"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1816"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1692"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1785"/>
         <source>Peak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1781"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1750"/>
         <source>Absolute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1751"/>
         <source>Per Kilogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1813"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
         <source>Total</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1814"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1783"/>
         <source>Running Total</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1815"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1784"/>
         <source>Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1817"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1786"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1820"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1789"/>
         <source>Aggregate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1828"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1797"/>
         <source># type in a formula to use
 # for e.g. BikeStress / Duration
 # as you type the available metrics
@@ -9023,292 +8937,292 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1839"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1808"/>
         <source>Weekly Best Performances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1840"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1809"/>
         <source>Submaximal Weekly Best</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1841"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1810"/>
         <source>Performance Tests</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1933"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1902"/>
         <source>Short Term Stress (STS/ATL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1934"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1903"/>
         <source>Long Term Stress  (LTS/CTL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1935"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1904"/>
         <source>Stress Balance    (SB/TSB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1936"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1905"/>
         <source>Stress Ramp Rate  (RR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1944"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1913"/>
         <source>Stress Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1949"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1918"/>
         <source>Negative Training Effect (NTE)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1950"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1919"/>
         <source>Positive Training Effect (PTE)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1951"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1920"/>
         <source>Performance (Power Index)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1952"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1921"/>
         <source>Predicted CP (Watts)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1969"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1938"/>
         <source>Curve Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1945"/>
         <source>Perf. Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2006"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1975"/>
         <source>Metadata Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2007"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
         <source>PMC metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2032"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2001"/>
         <source>Measure Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2009"/>
         <source>Measure Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2029"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2071"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2042"/>
         <source>Bar</source>
         <translation type="unfinished">Barra</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2074"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2043"/>
         <source>Line</source>
         <translation type="unfinished">Linha</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2075"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2044"/>
         <source>Sticks</source>
         <translation type="unfinished">Palitos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2076"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2045"/>
         <source>Dots</source>
         <translation type="unfinished">Pontos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2048"/>
         <source>Stack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2053"/>
         <source>Symbol</source>
         <translation type="unfinished">Símbolo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2086"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2055"/>
         <source>None</source>
         <translation type="unfinished">Nenhum</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2087"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2056"/>
         <source>Circle</source>
         <translation type="unfinished">Círculo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2057"/>
         <source>Square</source>
         <translation type="unfinished">Quadrado</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2089"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2058"/>
         <source>Diamond</source>
         <translation type="unfinished">Losango</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2090"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2059"/>
         <source>Triangle</source>
         <translation type="unfinished">Triângulo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2091"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
         <source>Cross</source>
         <translation type="unfinished">Cruz</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2092"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2061"/>
         <source>Hexagon</source>
         <translation type="unfinished">Hexágono</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2062"/>
         <source>Star</source>
         <translation type="unfinished">Estrela</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
         <source>Color</source>
         <translation type="unfinished">Cor</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2100"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2069"/>
         <source>Fill curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
         <source>Data labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2080"/>
         <source>Highlight Highest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
         <source>Highlight Lowest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2127"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
         <source>Highlight Outliers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2135"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
         <source>Baseline</source>
         <translation type="unfinished">Linha de base</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2143"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2112"/>
         <source>Smooth Curve</source>
         <translation type="unfinished">Curva suave</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2147"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2116"/>
         <source>No trend Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2148"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2117"/>
         <source>Linear Trend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2149"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2118"/>
         <source>Quadratic Trend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2150"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
         <source>Moving Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2151"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2120"/>
         <source>Simple Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2123"/>
         <source>Ignore Zeros</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2168"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2201"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2170"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2431"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2400"/>
         <source>Peak %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2402"/>
         <source> second </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2434"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2403"/>
         <source> minute </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2436"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2405"/>
         <source> hour </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2456"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2425"/>
         <source>%1 - %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2470"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2439"/>
         <source>Performances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2471"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2440"/>
         <source>Power Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2588"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2557"/>
         <source>Performances_%1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9630,93 +9544,93 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditUserAxisDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1731"/>
+        <location filename="../../Charts/UserChart.cpp" line="1689"/>
         <source>Edit Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1741"/>
+        <location filename="../../Charts/UserChart.cpp" line="1699"/>
         <source>&amp;OK</source>
         <translation type="unfinished">&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1742"/>
+        <location filename="../../Charts/UserChart.cpp" line="1700"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1750"/>
+        <location filename="../../Charts/UserChart.cpp" line="1708"/>
         <source>Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1760"/>
+        <location filename="../../Charts/UserChart.cpp" line="1718"/>
         <source>Logarithmic Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1757"/>
+        <location filename="../../Charts/UserChart.cpp" line="1715"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1761"/>
-        <location filename="../../Charts/UserChart.cpp" line="1780"/>
+        <location filename="../../Charts/UserChart.cpp" line="1719"/>
+        <location filename="../../Charts/UserChart.cpp" line="1738"/>
         <source> </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1763"/>
+        <location filename="../../Charts/UserChart.cpp" line="1721"/>
         <source>Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1774"/>
+        <location filename="../../Charts/UserChart.cpp" line="1732"/>
         <source> from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1776"/>
+        <location filename="../../Charts/UserChart.cpp" line="1734"/>
         <source> to </source>
         <translation type="unfinished">a</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1779"/>
+        <location filename="../../Charts/UserChart.cpp" line="1737"/>
         <source>Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1787"/>
+        <location filename="../../Charts/UserChart.cpp" line="1745"/>
         <source>Smoothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1792"/>
+        <location filename="../../Charts/UserChart.cpp" line="1750"/>
         <source>None</source>
         <translation type="unfinished">Nenhum</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1793"/>
+        <location filename="../../Charts/UserChart.cpp" line="1751"/>
         <source>Day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1794"/>
+        <location filename="../../Charts/UserChart.cpp" line="1752"/>
         <source>Week</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1795"/>
+        <location filename="../../Charts/UserChart.cpp" line="1753"/>
         <source>Month</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1796"/>
+        <location filename="../../Charts/UserChart.cpp" line="1754"/>
         <source>Year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1798"/>
+        <location filename="../../Charts/UserChart.cpp" line="1756"/>
         <source>Group By</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9909,158 +9823,158 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditUserSeriesDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1398"/>
+        <location filename="../../Charts/UserChart.cpp" line="1356"/>
         <source>Edit Data Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1414"/>
+        <location filename="../../Charts/UserChart.cpp" line="1372"/>
         <source>&amp;OK</source>
         <translation type="unfinished">&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1415"/>
+        <location filename="../../Charts/UserChart.cpp" line="1373"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1422"/>
+        <location filename="../../Charts/UserChart.cpp" line="1380"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1430"/>
+        <location filename="../../Charts/UserChart.cpp" line="1388"/>
         <source>Series Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1519"/>
+        <location filename="../../Charts/UserChart.cpp" line="1477"/>
         <source>Y units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1524"/>
+        <location filename="../../Charts/UserChart.cpp" line="1482"/>
         <source>X units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1528"/>
+        <location filename="../../Charts/UserChart.cpp" line="1486"/>
         <source>Sum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1529"/>
+        <location filename="../../Charts/UserChart.cpp" line="1487"/>
         <source>Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1530"/>
+        <location filename="../../Charts/UserChart.cpp" line="1488"/>
         <source>Peak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1531"/>
+        <location filename="../../Charts/UserChart.cpp" line="1489"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1532"/>
+        <location filename="../../Charts/UserChart.cpp" line="1490"/>
         <source>Running Total</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1533"/>
+        <location filename="../../Charts/UserChart.cpp" line="1491"/>
         <source>Mean Square Root</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1534"/>
+        <location filename="../../Charts/UserChart.cpp" line="1492"/>
         <source>Std Deviation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1537"/>
+        <location filename="../../Charts/UserChart.cpp" line="1495"/>
         <source>Aggregate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1541"/>
-        <location filename="../../Charts/UserChart.cpp" line="1557"/>
+        <location filename="../../Charts/UserChart.cpp" line="1499"/>
+        <location filename="../../Charts/UserChart.cpp" line="1515"/>
         <source>None</source>
         <translation type="unfinished">Nenhum</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1542"/>
+        <location filename="../../Charts/UserChart.cpp" line="1500"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1543"/>
+        <location filename="../../Charts/UserChart.cpp" line="1501"/>
         <source>Dashed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1544"/>
+        <location filename="../../Charts/UserChart.cpp" line="1502"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1545"/>
+        <location filename="../../Charts/UserChart.cpp" line="1503"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1546"/>
+        <location filename="../../Charts/UserChart.cpp" line="1504"/>
         <source>Fast Graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1547"/>
+        <location filename="../../Charts/UserChart.cpp" line="1505"/>
         <source>Show on Legend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1548"/>
+        <location filename="../../Charts/UserChart.cpp" line="1506"/>
         <source>Show Data Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1554"/>
+        <location filename="../../Charts/UserChart.cpp" line="1512"/>
         <source>Line Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1558"/>
+        <location filename="../../Charts/UserChart.cpp" line="1516"/>
         <source>Circle</source>
         <translation type="unfinished">Círculo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1559"/>
+        <location filename="../../Charts/UserChart.cpp" line="1517"/>
         <source>Rectangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1564"/>
+        <location filename="../../Charts/UserChart.cpp" line="1522"/>
         <source>Symbol</source>
         <translation type="unfinished">Símbolo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1572"/>
+        <location filename="../../Charts/UserChart.cpp" line="1530"/>
         <source>Color</source>
         <translation type="unfinished">Cor</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1575"/>
+        <location filename="../../Charts/UserChart.cpp" line="1533"/>
         <source>Fill curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1583"/>
+        <location filename="../../Charts/UserChart.cpp" line="1541"/>
         <source>Opacity (%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1589"/>
+        <location filename="../../Charts/UserChart.cpp" line="1547"/>
         <source>Size/Width</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10106,6 +10020,24 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
     <message>
         <location filename="../../Metrics/BasicRideMetrics.cpp" line="144"/>
         <source>Only useful for intervals, time the interval started</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ElevationChartWindow</name>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="221"/>
+        <source>Profile Distance (m)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="229"/>
+        <source>Seconds for delta slope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="237"/>
+        <source>Elevation window size (%) relative to current altitude</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10541,7 +10473,7 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ExhaustionDialog.cpp" line="160"/>
+        <location filename="../../Charts/ExhaustionDialog.cpp" line="162"/>
         <source>Time</source>
         <translation type="unfinished">Tempo</translation>
     </message>
@@ -12712,42 +12644,42 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>GcCrashDialog</name>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="78"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="74"/>
         <source>%1 Crash Recovery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="116"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="112"/>
         <source>&lt;b&gt;GoldenCheetah appears to have PREVIOUSLY crashed for this athlete. &lt;/b&gt;&lt;br&gt;&lt;br&gt;The report below gives some diagnostic information that will be useful to the developers. Feel free to post this with a short description of what was occurring when the crash happened to the &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah forums&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;We respect privacy - this log does NOT contain ids, passwords or personal information.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;When this dialog is closed the athlete will be opened.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="141"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="137"/>
         <source>Save Crash Report...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="143"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="139"/>
         <source>Close</source>
         <translation type="unfinished">Fechar</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="225"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="221"/>
         <source>&lt;p&gt;Build date: %1 %2&lt;br&gt;Build id: %3&lt;br&gt;Version: %4&lt;br&gt;DB Schema: %5&lt;br&gt;Metrics: %7&lt;br&gt;OS: %6&lt;br&gt;OpenGL: %10&lt;br&gt;UI: dpi scale (%8) font size (%9)&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="255"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="251"/>
         <source>&lt;table&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QT&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QWT&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;%3&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SRMIO&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;D2XX&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;ICAL&lt;/td&gt;&lt;td&gt;%9&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;USBXPRESS&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LIBUSB&lt;/td&gt;&lt;td&gt;%11&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VLC&lt;/td&gt;&lt;td&gt;%12&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VIDEO&lt;/td&gt;&lt;td&gt;%13&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SAMPLERATE&lt;/td&gt;&lt;td&gt;%14&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SSL&lt;/td&gt;&lt;td&gt;%15&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;R&lt;/td&gt;&lt;td&gt;%16&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;Python&lt;/td&gt;&lt;td&gt;%18&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LMFIT&lt;/td&gt;&lt;td&gt;7.0&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;GSL&lt;/td&gt;&lt;td&gt;%19&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Save Diagnostics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Text File (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13082,167 +13014,172 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>GcWindowRegistry</name>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
         <source>Performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="89"/>
         <source>Histogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
         <source>Distribution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
         <source>Pedal Force vs Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
         <source>Heartrate vs Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
         <source>Python Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
         <source>Python Chart </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="101"/>
         <source>Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
         <source>Navigator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="71"/>
         <source>Season Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="72"/>
         <source>Blank Overview </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="76"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="73"/>
         <source>User Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
         <source>Trends</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="78"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
         <source>TreeMap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
         <source>Power Duration </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="83"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
         <source>Activity Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="81"/>
         <source>Blank Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="85"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="82"/>
         <source>User Chart </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
         <source>Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="88"/>
         <source>Power Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
         <source>Scatter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="103"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
         <source>Aerolab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
         <source>Workout</source>
         <translation type="unfinished">Treino</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="106"/>
         <source>Realtime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
         <source>Pedal Stroke</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="113"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
         <source>Live Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="114"/>
-        <source>Web page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
-        <source>Map</source>
-        <translation type="unfinished">Mapa</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
-        <source>R Chart</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="98"/>
-        <source>R Chart </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
-        <source>Video Player</source>
+        <source>Elevation Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
+        <source>Web page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <source>Map</source>
+        <translation type="unfinished">Mapa</translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <source>R Chart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <source>R Chart </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <source>Video Player</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
         <source>Workout Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14335,142 +14272,147 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="296"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="294"/>
+        <source>Show elevation profile of instant position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
         <source>Predefined and configurable set of data ranges for selection of activities to be analysed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
         <source>Powerful filter and search engine to determine the activities which are considered in diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
         <source>Configurable list of activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="317"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
         <source>Configurable list of training devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
         <source>Configurable list of workout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
         <source>Configurable list of video files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="325"/>
         <source>Configurable list of video sync files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="327"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
         <source>Entry field for sophisticated Searching and Filtering of activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
         <source>Adding intervals to an activity using simple query methods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
         <source>To compare Activities/Intervals in Activity View and Date Ranges in Trends View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="335"/>
         <source>Workout Control, Intensity Adjustments and Notifications Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
         <source>Athlete Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
         <source>Athlete Measures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
         <source>Auto Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
         <source>Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="355"/>
         <source>Cloud Accounts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <source>Automatic Interval Detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
         <source>Definition of coloring rules for activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
         <source>Metrics shown in &apos;Intervals&apos; and &apos;Summary&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
         <source>User/Custom Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
         <source>Create or Edit a User Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
         <source>Measures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
         <source>Train View devices configuration and preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
         <source>Train View Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
         <source>Remote Controls Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
         <source>Add/Remove Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
         <source>Add Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="394"/>
         <source>Virtual Bicycle configuration for simulation rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14504,8 +14446,8 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
     </message>
     <message>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="219"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
         <source>Calendar</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14540,74 +14482,74 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
         <source>Definition of points in time &apos;Events&apos; which are marked explicitely on time related diagrams</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="316"/>
         <source>Simple summary view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
         <source>Alternative access to the charts created for the main view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
         <source>Display the available and add new intervals using simple query methods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="356"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="337"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
         <source>Athlete</source>
         <translation type="unfinished">Atleta</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
         <source>Training Zone definition for power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
         <source>Training Zone definition for heartrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
         <source>Training Zone definition for Swim and Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="364"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
         <source>Data Fields</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
         <source>Definition of default value(s) for data fields</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
         <source>Definition of processing default parameters for the fix, adjust,... tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
         <source>Metrics</source>
         <translation type="unfinished">Métrica</translation>
     </message>
@@ -14807,59 +14749,47 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2437"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2438"/>
         <source>Delete</source>
-        <translation type="unfinished">Apagar</translation>
+        <translation type="obsolete">Apagar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2431"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2432"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2447"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2332"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2458"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2343"/>
         <source>Short</source>
         <translation>Curto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2459"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2344"/>
         <source>Long</source>
         <translation>Comprido</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2460"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2345"/>
         <source>Percent of LT</source>
         <translation>Percentagem de LT</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2461"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2346"/>
         <source>Trimp k</source>
         <translation>Trimp k</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2506"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2513"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2390"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2397"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2508"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2515"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2392"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2399"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15049,17 +14979,17 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2245"/>
         <source>Sport</source>
         <translation type="unfinished">Desporto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2395"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2292"/>
         <source>Lactate Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2396"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2293"/>
         <source>Default</source>
         <translation type="unfinished">Padrão</translation>
     </message>
@@ -17194,545 +17124,530 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>LTMTool</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1303"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1272"/>
         <source>Metric</source>
         <translation>Métrico</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="351"/>
+        <location filename="../../Charts/LTMTool.cpp" line="325"/>
         <source>Skiba Long Term Stress</source>
         <translation type="unfinished">Skiba tensão a longo prazo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="89"/>
+        <location filename="../../Charts/LTMTool.cpp" line="90"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="94"/>
+        <location filename="../../Charts/LTMTool.cpp" line="95"/>
         <source>Data Table</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="98"/>
+        <location filename="../../Charts/LTMTool.cpp" line="99"/>
         <source>Show Stack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="121"/>
+        <location filename="../../Charts/LTMTool.cpp" line="122"/>
         <source>Stack Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="155"/>
+        <location filename="../../Charts/LTMTool.cpp" line="156"/>
         <source>Add Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="146"/>
+        <location filename="../../Charts/LTMTool.cpp" line="147"/>
         <source>Charts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="112"/>
         <source>Show Banister Helper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="155"/>
         <source>Apply</source>
         <translation type="unfinished">Aplicar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="287"/>
-        <source>Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/LTMTool.cpp" line="288"/>
-        <source>Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/LTMTool.cpp" line="353"/>
-        <location filename="../../Charts/LTMTool.cpp" line="368"/>
-        <location filename="../../Charts/LTMTool.cpp" line="429"/>
-        <location filename="../../Charts/LTMTool.cpp" line="444"/>
-        <location filename="../../Charts/LTMTool.cpp" line="505"/>
-        <location filename="../../Charts/LTMTool.cpp" line="520"/>
-        <location filename="../../Charts/LTMTool.cpp" line="580"/>
-        <location filename="../../Charts/LTMTool.cpp" line="595"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1080"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1095"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1156"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1171"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1309"/>
+        <location filename="../../Charts/LTMTool.cpp" line="327"/>
+        <location filename="../../Charts/LTMTool.cpp" line="342"/>
+        <location filename="../../Charts/LTMTool.cpp" line="403"/>
+        <location filename="../../Charts/LTMTool.cpp" line="418"/>
+        <location filename="../../Charts/LTMTool.cpp" line="479"/>
+        <location filename="../../Charts/LTMTool.cpp" line="494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="554"/>
+        <location filename="../../Charts/LTMTool.cpp" line="569"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1054"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1069"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1130"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1145"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1278"/>
         <source>Stress</source>
         <translation type="unfinished">Tensão</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="366"/>
+        <location filename="../../Charts/LTMTool.cpp" line="340"/>
         <source>Skiba Short Term Stress</source>
         <translation type="unfinished">Skiba tensão a curto prazo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="381"/>
+        <location filename="../../Charts/LTMTool.cpp" line="355"/>
         <source>Skiba Stress Balance</source>
         <translation type="unfinished">Skiba equilibriu de tensão</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="383"/>
-        <location filename="../../Charts/LTMTool.cpp" line="459"/>
-        <location filename="../../Charts/LTMTool.cpp" line="535"/>
-        <location filename="../../Charts/LTMTool.cpp" line="610"/>
-        <location filename="../../Charts/LTMTool.cpp" line="686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="762"/>
-        <location filename="../../Charts/LTMTool.cpp" line="838"/>
-        <location filename="../../Charts/LTMTool.cpp" line="914"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1110"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1186"/>
+        <location filename="../../Charts/LTMTool.cpp" line="357"/>
+        <location filename="../../Charts/LTMTool.cpp" line="433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="509"/>
+        <location filename="../../Charts/LTMTool.cpp" line="584"/>
+        <location filename="../../Charts/LTMTool.cpp" line="660"/>
+        <location filename="../../Charts/LTMTool.cpp" line="736"/>
+        <location filename="../../Charts/LTMTool.cpp" line="812"/>
+        <location filename="../../Charts/LTMTool.cpp" line="888"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1160"/>
         <source>Stress Balance</source>
         <translation type="unfinished">Equilibriu de tensão</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="396"/>
+        <location filename="../../Charts/LTMTool.cpp" line="370"/>
         <source>Skiba STS Ramp</source>
         <translation type="unfinished">Skiba TCP rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="398"/>
-        <location filename="../../Charts/LTMTool.cpp" line="413"/>
-        <location filename="../../Charts/LTMTool.cpp" line="474"/>
-        <location filename="../../Charts/LTMTool.cpp" line="489"/>
-        <location filename="../../Charts/LTMTool.cpp" line="550"/>
-        <location filename="../../Charts/LTMTool.cpp" line="565"/>
-        <location filename="../../Charts/LTMTool.cpp" line="625"/>
-        <location filename="../../Charts/LTMTool.cpp" line="640"/>
-        <location filename="../../Charts/LTMTool.cpp" line="701"/>
-        <location filename="../../Charts/LTMTool.cpp" line="716"/>
-        <location filename="../../Charts/LTMTool.cpp" line="777"/>
-        <location filename="../../Charts/LTMTool.cpp" line="792"/>
-        <location filename="../../Charts/LTMTool.cpp" line="853"/>
-        <location filename="../../Charts/LTMTool.cpp" line="868"/>
-        <location filename="../../Charts/LTMTool.cpp" line="929"/>
-        <location filename="../../Charts/LTMTool.cpp" line="944"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1005"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1020"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1125"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1140"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1201"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1216"/>
+        <location filename="../../Charts/LTMTool.cpp" line="372"/>
+        <location filename="../../Charts/LTMTool.cpp" line="387"/>
+        <location filename="../../Charts/LTMTool.cpp" line="448"/>
+        <location filename="../../Charts/LTMTool.cpp" line="463"/>
+        <location filename="../../Charts/LTMTool.cpp" line="524"/>
+        <location filename="../../Charts/LTMTool.cpp" line="539"/>
+        <location filename="../../Charts/LTMTool.cpp" line="599"/>
+        <location filename="../../Charts/LTMTool.cpp" line="614"/>
+        <location filename="../../Charts/LTMTool.cpp" line="675"/>
+        <location filename="../../Charts/LTMTool.cpp" line="690"/>
+        <location filename="../../Charts/LTMTool.cpp" line="751"/>
+        <location filename="../../Charts/LTMTool.cpp" line="766"/>
+        <location filename="../../Charts/LTMTool.cpp" line="827"/>
+        <location filename="../../Charts/LTMTool.cpp" line="842"/>
+        <location filename="../../Charts/LTMTool.cpp" line="903"/>
+        <location filename="../../Charts/LTMTool.cpp" line="918"/>
+        <location filename="../../Charts/LTMTool.cpp" line="979"/>
+        <location filename="../../Charts/LTMTool.cpp" line="994"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1099"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1114"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1175"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1190"/>
         <source>Ramp</source>
         <translation type="unfinished">Rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="411"/>
+        <location filename="../../Charts/LTMTool.cpp" line="385"/>
         <source>Skiba LTS Ramp</source>
         <translation type="unfinished">Skiba TLP rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="427"/>
+        <location filename="../../Charts/LTMTool.cpp" line="401"/>
         <source>Aerobic TISS Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="442"/>
+        <location filename="../../Charts/LTMTool.cpp" line="416"/>
         <source>Aerobic TISS Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="457"/>
+        <location filename="../../Charts/LTMTool.cpp" line="431"/>
         <source>Aerobic TISS Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="472"/>
+        <location filename="../../Charts/LTMTool.cpp" line="446"/>
         <source>Aerobic TISS STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="487"/>
+        <location filename="../../Charts/LTMTool.cpp" line="461"/>
         <source>Aerobic TISS LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="503"/>
+        <location filename="../../Charts/LTMTool.cpp" line="477"/>
         <source>Anaerobic TISS Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="518"/>
+        <location filename="../../Charts/LTMTool.cpp" line="492"/>
         <source>Anaerobic TISS Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="533"/>
+        <location filename="../../Charts/LTMTool.cpp" line="507"/>
         <source>Anaerobic TISS Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="548"/>
+        <location filename="../../Charts/LTMTool.cpp" line="522"/>
         <source>Anaerobic TISS STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="537"/>
         <source>Anaerobic TISS LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="578"/>
+        <location filename="../../Charts/LTMTool.cpp" line="552"/>
         <source>Daniels Long Term Stress</source>
         <translation type="unfinished">Daniels tensão a longo prazo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="593"/>
+        <location filename="../../Charts/LTMTool.cpp" line="567"/>
         <source>Daniels Short Term Stress</source>
         <translation type="unfinished">Daniels tensão a curto prazo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="582"/>
         <source>Daniels Stress Balance</source>
         <translation type="unfinished">Daniels equilibriu de tensão</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="623"/>
+        <location filename="../../Charts/LTMTool.cpp" line="597"/>
         <source>Daniels STS Ramp</source>
         <translation type="unfinished">Daniels TCP rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="638"/>
+        <location filename="../../Charts/LTMTool.cpp" line="612"/>
         <source>Daniels LTS Ramp</source>
         <translation type="unfinished">Daniels TLP rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="730"/>
+        <location filename="../../Charts/LTMTool.cpp" line="704"/>
         <source>W&apos; Work (Kj) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="745"/>
+        <location filename="../../Charts/LTMTool.cpp" line="719"/>
         <source>W&apos; Work (Kj) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="760"/>
+        <location filename="../../Charts/LTMTool.cpp" line="734"/>
         <source>W&apos; Work (Kj) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="775"/>
+        <location filename="../../Charts/LTMTool.cpp" line="749"/>
         <source>W&apos; Work (Kj) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="790"/>
+        <location filename="../../Charts/LTMTool.cpp" line="764"/>
         <source>W&apos; Work (Kj) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="806"/>
+        <location filename="../../Charts/LTMTool.cpp" line="780"/>
         <source>Below CP Work (Kj) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="821"/>
+        <location filename="../../Charts/LTMTool.cpp" line="795"/>
         <source>Below CP Work (Kj) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="836"/>
+        <location filename="../../Charts/LTMTool.cpp" line="810"/>
         <source>Below CP Work (Kj) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="851"/>
+        <location filename="../../Charts/LTMTool.cpp" line="825"/>
         <source>Below CP Work (Kj) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="866"/>
+        <location filename="../../Charts/LTMTool.cpp" line="840"/>
         <source>Below CP Work (Kj) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="958"/>
+        <location filename="../../Charts/LTMTool.cpp" line="932"/>
         <source>Coggan Chronic Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="973"/>
+        <location filename="../../Charts/LTMTool.cpp" line="947"/>
         <source>Coggan Acute Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="988"/>
+        <location filename="../../Charts/LTMTool.cpp" line="962"/>
         <source>Coggan Training Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1003"/>
+        <location filename="../../Charts/LTMTool.cpp" line="977"/>
         <source>Coggan STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1018"/>
+        <location filename="../../Charts/LTMTool.cpp" line="992"/>
         <source>Coggan LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1033"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1007"/>
         <source>Coggan Expected Chronic Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1048"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1022"/>
         <source>Coggan Expected Acute Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1063"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1037"/>
         <source>Coggan Expected Training Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1053"/>
         <source>TRIMP Long Term Stress</source>
         <translation type="unfinished">TRIMP tensão a longo prazo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1067"/>
         <source>TRIMP Short Term Stress</source>
         <translation type="unfinished">TRIMP tensão a curto prazo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1082"/>
         <source>TRIMP Stress Balance</source>
         <translation type="unfinished">TRIMP equilibriu de tensão</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1123"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1097"/>
         <source>TRIMP STS Ramp</source>
         <translation type="unfinished">TRIMP TCP rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1138"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1112"/>
         <source>TRIMP LTS Ramp</source>
         <translation type="unfinished">TRIMP TLP rampa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="124"/>
+        <location filename="../../Charts/LTMTool.cpp" line="125"/>
         <source>Use sidebar chart settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1307"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1276"/>
         <source>Estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1311"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1280"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1282"/>
         <source>Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1284"/>
         <source>Performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1317"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1286"/>
         <source>Banister</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1463"/>
         <source>Chart %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="74"/>
+        <location filename="../../Charts/LTMTool.cpp" line="75"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="80"/>
+        <location filename="../../Charts/LTMTool.cpp" line="81"/>
         <source>Date range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="84"/>
+        <location filename="../../Charts/LTMTool.cpp" line="85"/>
         <source>Days</source>
         <translation type="unfinished">Dias</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="85"/>
+        <location filename="../../Charts/LTMTool.cpp" line="86"/>
         <source>Weeks</source>
         <translation type="unfinished">Semanas</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="86"/>
+        <location filename="../../Charts/LTMTool.cpp" line="87"/>
         <source>Months</source>
         <translation type="unfinished">Mêses</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="87"/>
+        <location filename="../../Charts/LTMTool.cpp" line="88"/>
         <source>Years</source>
         <translation type="unfinished">Anos</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="88"/>
+        <location filename="../../Charts/LTMTool.cpp" line="89"/>
         <source>Time Of Day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="91"/>
+        <location filename="../../Charts/LTMTool.cpp" line="92"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="102"/>
+        <location filename="../../Charts/LTMTool.cpp" line="103"/>
         <source>Shade Zones</source>
         <translation type="unfinished">Zonas sombreadas</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="105"/>
+        <location filename="../../Charts/LTMTool.cpp" line="106"/>
         <source>Show Legend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="109"/>
         <source>Show Events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="628"/>
         <source>Work (Kj) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="656"/>
-        <location filename="../../Charts/LTMTool.cpp" line="671"/>
-        <location filename="../../Charts/LTMTool.cpp" line="732"/>
-        <location filename="../../Charts/LTMTool.cpp" line="747"/>
-        <location filename="../../Charts/LTMTool.cpp" line="808"/>
-        <location filename="../../Charts/LTMTool.cpp" line="823"/>
+        <location filename="../../Charts/LTMTool.cpp" line="630"/>
+        <location filename="../../Charts/LTMTool.cpp" line="645"/>
+        <location filename="../../Charts/LTMTool.cpp" line="706"/>
+        <location filename="../../Charts/LTMTool.cpp" line="721"/>
+        <location filename="../../Charts/LTMTool.cpp" line="782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="797"/>
         <source>Stress (Kj)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="669"/>
+        <location filename="../../Charts/LTMTool.cpp" line="643"/>
         <source>Work (Kj) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="684"/>
+        <location filename="../../Charts/LTMTool.cpp" line="658"/>
         <source>Work (Kj) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="699"/>
+        <location filename="../../Charts/LTMTool.cpp" line="673"/>
         <source>Work (Kj) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="714"/>
+        <location filename="../../Charts/LTMTool.cpp" line="688"/>
         <source>Work (Kj) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="882"/>
+        <location filename="../../Charts/LTMTool.cpp" line="856"/>
         <source>Distance (km|mi) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="884"/>
-        <location filename="../../Charts/LTMTool.cpp" line="899"/>
+        <location filename="../../Charts/LTMTool.cpp" line="858"/>
+        <location filename="../../Charts/LTMTool.cpp" line="873"/>
         <source>Stress (km|mi)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="897"/>
+        <location filename="../../Charts/LTMTool.cpp" line="871"/>
         <source>Distance (km|mi) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="912"/>
+        <location filename="../../Charts/LTMTool.cpp" line="886"/>
         <source>Distance (km|mi) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="927"/>
+        <location filename="../../Charts/LTMTool.cpp" line="901"/>
         <source>Distance (km|mi) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="942"/>
+        <location filename="../../Charts/LTMTool.cpp" line="916"/>
         <source>Distance (km|mi) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="268"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/LTMTool.cpp" line="313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Basic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="314"/>
+        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Preset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="289"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1128"/>
         <source>TriScore Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1169"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1143"/>
         <source>TriScore Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1184"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1158"/>
         <source>TriScore Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1173"/>
         <source>TriScore STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1214"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1188"/>
         <source>TriScore LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1305"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1274"/>
         <source>Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17931,106 +17846,90 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>LTPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2590"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2602"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2591"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2603"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2596"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2608"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2597"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2609"/>
         <source>Delete</source>
-        <translation type="unfinished">Apagar</translation>
+        <translation type="obsolete">Apagar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2599"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2467"/>
         <source>Def</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2651"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2790"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2494"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2631"/>
         <source>Lactate Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2652"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2791"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2495"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2632"/>
         <source>Aerobic Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2967"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2974"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2804"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2811"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2969"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2976"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2806"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2813"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2653"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2496"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
         <source>Rest HR</source>
         <translation>HR do repouso</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2628"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2690"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2770"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2775"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2780"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2785"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2473"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2478"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2488"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2611"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2621"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2626"/>
         <source>bpm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2650"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2493"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2630"/>
         <source>Start Date</source>
         <translation type="unfinished">Data de início</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2654"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2497"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2634"/>
         <source>Max HR</source>
         <translation>HR Max</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2701"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2544"/>
         <source>Short</source>
         <translation>Curto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2702"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2545"/>
         <source>Long</source>
         <translation>Comprido</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2703"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2546"/>
         <source>From BPM</source>
         <translation>De BPM</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2704"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2547"/>
         <source>Trimp k</source>
         <translation>Trimp k</translation>
     </message>
@@ -18771,62 +18670,62 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>Library</name>
     <message>
+        <location filename="../../Train/Library.cpp" line="126"/>
         <location filename="../../Train/Library.cpp" line="130"/>
-        <location filename="../../Train/Library.cpp" line="134"/>
         <source>Import Videos, VideoSyncs and Workouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="127"/>
         <location filename="../../Train/Library.cpp" line="131"/>
-        <location filename="../../Train/Library.cpp" line="135"/>
         <source>No supported videos, videoSyncs or workouts were found to import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="189"/>
         <location filename="../../Train/Library.cpp" line="193"/>
-        <location filename="../../Train/Library.cpp" line="197"/>
+        <location filename="../../Train/Library.cpp" line="198"/>
         <location filename="../../Train/Library.cpp" line="202"/>
-        <location filename="../../Train/Library.cpp" line="206"/>
         <source>Copy VideoSync Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="190"/>
         <location filename="../../Train/Library.cpp" line="194"/>
-        <location filename="../../Train/Library.cpp" line="198"/>
         <source>%1 already exists in videoSync library: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="203"/>
+        <location filename="../../Train/Library.cpp" line="199"/>
         <source>%1 cannot be written to videoSync library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="207"/>
+        <location filename="../../Train/Library.cpp" line="203"/>
         <source>%1 cannot be written to videoSync library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="253"/>
+        <location filename="../../Train/Library.cpp" line="249"/>
         <source>%1 cannot be written to workout library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="257"/>
+        <location filename="../../Train/Library.cpp" line="253"/>
         <source>%1 cannot be written to workout library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="239"/>
         <location filename="../../Train/Library.cpp" line="243"/>
-        <location filename="../../Train/Library.cpp" line="247"/>
+        <location filename="../../Train/Library.cpp" line="248"/>
         <location filename="../../Train/Library.cpp" line="252"/>
-        <location filename="../../Train/Library.cpp" line="256"/>
         <source>Copy Workout Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="240"/>
         <location filename="../../Train/Library.cpp" line="244"/>
-        <location filename="../../Train/Library.cpp" line="248"/>
         <source>%1 already exists in workout library: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18834,89 +18733,89 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>LibrarySearchDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="330"/>
+        <location filename="../../Train/Library.cpp" line="326"/>
         <source>Search for Workouts, Syncs and Media</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="337"/>
+        <location filename="../../Train/Library.cpp" line="333"/>
         <source>Workout files (.erg, .mrc, .zwo etc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="339"/>
+        <location filename="../../Train/Library.cpp" line="335"/>
         <source>Video files (.mp4, .avi etc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="341"/>
+        <location filename="../../Train/Library.cpp" line="337"/>
         <source>VideoSync files (.rlv, .tts etc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="359"/>
+        <location filename="../../Train/Library.cpp" line="353"/>
         <source>Search Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="379"/>
+        <location filename="../../Train/Library.cpp" line="373"/>
         <source>Video references</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="391"/>
+        <location filename="../../Train/Library.cpp" line="385"/>
         <source>Searching...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="394"/>
+        <location filename="../../Train/Library.cpp" line="388"/>
         <source>Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="396"/>
+        <location filename="../../Train/Library.cpp" line="390"/>
         <source>Workouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="398"/>
+        <location filename="../../Train/Library.cpp" line="392"/>
         <source>VideoSyncs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="407"/>
-        <location filename="../../Train/Library.cpp" line="494"/>
+        <location filename="../../Train/Library.cpp" line="401"/>
+        <location filename="../../Train/Library.cpp" line="484"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="409"/>
+        <location filename="../../Train/Library.cpp" line="403"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="412"/>
+        <location filename="../../Train/Library.cpp" line="406"/>
         <source>Files to search for:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="475"/>
+        <location filename="../../Train/Library.cpp" line="466"/>
         <source>Abort Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="515"/>
-        <location filename="../../Train/Library.cpp" line="559"/>
+        <location filename="../../Train/Library.cpp" line="504"/>
+        <location filename="../../Train/Library.cpp" line="548"/>
         <source>Save</source>
         <translation type="unfinished">Guardar</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="557"/>
+        <location filename="../../Train/Library.cpp" line="546"/>
         <source>Search completed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="645"/>
+        <location filename="../../Train/Library.cpp" line="634"/>
         <source>Select Directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18924,12 +18823,12 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>ListEditWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="623"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="654"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="625"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="656"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18942,7 +18841,12 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="90"/>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="85"/>
+        <source>Initial Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="98"/>
         <source>Apply changes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19187,29 +19091,29 @@ e que o ecrã mostra &quot;PC Link&quot;</translation>
         <translation>&amp;Sobre GoldenCHeetah</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1799"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2369"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1809"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2379"/>
         <source>Import from File</source>
         <translation>Importar do ficheiro</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2342"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2352"/>
         <source>Refresh in Progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Export Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2399"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2420"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2409"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2430"/>
         <source>Workout Directory Invalid</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19229,7 +19133,7 @@ e que o ecrã mostra &quot;PC Link&quot;</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>Delete Activity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19401,125 +19305,125 @@ e que o ecrã mostra &quot;PC Link&quot;</translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Activity Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Closing of athlete window not possible while background activity import is in progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Chart Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>Import Images Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>You can only import images on the activities view with an activity selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>Import Images to Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>%1 images imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
         <source>Select Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>No activity selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1724"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1734"/>
         <source>Export Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1778"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1788"/>
         <source>Failed to export activity, please check permissions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1814"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1824"/>
         <source>No Activity To Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1815"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1825"/>
         <source>There is no currently selected activity to save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
         <location filename="../../Gui/MainWindow.cpp" line="1886"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Split Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
         <source>No activity selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
         <source>Current activity contains no data to split</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Current activity contains no data to merge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1904"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1914"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2400"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2421"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2410"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2431"/>
         <source>The workout directory is not configured, or the directory selected no longer exists.
 
 Please check your preference settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2611"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2621"/>
         <source>Loading activities: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>CloudDB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>Current athlete is not registered as curator - please contact the GoldenCheetah team</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19619,12 +19523,12 @@ Please check your preference settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Imported %1 metric charts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2165"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2175"/>
         <source>&amp;New Athlete...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19831,12 +19735,12 @@ Please check your preference settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1777"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1787"/>
         <source>Export Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1906"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1916"/>
         <source>Delete</source>
         <translation>Apagar</translation>
     </message>
@@ -20736,55 +20640,43 @@ Please check your preference settings.</source>
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="656"/>
+        <location filename="../../Gui/AthletePages.cpp" line="641"/>
         <source>From Date - Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="780"/>
+        <location filename="../../Gui/AthletePages.cpp" line="751"/>
         <source>Start Date</source>
         <translation type="unfinished">Data de início</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="893"/>
+        <location filename="../../Gui/AthletePages.cpp" line="864"/>
         <source>MMM d, yyyy - hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="659"/>
-        <location filename="../../Gui/AthletePages.cpp" line="807"/>
+        <location filename="../../Gui/AthletePages.cpp" line="644"/>
+        <location filename="../../Gui/AthletePages.cpp" line="778"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="662"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="663"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Delete</source>
-        <translation type="unfinished">Apagar</translation>
+        <translation type="obsolete">Apagar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="698"/>
+        <location filename="../../Gui/AthletePages.cpp" line="668"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="699"/>
+        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Original Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="668"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
 </context>
 <context>
@@ -21457,17 +21349,17 @@ No rides found to import.
 <context>
     <name>MultiDeviceDialog</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3048"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3060"/>
         <source>Multiple Device Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3103"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3115"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3106"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3118"/>
         <source>Apply</source>
         <translation type="unfinished">Aplicar</translation>
     </message>
@@ -22392,54 +22284,42 @@ No rides found to import.
 <context>
     <name>PaceSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3154"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3155"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3160"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3161"/>
         <source>Delete</source>
-        <translation type="unfinished">Apagar</translation>
+        <translation type="obsolete">Apagar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3176"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2987"/>
         <source>Short</source>
         <translation type="unfinished">Curto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3177"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2988"/>
         <source>Long</source>
         <translation type="unfinished">Comprido</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3178"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2989"/>
         <source>Percent of CV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3220"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3227"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3037"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3222"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3229"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3032"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3039"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -22639,27 +22519,27 @@ No rides found to import.
 <context>
     <name>PaceZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3082"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2905"/>
         <source>Sport</source>
         <translation type="unfinished">Desporto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3084"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2907"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3085"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2908"/>
         <source>Swim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3126"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2949"/>
         <source>Critical Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2950"/>
         <source>Default</source>
         <translation type="unfinished">Padrão</translation>
     </message>
@@ -24805,78 +24685,71 @@ Quer continuar?</translation>
 <context>
     <name>PerspectiveDialog</name>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="34"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="35"/>
         <source>Manage Perspectives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="43"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="44"/>
         <source>Perspectives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="60"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="61"/>
         <source>Charts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="83"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="78"/>
         <source>Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="84"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="77"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="90"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="91"/>
         <source>Delete</source>
-        <translation type="unfinished">Apagar</translation>
+        <translation type="obsolete">Apagar</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="98"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Drag charts to move to a perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="287"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="256"/>
         <source>Export Persepctive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
         <source>Export Perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>No perspective file selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
-        <source>Select Perspective file to export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
         <source>GoldenCheetah Perspective Files (*.gchartset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
+        <source>Select Perspective file to import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>Import Perspective</source>
         <translation type="unfinished"></translation>
     </message>
@@ -26027,307 +25900,307 @@ Python disabled in preferences.</source>
 <context>
     <name>RealtimeData</name>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="621"/>
+        <location filename="../../Train/RealtimeData.cpp" line="623"/>
         <source>None</source>
         <translation type="unfinished">Nenhum</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="624"/>
+        <location filename="../../Train/RealtimeData.cpp" line="626"/>
         <source>Time</source>
         <translation type="unfinished">Tempo</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="627"/>
+        <location filename="../../Train/RealtimeData.cpp" line="629"/>
         <source>Lap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="630"/>
+        <location filename="../../Train/RealtimeData.cpp" line="632"/>
         <source>Lap Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="633"/>
+        <location filename="../../Train/RealtimeData.cpp" line="635"/>
         <source>Lap Time Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="636"/>
+        <location filename="../../Train/RealtimeData.cpp" line="638"/>
         <source>Section Time Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="639"/>
+        <location filename="../../Train/RealtimeData.cpp" line="641"/>
         <source>BikeStress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="645"/>
+        <location filename="../../Train/RealtimeData.cpp" line="647"/>
         <source>kJoules</source>
         <translation type="unfinished">kJoules</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="648"/>
+        <location filename="../../Train/RealtimeData.cpp" line="650"/>
         <source>W&apos; bal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="651"/>
+        <location filename="../../Train/RealtimeData.cpp" line="653"/>
         <source>XPower</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="654"/>
+        <location filename="../../Train/RealtimeData.cpp" line="656"/>
         <source>Iso Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="657"/>
+        <location filename="../../Train/RealtimeData.cpp" line="659"/>
         <source>Intensity Factor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="660"/>
+        <location filename="../../Train/RealtimeData.cpp" line="662"/>
         <source>Relative Intensity</source>
         <translation type="unfinished">Intensidade relativa</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="663"/>
+        <location filename="../../Train/RealtimeData.cpp" line="665"/>
         <source>Skiba Variability Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="666"/>
+        <location filename="../../Train/RealtimeData.cpp" line="668"/>
         <source>Variability Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="669"/>
+        <location filename="../../Train/RealtimeData.cpp" line="671"/>
         <source>Distance</source>
         <translation type="unfinished">Distância</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="672"/>
+        <location filename="../../Train/RealtimeData.cpp" line="674"/>
         <source>Route Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="675"/>
+        <location filename="../../Train/RealtimeData.cpp" line="677"/>
         <source>Distance Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="678"/>
+        <location filename="../../Train/RealtimeData.cpp" line="680"/>
         <source>Alternate Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="681"/>
+        <location filename="../../Train/RealtimeData.cpp" line="683"/>
         <source>Power</source>
         <translation type="unfinished">Potência</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="684"/>
+        <location filename="../../Train/RealtimeData.cpp" line="686"/>
         <source>Speed</source>
         <translation type="unfinished">Velocidade</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="687"/>
+        <location filename="../../Train/RealtimeData.cpp" line="689"/>
         <source>Virtual Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="690"/>
+        <location filename="../../Train/RealtimeData.cpp" line="692"/>
         <source>Cadence</source>
         <translation type="unfinished">Cadência</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="693"/>
+        <location filename="../../Train/RealtimeData.cpp" line="695"/>
         <source>Heart Rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="696"/>
+        <location filename="../../Train/RealtimeData.cpp" line="698"/>
         <source>Target Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="699"/>
+        <location filename="../../Train/RealtimeData.cpp" line="701"/>
         <source>Average Power</source>
         <translation type="unfinished">Potência média</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="702"/>
+        <location filename="../../Train/RealtimeData.cpp" line="704"/>
         <source>Average Speed</source>
         <translation type="unfinished">Velocidade média</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="705"/>
+        <location filename="../../Train/RealtimeData.cpp" line="707"/>
         <source>Average Heartrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="708"/>
+        <location filename="../../Train/RealtimeData.cpp" line="710"/>
         <source>Average Cadence</source>
         <translation type="unfinished">Cadência Média</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="711"/>
+        <location filename="../../Train/RealtimeData.cpp" line="713"/>
         <source>Lap Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="714"/>
+        <location filename="../../Train/RealtimeData.cpp" line="716"/>
         <source>Lap Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="717"/>
+        <location filename="../../Train/RealtimeData.cpp" line="719"/>
         <source>Lap Heartrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="720"/>
+        <location filename="../../Train/RealtimeData.cpp" line="722"/>
         <source>Lap Cadence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="723"/>
+        <location filename="../../Train/RealtimeData.cpp" line="725"/>
         <source>Left/Right Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="726"/>
+        <location filename="../../Train/RealtimeData.cpp" line="728"/>
         <source>Total Hb Mass</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="729"/>
+        <location filename="../../Train/RealtimeData.cpp" line="731"/>
         <source>Hb O2 Saturation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="732"/>
+        <location filename="../../Train/RealtimeData.cpp" line="734"/>
         <source>Deoxy Hb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="735"/>
+        <location filename="../../Train/RealtimeData.cpp" line="737"/>
         <source>Oxy Hb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="738"/>
+        <location filename="../../Train/RealtimeData.cpp" line="740"/>
         <source>Left Torque Effectiveness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="741"/>
+        <location filename="../../Train/RealtimeData.cpp" line="743"/>
         <source>Right Torque Effectiveness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="744"/>
+        <location filename="../../Train/RealtimeData.cpp" line="746"/>
         <source>Left Pedal Smoothness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="747"/>
+        <location filename="../../Train/RealtimeData.cpp" line="749"/>
         <source>Right Pedal Smoothness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="750"/>
+        <location filename="../../Train/RealtimeData.cpp" line="752"/>
         <source>Right Power Phase Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="753"/>
+        <location filename="../../Train/RealtimeData.cpp" line="755"/>
         <source>Right Power Phase End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="756"/>
+        <location filename="../../Train/RealtimeData.cpp" line="758"/>
         <source>Right Power Phase Peak Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="759"/>
+        <location filename="../../Train/RealtimeData.cpp" line="761"/>
         <source>Right Power Phase Peak End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="762"/>
+        <location filename="../../Train/RealtimeData.cpp" line="764"/>
         <source>Slope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="765"/>
+        <location filename="../../Train/RealtimeData.cpp" line="767"/>
         <source>Lap Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="768"/>
+        <location filename="../../Train/RealtimeData.cpp" line="770"/>
         <source>Lap Distance Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="771"/>
+        <location filename="../../Train/RealtimeData.cpp" line="773"/>
         <source>Latitude</source>
         <translation type="unfinished">Latitude</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="774"/>
+        <location filename="../../Train/RealtimeData.cpp" line="776"/>
         <source>Longitude</source>
         <translation type="unfinished">Longitude</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="777"/>
+        <location filename="../../Train/RealtimeData.cpp" line="779"/>
         <source>Altitude</source>
         <translation type="unfinished">Altitude</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="780"/>
+        <location filename="../../Train/RealtimeData.cpp" line="782"/>
         <source>Respiratory Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="783"/>
+        <location filename="../../Train/RealtimeData.cpp" line="785"/>
         <source>Ventilation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="786"/>
+        <location filename="../../Train/RealtimeData.cpp" line="788"/>
         <source>VO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="789"/>
+        <location filename="../../Train/RealtimeData.cpp" line="791"/>
         <source>VCO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="792"/>
+        <location filename="../../Train/RealtimeData.cpp" line="794"/>
         <source>Respiratory Exchange Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="795"/>
+        <location filename="../../Train/RealtimeData.cpp" line="797"/>
         <source>Tidal Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="798"/>
+        <location filename="../../Train/RealtimeData.cpp" line="800"/>
         <source>Fraction O2 Expired</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="801"/>
+        <location filename="../../Train/RealtimeData.cpp" line="803"/>
         <source>Temperature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="804"/>
+        <location filename="../../Train/RealtimeData.cpp" line="806"/>
         <source>CoreTemp</source>
         <translation type="unfinished"></translation>
     </message>
@@ -26423,22 +26296,22 @@ Python disabled in preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="172"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
         <source>Power</source>
         <translation type="unfinished">Potência</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="176"/>
         <source>Heart Rate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -28732,317 +28605,317 @@ native format. Should we do so?
 <context>
     <name>ScatterPlot</name>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="113"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
         <source>Power (watts)</source>
         <translation type="unfinished">Potência (Watts)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
         <source>Cadence (rpm)</source>
         <translation type="unfinished">Cadência (rpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="116"/>
         <source>Heartrate (bpm)</source>
         <translation type="unfinished">Frequência Cardíaca (bpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="118"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="119"/>
         <source>Speed (kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="120"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="121"/>
         <source>Speed (mph)</source>
         <translation type="unfinished">Velocidade (mph)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="124"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="125"/>
         <source>Altitude (meters)</source>
         <translation type="unfinished">Altitude (metros)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="126"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="127"/>
         <source>Altitude (feet)</source>
         <translation type="unfinished">Altitude (pés)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="128"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
         <source>Torque (N)</source>
         <translation type="unfinished">Torque (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="130"/>
         <source>Elapsed Time (secs)</source>
         <translation type="unfinished">Tempo decorrido (segs)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="132"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="133"/>
         <source>Elapsed Distance (km)</source>
         <translation type="unfinished">Distância decorrido (km)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="134"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="135"/>
         <source>Elapsed Distance (mi)</source>
         <translation type="unfinished">Distância decorrido (mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="136"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
         <source>Interval Number</source>
         <translation type="unfinished">Número do intervalo</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
         <source>Latitude (degree offset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
         <source>Longitude (degree offset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
         <source>Circumferential Pedal Velocity (m/s)</source>
         <translation type="unfinished">Velocity de pedal circunferencial (m / s)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="141"/>
         <source>Average Effective Pedal Force (N)</source>
         <translation type="unfinished">Força Pedal efectiva média (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="144"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
         <source>Time at X/Y (%)</source>
         <translation type="unfinished">Tempo em X/Y (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
         <source>Power Zone</source>
         <translation type="unfinished">Zona de potência</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
         <source>Headwind (kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
         <source>Slope (gradient)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
         <source>Temperature (C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
         <source>L/R Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
         <source>Torque Efficiency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
         <source>Pedal Smoothness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
         <source>Running Vertical Oscillation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
         <source>Running Ground Contact Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
         <source>Running Cadence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
         <source>Gear Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
         <source>Muscle Oxygen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
         <source>Haemoglobin Mass</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
         <source>Deoxygenated Haemoglobin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="160"/>
         <source>Oxygenated Haemoglobin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="161"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="162"/>
         <source>Unknown</source>
         <translation type="unfinished">Desconhecido</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="165"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
         <source>Power</source>
         <translation type="unfinished">Potência</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
         <source>Cadence</source>
         <translation type="unfinished">Cadência</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
         <source>Heartrate</source>
         <translation type="unfinished">Frequência Cardíaca</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
         <source>Speed</source>
         <translation type="unfinished">Velocidade</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
         <source>Altitude</source>
         <translation type="unfinished">Altitude</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
         <source>Pedal Force</source>
         <translation type="unfinished">Força Pedal</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
         <source>Time</source>
         <translation type="unfinished">Tempo</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
         <source>Distance</source>
         <translation type="unfinished">Distância</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
         <source>Interval</source>
         <translation type="unfinished">Intervalo</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
         <source>Latitude</source>
         <translation type="unfinished">Latitude</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
         <source>Longitude</source>
         <translation type="unfinished">Longitude</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
         <source>Time at X/Y</source>
         <translation type="unfinished">Tempo em X/Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
         <source>Zone</source>
         <translation type="unfinished">Zona</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
         <source>CPV</source>
         <translation type="unfinished">CPV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
         <source>AEPF</source>
         <translation type="unfinished">AEPF</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
         <source>Headwind</source>
         <translation type="unfinished">Vento de frente</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
         <source>Slope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
         <source>Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
         <source>Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
         <source>TE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
         <source>PS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
         <source>GCT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
         <source>Run Cad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
         <source>Gear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
         <source>SmO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
         <source>tHb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
         <source>O2Hb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="194"/>
         <source>HHb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="195"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="196"/>
         <source>None</source>
         <translation type="unfinished">Nenhum</translation>
     </message>
@@ -29280,54 +29153,42 @@ native format. Should we do so?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1012"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1013"/>
         <source>Delete</source>
-        <translation type="unfinished">Apagar</translation>
+        <translation type="obsolete">Apagar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1006"/>
-        <source>+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1007"/>
-        <source>-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1023"/>
+        <location filename="../../Gui/AthletePages.cpp" line="982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="988"/>
         <source>Short</source>
         <translation>Curto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="989"/>
         <source>Long</source>
         <translation>Comprido</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1031"/>
+        <location filename="../../Gui/AthletePages.cpp" line="990"/>
         <source>Percent of CP</source>
         <translation>Percentagem do CP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1069"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1076"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1034"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1071"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1078"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1036"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -29500,64 +29361,64 @@ native format. Should we do so?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3821"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3569"/>
         <source>Add</source>
         <translation type="unfinished">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3822"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3570"/>
         <source>Delete</source>
         <translation type="unfinished">Apagar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3823"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3571"/>
         <source>Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3824"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3572"/>
         <source>Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3870"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3872"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3963"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3965"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3711"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3713"/>
         <source>ddd MMM d, yyyy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3557"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3810"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3558"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3804"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3835"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3583"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3805"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3836"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3553"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3584"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3806"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3837"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3554"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3585"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3807"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3838"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3555"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3586"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
@@ -31837,398 +31698,398 @@ tab.</source>
 <context>
     <name>TrainSidebar</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="253"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="257"/>
         <source>Save workout data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="259"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="263"/>
         <source>Devices</source>
         <translation type="unfinished">Dispositivos</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="262"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="267"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="311"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="321"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="271"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="315"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="325"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="270"/>
         <source>Workouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="303"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="307"/>
         <source>Workout Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="310"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="314"/>
         <source>Media</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="320"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="324"/>
         <source>VideoSync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="506"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
         <source>Import Workout from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="507"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="511"/>
         <source>Get Workouts from TrainerDay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="509"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="513"/>
         <source>Create Workout via Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="514"/>
         <source>Scan for Workouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="534"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="538"/>
         <source>Delete selected Workout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="541"/>
         <source>Delete %1 selected Workouts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Train mode active</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Please stop the train mode before closing the window or application.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="635"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="639"/>
         <source>Remove reference to selected video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="650"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="654"/>
         <source>Import VideoSync from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="651"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="655"/>
         <source>Scan for VideoSyncs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="668"/>
         <source>Delete selected VideoSync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1064"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1068"/>
         <source>Are you sure you want to remove the reference to this video?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1066"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1128"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1204"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1070"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1132"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1208"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1099"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1103"/>
         <source>Are you sure you want to delete this VideoSync?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1126"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1130"/>
         <source>The VideoSync file is either not valid or not existing and will be removed from the library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1160"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1164"/>
         <source>Are you sure you want to delete this Workout?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1163"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1167"/>
         <source>Are you sure you want to delete this %1 workouts?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1202"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1206"/>
         <source>The Workout file is either not valid or not existing and will be removed from the library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1347"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1351"/>
         <source>Starting in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2225"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2237"/>
         <source>Recalibrating steering..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2521"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2525"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2594"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2645"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2649"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2533"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2606"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2657"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2661"/>
         <source>Requesting calibration..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2532"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2544"/>
         <source>Calibrating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2536"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2548"/>
         <source>Calibrating...
 Current speed %1 kph
 Increase speed to %2 kph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2540"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2552"/>
         <source>Calibrating...
 Stop pedalling until speed drops to 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2545"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2557"/>
         <source>Calibration completed successfully!
 Spindown %1 ms
 Zero Offset %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2553"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2620"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2672"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2565"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2632"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2684"/>
         <source>Calibration failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2573"/>
         <source>Calibration Failed: Loosen Roller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2569"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2581"/>
         <source>Calibration Failed: Tighten Roller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2588"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2639"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2600"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2651"/>
         <source>Unclip or stop pedalling to begin calibration..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2607"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2619"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Torque %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2612"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2624"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Torque %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2659"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2671"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Zero Offset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2676"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Slope %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2693"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2705"/>
         <source>Give the pedal a kick to start calibration...
 The motor will run until calibration is complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2695"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
         <source>Allow wheel speed to settle, DO NOT PEDAL...
 The motor will run until calibration is complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2700"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2712"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Gathering enough samples to calculate average: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2719"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Waiting for value to stabilize (max %1s): %2 (%3W @ %4kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2722"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
         <source>Calibration completed successfully!
 Final calibration value %1 (%2W @ %3kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2746"/>
         <source>Calibration failed! Do not pedal while calibration is taking place.
 Allow wheel to run freely.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2780"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2792"/>
         <source>Fast forward..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2813"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2825"/>
         <source>Rewind..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2843"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2855"/>
         <source>Next Lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2876"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2888"/>
         <source>Back Lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2902"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2914"/>
         <source>Increasing intensity..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2928"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2940"/>
         <source>Decreasing intensity..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="621"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="625"/>
         <source>Import Video from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="508"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="512"/>
         <source>Get Workouts from Strava Routes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="622"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="626"/>
         <source>Scan for Videos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1101"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1173"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3183"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1105"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1177"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3195"/>
         <source>Delete</source>
         <translation type="unfinished">Apagar</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1309"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1313"/>
         <source>Resuming..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1336"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1340"/>
         <source>Paused..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1465"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1469"/>
         <source>Starting..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1673"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1677"/>
         <source>Stopped..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1763"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1769"/>
         <source>Connected..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1787"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1793"/>
         <source>Disconnected..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2198"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2210"/>
         <source>New lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>No Devices Configured</source>
         <translation type="unfinished">Dispositivos não configurados</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>Please configure a device in Preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2483"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2495"/>
         <source>Exiting calibration..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2498"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2510"/>
         <source>Calibration not supported for this device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2505"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2517"/>
         <source>Calibrating...
 Press F3 on Controller when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3135"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3153"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3147"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3165"/>
         <source>Add Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3140"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3158"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3152"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3170"/>
         <source>Delete Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3181"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3193"/>
         <source>Are you sure you want to delete this device?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -32545,7 +32406,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>UniqueLabelEditDelegate</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="77"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="108"/>
         <source>The given value &quot;%1&quot; is not unique</source>
         <translation type="unfinished"></translation>
     </message>
@@ -32561,171 +32422,155 @@ Press F3 on Controller when done.</source>
 <context>
     <name>UserChartSettings</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="772"/>
+        <location filename="../../Charts/UserChart.cpp" line="773"/>
         <source>Chart</source>
         <translation type="unfinished">Gráfico</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="782"/>
+        <location filename="../../Charts/UserChart.cpp" line="783"/>
         <source>Sub-title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="785"/>
+        <location filename="../../Charts/UserChart.cpp" line="786"/>
         <source>Description</source>
         <translation type="unfinished">Descrição</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="791"/>
+        <location filename="../../Charts/UserChart.cpp" line="792"/>
         <source>Line Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="792"/>
+        <location filename="../../Charts/UserChart.cpp" line="793"/>
         <source>Scatter Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="793"/>
+        <location filename="../../Charts/UserChart.cpp" line="794"/>
         <source>Bar Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="794"/>
+        <location filename="../../Charts/UserChart.cpp" line="795"/>
         <source>Stacked Bar Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="795"/>
+        <location filename="../../Charts/UserChart.cpp" line="796"/>
         <source>Stacked Percent Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="796"/>
+        <location filename="../../Charts/UserChart.cpp" line="797"/>
         <source>Pie Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="800"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="801"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="804"/>
+        <location filename="../../Charts/UserChart.cpp" line="805"/>
         <source>Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="805"/>
+        <location filename="../../Charts/UserChart.cpp" line="806"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="808"/>
+        <location filename="../../Charts/UserChart.cpp" line="809"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="812"/>
+        <location filename="../../Charts/UserChart.cpp" line="813"/>
         <source>None</source>
         <translation type="unfinished">Nenhum</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="813"/>
+        <location filename="../../Charts/UserChart.cpp" line="814"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="814"/>
+        <location filename="../../Charts/UserChart.cpp" line="815"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="815"/>
+        <location filename="../../Charts/UserChart.cpp" line="816"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="816"/>
+        <location filename="../../Charts/UserChart.cpp" line="817"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="820"/>
+        <location filename="../../Charts/UserChart.cpp" line="821"/>
         <source>Legend</source>
         <translation type="unfinished">legenda</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="829"/>
+        <location filename="../../Charts/UserChart.cpp" line="830"/>
         <source>Font scaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="831"/>
-        <location filename="../../Charts/UserChart.cpp" line="833"/>
+        <location filename="../../Charts/UserChart.cpp" line="832"/>
+        <location filename="../../Charts/UserChart.cpp" line="834"/>
         <source>Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="836"/>
+        <location filename="../../Charts/UserChart.cpp" line="837"/>
         <source>Animate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="838"/>
+        <location filename="../../Charts/UserChart.cpp" line="839"/>
         <source>Single series per plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="841"/>
+        <location filename="../../Charts/UserChart.cpp" line="842"/>
         <source>Refresh for intervals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="848"/>
+        <location filename="../../Charts/UserChart.cpp" line="849"/>
         <source>Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Y Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="870"/>
-        <location filename="../../Charts/UserChart.cpp" line="932"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/UserChart.cpp" line="889"/>
-        <source>Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/UserChart.cpp" line="890"/>
-        <source>Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/UserChart.cpp" line="911"/>
+        <location filename="../../Charts/UserChart.cpp" line="885"/>
         <source>Axes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33391,72 +33236,72 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VideoWindow</name>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> kph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="119"/>
+        <location filename="../../Train/VideoWindow.cpp" line="144"/>
         <source>Meters layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="127"/>
+        <location filename="../../Train/VideoWindow.cpp" line="152"/>
         <source>Reset Meters layout to default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> feet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="625"/>
+        <location filename="../../Train/VideoWindow.cpp" line="681"/>
         <source>w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="629"/>
+        <location filename="../../Train/VideoWindow.cpp" line="685"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> km</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> mi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="673"/>
+        <location filename="../../Train/VideoWindow.cpp" line="729"/>
         <source>Calibration required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="678"/>
+        <location filename="../../Train/VideoWindow.cpp" line="734"/>
         <source>Configuration required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="683"/>
+        <location filename="../../Train/VideoWindow.cpp" line="739"/>
         <source>brake fault</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="688"/>
+        <location filename="../../Train/VideoWindow.cpp" line="744"/>
         <source>Ready</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33891,27 +33736,27 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WheelSizeCalculator</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="202"/>
+        <location filename="../../Gui/AthletePages.cpp" line="187"/>
         <source>Wheel Size Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="221"/>
+        <location filename="../../Gui/AthletePages.cpp" line="206"/>
         <source>Rim Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="222"/>
+        <location filename="../../Gui/AthletePages.cpp" line="207"/>
         <source>Tire Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="223"/>
+        <location filename="../../Gui/AthletePages.cpp" line="208"/>
         <source>Wheel Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="227"/>
         <source>mm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34023,12 +33868,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutFilterBox</name>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="34"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="44"/>
         <source>Filter...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="64"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="95"/>
         <source>ERROR: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34036,35 +33881,118 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutImportDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="820"/>
+        <location filename="../../Train/Library.cpp" line="809"/>
         <source>Import to Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="854"/>
+        <location filename="../../Train/Library.cpp" line="843"/>
         <source>Please note, that when importing or drag and dropping videos into the library we DO NOT copy the file into the GoldenCheetah library, instead we add a REFERENCE to it. We DO copy workout and videoSync files, since they are smaller.
 
 You can remove references when managing the library via the context menu options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="868"/>
+        <location filename="../../Train/Library.cpp" line="857"/>
         <source>Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="878"/>
+        <location filename="../../Train/Library.cpp" line="867"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="880"/>
+        <location filename="../../Train/Library.cpp" line="869"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="884"/>
+        <location filename="../../Train/Library.cpp" line="873"/>
         <source>Overwite existing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WorkoutMenuProvider</name>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="271"/>
+        <source>Select Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="274"/>
+        <source>Manage Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="275"/>
+        <source>Add Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="289"/>
+        <source>Add Tag to Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="292"/>
+        <source>Filter Tags...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="310"/>
+        <source>Match all selected tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="353"/>
+        <source>Manage Workout Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="360"/>
+        <source>Name</source>
+        <translation type="unfinished">Nome</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="361"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="362"/>
+        <source>_index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="370"/>
+        <source>Execute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="371"/>
+        <source>Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="423"/>
+        <source>Add Workout Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="426"/>
+        <source>Name of the Filter...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="467"/>
+        <source>New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="469"/>
+        <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -34080,41 +34008,41 @@ You can remove references when managing the library via the context menu options
     <name>WorkoutPlotWindow</name>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="40"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="104"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
         <source>Ergmode specific settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="46"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
         <source>Color power zones</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="48"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="56"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="49"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="50"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="57"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="109"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="113"/>
         <source>When stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="54"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="110"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
         <source>Show tooltip</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34200,12 +34128,12 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>WorkoutWidget</name>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="1531"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="1532"/>
         <source>File save failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="2367"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="2368"/>
         <source>Intensity</source>
         <translation type="unfinished">Intensidade</translation>
     </message>
@@ -34359,26 +34287,22 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="44"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="45"/>
         <source>xData</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="58"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="59"/>
         <source>Data Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="78"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="80"/>
         <source>Add</source>
-        <translation type="unfinished">Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="79"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="81"/>
         <source>Delete</source>
-        <translation type="unfinished">Apagar</translation>
+        <translation type="obsolete">Apagar</translation>
     </message>
 </context>
 <context>
@@ -34455,32 +34379,32 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataSeriesSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="333"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="315"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="338"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="320"/>
         <source>Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="346"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="328"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="347"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="329"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Name is blank</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34488,48 +34412,48 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="262"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="244"/>
         <source>xData</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="269"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="251"/>
         <source>Data Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="270"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="252"/>
         <source>Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="274"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="256"/>
         <source>Series %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="281"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="263"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="282"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="264"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
         <source>XData name is blank</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Must have at least one data series.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34850,17 +34774,17 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="915"/>
+        <location filename="../../Gui/AthletePages.cpp" line="886"/>
         <source>Sport</source>
         <translation type="unfinished">Desporto</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="962"/>
+        <location filename="../../Gui/AthletePages.cpp" line="933"/>
         <source>Critical Power</source>
         <translation type="unfinished">Potência Crítica</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="963"/>
+        <location filename="../../Gui/AthletePages.cpp" line="934"/>
         <source>Default</source>
         <translation type="unfinished">Padrão</translation>
     </message>

--- a/src/Resources/translations/gc_ru.ts
+++ b/src/Resources/translations/gc_ru.ts
@@ -107,38 +107,38 @@ It might be necessary to manually disable it.</source>
         <translation type="vanished">Период Длительного тренировочного стресса (LTS, дни)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="504"/>
+        <location filename="../../Gui/AthletePages.cpp" line="489"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="517"/>
-        <location filename="../../Gui/AthletePages.cpp" line="522"/>
+        <location filename="../../Gui/AthletePages.cpp" line="502"/>
+        <location filename="../../Gui/AthletePages.cpp" line="507"/>
         <source>days</source>
         <translation type="unfinished">дней</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="525"/>
+        <location filename="../../Gui/AthletePages.cpp" line="510"/>
         <source>PMC Stress Balance Today</source>
         <translation>Баланс стресса PMC на сегодня</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="528"/>
+        <location filename="../../Gui/AthletePages.cpp" line="513"/>
         <source>Restore Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="517"/>
         <source>W&apos;bal tau</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="518"/>
         <source>Short Term Stress (STS) average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="534"/>
+        <location filename="../../Gui/AthletePages.cpp" line="519"/>
         <source>Long Term Stress (LTS) average</source>
         <translation type="unfinished"></translation>
     </message>
@@ -154,96 +154,96 @@ It might be necessary to manually disable it.</source>
 <context>
     <name>AboutRiderPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="372"/>
+        <location filename="../../Gui/AthletePages.cpp" line="357"/>
         <source>Nickname</source>
         <translation>Псевдоним</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="373"/>
+        <location filename="../../Gui/AthletePages.cpp" line="358"/>
         <source>Date of Birth</source>
         <translation>Дата рождения</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="374"/>
+        <location filename="../../Gui/AthletePages.cpp" line="359"/>
         <source>Sex</source>
         <translation>Пол</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="376"/>
+        <location filename="../../Gui/AthletePages.cpp" line="361"/>
         <source>Weight</source>
         <translation>Вес</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="375"/>
+        <location filename="../../Gui/AthletePages.cpp" line="360"/>
         <source>Height</source>
         <translation>Рост</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="279"/>
+        <location filename="../../Gui/AthletePages.cpp" line="264"/>
         <source>Male</source>
         <translation>Мужской</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="280"/>
+        <location filename="../../Gui/AthletePages.cpp" line="265"/>
         <source>Female</source>
         <translation>Женский</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> kg</source>
         <translation> кг</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> lb</source>
         <translation> фунт</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> cm</source>
         <translation> см</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> in</source>
         <translation> дюйм</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="359"/>
+        <location filename="../../Gui/AthletePages.cpp" line="344"/>
         <source>Calculate...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="378"/>
+        <location filename="../../Gui/AthletePages.cpp" line="363"/>
         <source>Bike</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="379"/>
+        <location filename="../../Gui/AthletePages.cpp" line="364"/>
         <source>Crank Length</source>
         <translation>Длина шатуна</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="380"/>
+        <location filename="../../Gui/AthletePages.cpp" line="365"/>
         <source>Wheelsize</source>
         <translation>Диаметр колёс</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="438"/>
+        <location filename="../../Gui/AthletePages.cpp" line="423"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="356"/>
+        <location filename="../../Gui/AthletePages.cpp" line="341"/>
         <source>mm</source>
         <translation>мм</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="437"/>
+        <location filename="../../Gui/AthletePages.cpp" line="422"/>
         <source>Choose Picture</source>
         <translation>Выберите фотографию</translation>
     </message>
@@ -2278,397 +2278,394 @@ Press Next to Continue
 <context>
     <name>AllPlotWindow</name>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="190"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="444"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="165"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
         <source>Smooth</source>
         <translation>Сглаживание</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="198"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="173"/>
         <source>Stacked</source>
         <translation>Раздельно</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="199"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="174"/>
         <source>by series</source>
         <translation>По сериям</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="200"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="175"/>
         <source>Fullplot</source>
         <translation>Полный график</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="201"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="176"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="239"/>
         <source>Overlay</source>
         <translation>Детализация по интервалу</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="229"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="204"/>
         <source>View</source>
         <translation>Вид</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="206"/>
         <source>Stack</source>
         <translation>В стопке</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="210"/>
         <source>By Series</source>
         <translation>По сериям</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="246"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="221"/>
         <source>Stack Zoom</source>
         <translation>Масштаб стопок</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="248"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="223"/>
         <source>Full plot</source>
         <translation>Полный график</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="227"/>
         <source>Show Interval Markers</source>
         <translation>Отображать маркеры интервалов</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="256"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
         <source>Interval Navigator</source>
         <translation>Навигатор интервалов</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="260"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
         <source>Hover intervals</source>
         <translation>Подсвечивать интервалы под курсором</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="268"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="243"/>
         <source>Fill Curves</source>
         <translation>Выполнять заливку кривых</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="247"/>
         <source>Grid</source>
         <translation>Сетка</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="277"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
         <source>Acceleration</source>
         <translation>Ускорение</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="279"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="254"/>
         <source>Delta Series</source>
         <translation>Серии дельт</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="280"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="255"/>
         <source>Power %1</source>
         <translation>Мощность %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="283"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="258"/>
         <source>Cadence %1</source>
         <translation>Каденс %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="261"/>
         <source>Torque %1</source>
         <translation>Крутящий момент %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="289"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
         <source>Heartrate %1</source>
         <translation>ЧСС %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="295"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="270"/>
         <source>Balance</source>
         <translation>Баланс</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
         <source>Left/Right</source>
         <translation>Слева/Справа</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="274"/>
         <source>Torque Effectiveness</source>
         <translation>Эффективность крутящего момента</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="303"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="278"/>
         <source>Smoothness</source>
         <translation>Плавность</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="282"/>
         <source>Pedal Center Offset</source>
         <translation>Смещение от центра оси педали</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="311"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
         <source>Power Phase</source>
         <translation>Фаза мощности</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="290"/>
         <source>Peak Power Phase</source>
         <translation>Фаза пика мощности</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="322"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
         <source>Vertical Oscillation</source>
         <translation>Вертикальное колебание</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="324"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
         <source>Running</source>
         <translation>Бег</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="326"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="301"/>
         <source>Ground Contact Time</source>
         <translation>Время контакта с землёй</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
         <source>Cadence </source>
         <translation>Каденс </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="313"/>
         <source>SmO2</source>
         <translation>SmO₂</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="340"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
         <source>Moxy</source>
         <translation>Moxy</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="317"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="321"/>
         <source>O2Hb</source>
         <translation>O₂Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="325"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="355"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="330"/>
         <source>Heart Rate</source>
         <translation>ЧСС</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="357"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
         <source>Data series</source>
         <translation>Серия данных</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="359"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="334"/>
         <source>Core Temperature</source>
         <translation>Температура тела</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="363"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
         <source>Speed</source>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="367"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
         <source>Cadence</source>
         <translation>Каденс</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="94"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="95"/>
         <source>Basic</source>
         <translation>Основные параметры</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="109"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="110"/>
         <source>Curves</source>
         <translation>Показатели</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="116"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="117"/>
         <source>User Data</source>
         <translation>Пользовательские данные</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="132"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="134"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Formula</source>
         <translation>Формула</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="144"/>
         <source>Edit</source>
-        <translation>Изменить</translation>
+        <translation type="vanished">Изменить</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="163"/>
         <source>Up</source>
-        <translation type="unfinished">Поднять</translation>
+        <translation type="obsolete">Поднять</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="164"/>
         <source>Down</source>
-        <translation type="unfinished">Опустить</translation>
+        <translation type="obsolete">Опустить</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="371"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
         <source>Altitude</source>
         <translation>Высота</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
         <source>Temperature</source>
         <translation>Температура</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="379"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="354"/>
         <source>Headwind</source>
         <translation>Встречный ветер</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="383"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="358"/>
         <source>Torque</source>
         <translation>Крутящий момент</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="387"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="362"/>
         <source>Gear Ratio</source>
         <translation>Передаточное отношение</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="391"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="366"/>
         <source>Slope</source>
         <translation>Наклон</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="373"/>
         <source>No Alt/Slope</source>
         <translation>Без высоты/наклона</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="399"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="374"/>
         <source>0.1km|mi -  1min</source>
         <translation>0,1км|миля - 1 мин</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="400"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
         <source>0.5km|mi -  5min</source>
         <translation>0,5км|миля - 5 мин</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="401"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="376"/>
         <source>1.0km|mi - 10min</source>
         <translation>1км|миля - 10 мин</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1528"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="377"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="1503"/>
         <source>Alt/Slope</source>
         <translation>Высота/Наклон</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="382"/>
         <source>Anaerobic TISS</source>
         <translation>Анаэробный TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="384"/>
         <source>Metrics</source>
         <translation>Показатели</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="411"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="386"/>
         <source>Aerobic TISS</source>
         <translation>Аэробный TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="390"/>
         <source>Iso Power</source>
         <translation type="unfinished">Нормированная мощность (Iso)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="394"/>
         <source>Skiba xPower</source>
         <translation type="unfinished">xPower Скиба</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="423"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
         <source>Altitude Power</source>
         <translation type="unfinished">Мощность с учётом высоты</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="427"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
         <source>W&apos; balance</source>
         <translation>Баланс W&apos;</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="441"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="416"/>
         <source>Time of day</source>
         <translation>Время суток</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="742"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="717"/>
         <source>Intervals</source>
         <translation>Интервалы</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="2253"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="2228"/>
         <source>Selection #%1 </source>
         <translation>Выделение #%1 </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="432"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
         <source>Power + shade</source>
         <translation>Мощность + зоны</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="433"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="408"/>
         <source>Power - shade</source>
         <translation>Мощность - зоны</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="434"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
         <source>No Power</source>
         <translation>Без мощности</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="435"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="410"/>
         <source>Shading</source>
         <translation>На фоне</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="439"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="414"/>
         <source>Time</source>
         <translation>Время</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="440"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
         <source>Distance</source>
         <translation>Дистанция</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="442"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="417"/>
         <source>X Axis</source>
         <translation>Ось X</translation>
     </message>
@@ -3480,51 +3477,45 @@ Press Next to Continue
 <context>
     <name>AutoImportPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4028"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4029"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
         <source>Browse</source>
         <translation type="vanished">Обзор</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4040"/>
         <source>Add</source>
-        <translation>Добавить</translation>
+        <translation type="vanished">Добавить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4041"/>
         <source>Delete</source>
-        <translation>Удалить</translation>
+        <translation type="vanished">Удалить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4042"/>
         <source>Up</source>
-        <translation>Поднять</translation>
+        <translation type="vanished">Поднять</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4043"/>
         <source>Down</source>
-        <translation>Опустить</translation>
+        <translation type="vanished">Опустить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4054"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3779"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4059"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3784"/>
         <source>Directory</source>
         <translation>Каталог</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4060"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3785"/>
         <source>Import Rule</source>
         <translation>Правило импорта</translation>
     </message>
@@ -4342,37 +4333,37 @@ Press Next to Continue
 <context>
     <name>BackupPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="608"/>
+        <location filename="../../Gui/AthletePages.cpp" line="593"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="601"/>
         <source>every</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="617"/>
+        <location filename="../../Gui/AthletePages.cpp" line="602"/>
         <source>times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="603"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="605"/>
         <source>Backup now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="623"/>
+        <location filename="../../Gui/AthletePages.cpp" line="608"/>
         <source>Auto Backup Folder</source>
         <translation>Папка для авторезервирования</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="624"/>
+        <location filename="../../Gui/AthletePages.cpp" line="609"/>
         <source>Auto Backup after closing the athlete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5199,41 +5190,33 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">Обновить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1202"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1203"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1204"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1150"/>
         <source>Review...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1206"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1152"/>
         <source>Changed power estimates are available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1213"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1225"/>
         <source>Add</source>
-        <translation>Добавить</translation>
+        <translation type="vanished">Добавить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1214"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1226"/>
         <source>Delete</source>
-        <translation>Удалить</translation>
+        <translation type="vanished">Удалить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1216"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1158"/>
         <source>Def</source>
         <translation>По умолчанию</translation>
     </message>
@@ -5242,27 +5225,27 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">Дата замера</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1218"/>
         <source>Critical Power</source>
         <translation>Критическая мощность (CP)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1305"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>AeTP</source>
         <translation type="unfinished">AeTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1306"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>FTP</source>
         <translation>FTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1307"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1221"/>
         <source>W&apos;</source>
         <translation>W&apos;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1308"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1222"/>
         <source>Pmax</source>
         <translation type="unfinished">Pмакс</translation>
     </message>
@@ -5275,207 +5258,207 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">d MMM yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1347"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1261"/>
         <source>Short</source>
         <translation>Обозначение</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1247"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1169"/>
         <source>Use CP for all metrics</source>
         <translation>Использовать CP для всех метрик</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1240"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1162"/>
         <source>Manual</source>
         <translation type="unfinished">вручную</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1241"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1163"/>
         <source>Semi-Automatic (CP2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1164"/>
         <source>Semi-Automatic (CP3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1243"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1165"/>
         <source>Semi-Automatic (Extended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1170"/>
         <source>Use FTP for Coggan metrics</source>
         <translation>Использовать FTP для метрик Coggan</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1273"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1279"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1285"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1342"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1618"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1631"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2283"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2289"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2310"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1187"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1193"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1199"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1211"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1537"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1545"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2180"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2186"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2194"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2207"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1205"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1547"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2201"/>
         <source>J</source>
         <translation type="unfinished">Дж</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1303"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1217"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2145"/>
         <source>Start Date</source>
         <translation type="unfinished">Дата начала</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1309"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1223"/>
         <source>Model Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1262"/>
         <source>Long</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1349"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1263"/>
         <source>From Watts</source>
         <translation>От ватт</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1598"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1512"/>
         <source>Review range starting on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1614"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1528"/>
         <source>Current</source>
         <translation type="unfinished">Текущее</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1615"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1529"/>
         <source>Estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1530"/>
         <source>Accept</source>
         <translation type="unfinished">Принять</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1788"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1691"/>
         <source>🗹</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1692"/>
         <source>Estimate and settings &lt;b&gt;match&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1695"/>
         <source>☐</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1696"/>
         <source>Estimate and settings &lt;b&gt;differ&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1797"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1700"/>
         <source>⏲</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1800"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1703"/>
         <source>Range is %1 days older than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1802"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1705"/>
         <source>Range is %1 days younger than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1808"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1711"/>
         <source>∅</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1712"/>
         <source>No estimate available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1902"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1805"/>
         <source>New range from estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2237"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2134"/>
         <source>The proposed value for AeTP is a very rough estimate, assuming %1 % of CP. Usually it is determined by a&lt;ul&gt;&lt;li&gt;Metabolic test&lt;/li&gt;&lt;li&gt;Lactate ramp test&lt;/li&gt;&lt;li&gt;Run / Cycling ‘conversational’ test&lt;/li&gt;&lt;li&gt;Run Decoupling test&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2239"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2136"/>
         <source>Updating FTP internally to match CP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2139"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2244"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2141"/>
         <source>Your selected model does not deliver values for PMax, using default value of %1 W instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2246"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2143"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;li&gt;PMax, assuming a default of %1 W&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2250"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2147"/>
         <source>Critical Power (CP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2252"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2149"/>
         <source>Aerobic Threshold Power (AeTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2254"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2151"/>
         <source>Functional Threshold Power (FTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2153"/>
         <source>Anaerobic Work Capacity (W&apos;)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2258"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2155"/>
         <source>Maximum Power (PMax)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2270"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2167"/>
         <source>Manual range</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5484,14 +5467,14 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">Достигнут предел в 10 зон.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2018"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2025"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1917"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1924"/>
         <source>New</source>
         <translation>Новое</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2020"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1919"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1926"/>
         <source>New (%1)</source>
         <translation>Новое (%1)</translation>
     </message>
@@ -5943,52 +5926,44 @@ ddd, dd MMM yyyy</source>
         <translation type="vanished">Обновить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3307"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3319"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3308"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3320"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3313"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3325"/>
         <source>Add</source>
-        <translation>Добавить</translation>
+        <translation type="vanished">Добавить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3314"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3326"/>
         <source>Delete</source>
-        <translation>Удалить</translation>
+        <translation type="vanished">Удалить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3316"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3109"/>
         <source>Def</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3359"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3506"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3272"/>
         <source>Start Date</source>
         <translation type="unfinished">Дата начала</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3249"/>
         <source>New range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3507"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3273"/>
         <source>Critical Velocity (CV)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3508"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3274"/>
         <source>Aerobic Threshold (AeT)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5997,12 +5972,12 @@ ddd, dd MMM yyyy</source>
         <translation type="vanished">Дата замера</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3360"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3128"/>
         <source>Critical Velocity</source>
         <translation>Критический темп</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3361"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3129"/>
         <source>Aerobic Threshold</source>
         <translation>Аэробный порог</translation>
     </message>
@@ -6015,17 +5990,17 @@ ddd, dd MMM yyyy</source>
         <translation type="vanished">d MMM yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3403"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
         <source>Short</source>
         <translation>Обозначение</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3404"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3172"/>
         <source>Long</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3405"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3173"/>
         <source>From</source>
         <translation>Предел</translation>
     </message>
@@ -6034,14 +6009,14 @@ ddd, dd MMM yyyy</source>
         <translation type="vanished">Достигнут предел в 10 зон.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3679"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3686"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3441"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3448"/>
         <source>New</source>
         <translation>Новое</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3681"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3688"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3443"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3450"/>
         <source>New (%1)</source>
         <translation>Новое (%1)</translation>
     </message>
@@ -7585,37 +7560,32 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>CredentialsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="67"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
+    </message>
+    <message>
+        <source>-</source>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="vanished">Изменить</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">Добавить</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">Удалить</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="68"/>
-        <source>-</source>
-        <translation>-</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="69"/>
-        <source>Edit</source>
-        <translation>Изменить</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="74"/>
-        <source>Add</source>
-        <translation>Добавить</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="75"/>
-        <source>Delete</source>
-        <translation>Удалить</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="86"/>
         <source>Service</source>
         <translation>Сервис</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="87"/>
+        <location filename="../../Gui/AthletePages.cpp" line="69"/>
         <source>Description</source>
         <translation>Описание</translation>
     </message>
@@ -8302,7 +8272,7 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>DataFilterEdit</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2743"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2712"/>
         <source>Warning: sample() is slow -- update code to use samples()</source>
         <translation>Внимание: sample() работает медленно, измените код что бы использовать samples()</translation>
     </message>
@@ -8661,7 +8631,7 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>DirectoryPathWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="277"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="308"/>
         <source>Browse</source>
         <translation type="unfinished">Обзор</translation>
     </message>
@@ -8898,28 +8868,28 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>Dropbox</name>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="68"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="77"/>
         <source>Problem accessing Dropbox data</source>
         <translation>Проблема с доступом к данным Dropbox</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="130"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="139"/>
         <source>You must authorise with Dropbox first</source>
         <translation>Сначала необходимо авторизоваться в Dropbox</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="205"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="214"/>
         <source>Parsing Error: %1</source>
         <translation>Ошибка обработки: %1</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="293"/>
-        <location filename="../../Cloud/Dropbox.cpp" line="312"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="302"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="321"/>
         <source>Completed.</source>
         <translation>Завершено.</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="297"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="306"/>
         <source>Network Error - Upload failed.</source>
         <translation>Ошибка сети — выгрузка файла не удалась.</translation>
     </message>
@@ -9064,136 +9034,136 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2064"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2033"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2034"/>
         <source>Axis Label / Units</source>
         <translation>Подпись / Единица измерения</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1597"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1566"/>
         <source>Curve Settings</source>
         <translation>Параметры данных</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1558"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1527"/>
         <source>Estimate %1 %2 Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1562"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1531"/>
         <source>Endurance Index</source>
         <translation>Выносливость</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1532"/>
         <source>Vo2Max Estimate</source>
         <translation>Оценка VO₂ макс</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1605"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1574"/>
         <source>Metric</source>
         <translation>Показатель</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1606"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1575"/>
         <source>Best</source>
         <translation>Лучшие</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1607"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1576"/>
         <source>Estimate</source>
         <translation>Оценка</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1577"/>
         <source>PMC</source>
         <translation>PMC</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1609"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1578"/>
         <source>Formula</source>
         <translation>Формула</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1610"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1579"/>
         <source>Measure</source>
         <translation>Измерение</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1611"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1580"/>
         <source>Performance</source>
         <translation>Результативность</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1612"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1581"/>
         <source>Banister</source>
         <translation>модель Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1684"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1767"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1653"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1736"/>
         <source>seconds</source>
         <translation>секунд</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1685"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1768"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1737"/>
         <source>minutes</source>
         <translation>минут</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1769"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1655"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1738"/>
         <source>hours</source>
         <translation>часов</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1723"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1816"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1692"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1785"/>
         <source>Peak</source>
         <translation>Пиковое значение</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1781"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1750"/>
         <source>Absolute</source>
         <translation>В абсолюте</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1751"/>
         <source>Per Kilogram</source>
         <translation>На килограмм</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1813"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
         <source>Total</source>
         <translation>Всего</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1814"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1783"/>
         <source>Running Total</source>
         <translation>Нарастающий итог</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1815"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1784"/>
         <source>Average</source>
         <translation>Среднее</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1817"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1786"/>
         <source>Low</source>
         <translation>Минимальное</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1820"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1789"/>
         <source>Aggregate:</source>
         <translation>Функция агрегирования:</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1828"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1797"/>
         <source># type in a formula to use
 # for e.g. BikeStress / Duration
 # as you type the available metrics
@@ -9206,292 +9176,292 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1839"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1808"/>
         <source>Weekly Best Performances</source>
         <translation type="unfinished">Лучшая недельная результативность</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1840"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1809"/>
         <source>Submaximal Weekly Best</source>
         <translation type="unfinished">Субмаксимальная лучшая недельная</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1841"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1810"/>
         <source>Performance Tests</source>
         <translation type="unfinished">Тесты результативности</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1933"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1902"/>
         <source>Short Term Stress (STS/ATL)</source>
         <translation>Краткосрочная нагрузка (STS/ATL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1934"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1903"/>
         <source>Long Term Stress  (LTS/CTL)</source>
         <translation>Длительная нагрузка (LTS/CTL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1935"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1904"/>
         <source>Stress Balance    (SB/TSB)</source>
         <translation>Баланс нагрузки (SB/TSB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1936"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1905"/>
         <source>Stress Ramp Rate  (RR)</source>
         <translation>Скорость изменения нагрузки (RR)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1944"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1913"/>
         <source>Stress Type</source>
         <translation>Тип нагрузки</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1949"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1918"/>
         <source>Negative Training Effect (NTE)</source>
         <translation>Негативный тренировочный эффект (NTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1950"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1919"/>
         <source>Positive Training Effect (PTE)</source>
         <translation>Позитивный тренировочный эффект (PTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1951"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1920"/>
         <source>Performance (Power Index)</source>
         <translation>Результативность (Индекс Мощности)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1952"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1921"/>
         <source>Predicted CP (Watts)</source>
         <translation>Прогноз критической мощности (CP, Вт)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1969"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1938"/>
         <source>Curve Type</source>
         <translation>Тип кривой</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1945"/>
         <source>Perf. Metric</source>
         <translation>Показатель результативности</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2006"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1975"/>
         <source>Metadata Field</source>
         <translation type="unfinished">Поле матаданных</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2007"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
         <source>PMC metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2032"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2001"/>
         <source>Measure Group</source>
         <translation>Группа измерений</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2009"/>
         <source>Measure Field</source>
         <translation>Параметр измерений</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2029"/>
         <source>Filter</source>
         <translation>Фильтр</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2071"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
         <source>Style</source>
         <translation>Стиль</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2042"/>
         <source>Bar</source>
         <translation>Столбики</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2074"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2043"/>
         <source>Line</source>
         <translation>Линии</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2075"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2044"/>
         <source>Sticks</source>
         <translation>Полоски</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2076"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2045"/>
         <source>Dots</source>
         <translation>Точки</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2048"/>
         <source>Stack</source>
         <translation>Показывать раздельно</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2053"/>
         <source>Symbol</source>
         <translation>Символ</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2086"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2055"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2087"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2056"/>
         <source>Circle</source>
         <translation>Круг</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2057"/>
         <source>Square</source>
         <translation>Квадрат</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2089"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2058"/>
         <source>Diamond</source>
         <translation>Ромб</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2090"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2059"/>
         <source>Triangle</source>
         <translation>Треугольник</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2091"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
         <source>Cross</source>
         <translation>Крест</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2092"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2061"/>
         <source>Hexagon</source>
         <translation>Шестиугольник</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2062"/>
         <source>Star</source>
         <translation>Звезда</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2100"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2069"/>
         <source>Fill curve</source>
         <translation>Выполнять заливку кривых</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
         <source>Data labels</source>
         <translation>Подписывать данные</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2080"/>
         <source>Highlight Highest</source>
         <translation>Выделять самые высокие значения</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
         <source>Highlight Lowest</source>
         <translation>Выделять самые низкие значения</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2127"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
         <source>Highlight Outliers</source>
         <translation>Выделять резко отклоняющиеся</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2135"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
         <source>Baseline</source>
         <translation>Точка отсчёта</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2143"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2112"/>
         <source>Smooth Curve</source>
         <translation>Сглаживать кривую</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2147"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2116"/>
         <source>No trend Line</source>
         <translation>Без линии динамики</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2148"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2117"/>
         <source>Linear Trend</source>
         <translation>Линейная динамика</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2149"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2118"/>
         <source>Quadratic Trend</source>
         <translation>Квадратичная динамика</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2150"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
         <source>Moving Average</source>
         <translation>Скользящее среднее</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2151"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2120"/>
         <source>Simple Average</source>
         <translation>Простое среднее</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2123"/>
         <source>Ignore Zeros</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2168"/>
         <source>&amp;OK</source>
         <translation>&amp;ОК</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2201"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2170"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Отмена</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2431"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2400"/>
         <source>Peak %1</source>
         <translation>Пик %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2402"/>
         <source> second </source>
         <translation> секунда </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2434"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2403"/>
         <source> minute </source>
         <translation> минута </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2436"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2405"/>
         <source> hour </source>
         <translation> час </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2456"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2425"/>
         <source>%1 - %2</source>
         <translation>%1 - %2</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2470"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2439"/>
         <source>Performances</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2471"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2440"/>
         <source>Power Index</source>
         <translation>Индекс мощности</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2588"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2557"/>
         <source>Performances_%1_%2_%3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9821,93 +9791,93 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditUserAxisDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1731"/>
+        <location filename="../../Charts/UserChart.cpp" line="1689"/>
         <source>Edit Axis</source>
         <translation>Редактировать ось</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1741"/>
+        <location filename="../../Charts/UserChart.cpp" line="1699"/>
         <source>&amp;OK</source>
         <translation>&amp;ОК</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1742"/>
+        <location filename="../../Charts/UserChart.cpp" line="1700"/>
         <source>&amp;Cancel</source>
         <translation>О&amp;тмена</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1750"/>
+        <location filename="../../Charts/UserChart.cpp" line="1708"/>
         <source>Units</source>
         <translation>Единицы измерения</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1760"/>
+        <location filename="../../Charts/UserChart.cpp" line="1718"/>
         <source>Logarithmic Scale</source>
         <translation>Логарифмическая шкала</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1757"/>
+        <location filename="../../Charts/UserChart.cpp" line="1715"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1761"/>
-        <location filename="../../Charts/UserChart.cpp" line="1780"/>
+        <location filename="../../Charts/UserChart.cpp" line="1719"/>
+        <location filename="../../Charts/UserChart.cpp" line="1738"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1763"/>
+        <location filename="../../Charts/UserChart.cpp" line="1721"/>
         <source>Fixed</source>
         <translation>Фиксированный</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1774"/>
+        <location filename="../../Charts/UserChart.cpp" line="1732"/>
         <source> from </source>
         <translation> от </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1776"/>
+        <location filename="../../Charts/UserChart.cpp" line="1734"/>
         <source> to </source>
         <translation> до </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1779"/>
+        <location filename="../../Charts/UserChart.cpp" line="1737"/>
         <source>Range</source>
         <translation>Диапазон</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1787"/>
+        <location filename="../../Charts/UserChart.cpp" line="1745"/>
         <source>Smoothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1792"/>
+        <location filename="../../Charts/UserChart.cpp" line="1750"/>
         <source>None</source>
         <translation type="unfinished">Нет</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1793"/>
+        <location filename="../../Charts/UserChart.cpp" line="1751"/>
         <source>Day</source>
         <translation type="unfinished">День</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1794"/>
+        <location filename="../../Charts/UserChart.cpp" line="1752"/>
         <source>Week</source>
         <translation type="unfinished">Неделя</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1795"/>
+        <location filename="../../Charts/UserChart.cpp" line="1753"/>
         <source>Month</source>
         <translation type="unfinished">Месяц</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1796"/>
+        <location filename="../../Charts/UserChart.cpp" line="1754"/>
         <source>Year</source>
         <translation type="unfinished">Год</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1798"/>
+        <location filename="../../Charts/UserChart.cpp" line="1756"/>
         <source>Group By</source>
         <translation type="unfinished">Сгруппировать по</translation>
     </message>
@@ -10104,158 +10074,158 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditUserSeriesDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1398"/>
+        <location filename="../../Charts/UserChart.cpp" line="1356"/>
         <source>Edit Data Series</source>
         <translation>Редактировать серию данных</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1414"/>
+        <location filename="../../Charts/UserChart.cpp" line="1372"/>
         <source>&amp;OK</source>
         <translation>&amp;ОК</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1415"/>
+        <location filename="../../Charts/UserChart.cpp" line="1373"/>
         <source>&amp;Cancel</source>
         <translation>О&amp;тмена</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1422"/>
+        <location filename="../../Charts/UserChart.cpp" line="1380"/>
         <source>Group</source>
         <translation type="unfinished">Группа</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1430"/>
+        <location filename="../../Charts/UserChart.cpp" line="1388"/>
         <source>Series Name</source>
         <translation>Название серии данных</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1519"/>
+        <location filename="../../Charts/UserChart.cpp" line="1477"/>
         <source>Y units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1524"/>
+        <location filename="../../Charts/UserChart.cpp" line="1482"/>
         <source>X units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1528"/>
+        <location filename="../../Charts/UserChart.cpp" line="1486"/>
         <source>Sum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1529"/>
+        <location filename="../../Charts/UserChart.cpp" line="1487"/>
         <source>Average</source>
         <translation type="unfinished">Среднее</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1530"/>
+        <location filename="../../Charts/UserChart.cpp" line="1488"/>
         <source>Peak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1531"/>
+        <location filename="../../Charts/UserChart.cpp" line="1489"/>
         <source>Low</source>
         <translation type="unfinished">Минимальное</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1532"/>
+        <location filename="../../Charts/UserChart.cpp" line="1490"/>
         <source>Running Total</source>
         <translation type="unfinished">Нарастающий итог</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1533"/>
+        <location filename="../../Charts/UserChart.cpp" line="1491"/>
         <source>Mean Square Root</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1534"/>
+        <location filename="../../Charts/UserChart.cpp" line="1492"/>
         <source>Std Deviation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1537"/>
+        <location filename="../../Charts/UserChart.cpp" line="1495"/>
         <source>Aggregate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1541"/>
-        <location filename="../../Charts/UserChart.cpp" line="1557"/>
+        <location filename="../../Charts/UserChart.cpp" line="1499"/>
+        <location filename="../../Charts/UserChart.cpp" line="1515"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1542"/>
+        <location filename="../../Charts/UserChart.cpp" line="1500"/>
         <source>Solid</source>
         <translation>сплошной</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1543"/>
+        <location filename="../../Charts/UserChart.cpp" line="1501"/>
         <source>Dashed</source>
         <translation>штрихи</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1544"/>
+        <location filename="../../Charts/UserChart.cpp" line="1502"/>
         <source>Dot</source>
         <translation>точки</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1545"/>
+        <location filename="../../Charts/UserChart.cpp" line="1503"/>
         <source>Dash Dot</source>
         <translation>штрихпунктир</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1546"/>
+        <location filename="../../Charts/UserChart.cpp" line="1504"/>
         <source>Fast Graphics</source>
         <translation type="unfinished">Быстрая графика</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1547"/>
+        <location filename="../../Charts/UserChart.cpp" line="1505"/>
         <source>Show on Legend</source>
         <translation>Отображать в легенде</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1548"/>
+        <location filename="../../Charts/UserChart.cpp" line="1506"/>
         <source>Show Data Labels</source>
         <translation>Показывать подписи данных</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1554"/>
+        <location filename="../../Charts/UserChart.cpp" line="1512"/>
         <source>Line Style</source>
         <translation>Стиль линий</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1558"/>
+        <location filename="../../Charts/UserChart.cpp" line="1516"/>
         <source>Circle</source>
         <translation>Круг</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1559"/>
+        <location filename="../../Charts/UserChart.cpp" line="1517"/>
         <source>Rectangle</source>
         <translation>прямоугольник</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1564"/>
+        <location filename="../../Charts/UserChart.cpp" line="1522"/>
         <source>Symbol</source>
         <translation>Символ</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1572"/>
+        <location filename="../../Charts/UserChart.cpp" line="1530"/>
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1575"/>
+        <location filename="../../Charts/UserChart.cpp" line="1533"/>
         <source>Fill curve</source>
         <translation>Выполнять заливку кривых</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1583"/>
+        <location filename="../../Charts/UserChart.cpp" line="1541"/>
         <source>Opacity (%)</source>
         <translation>Прозрачность (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1589"/>
+        <location filename="../../Charts/UserChart.cpp" line="1547"/>
         <source>Size/Width</source>
         <translation>Размер/Ширина</translation>
     </message>
@@ -10302,6 +10272,24 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
         <location filename="../../Metrics/BasicRideMetrics.cpp" line="144"/>
         <source>Only useful for intervals, time the interval started</source>
         <translation>Полезно для интервалов, время прошедшее с начала интервала</translation>
+    </message>
+</context>
+<context>
+    <name>ElevationChartWindow</name>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="221"/>
+        <source>Profile Distance (m)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="229"/>
+        <source>Seconds for delta slope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="237"/>
+        <source>Elevation window size (%) relative to current altitude</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10741,7 +10729,7 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
         <translation type="unfinished"> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ExhaustionDialog.cpp" line="160"/>
+        <location filename="../../Charts/ExhaustionDialog.cpp" line="162"/>
         <source>Time</source>
         <translation type="unfinished">Время</translation>
     </message>
@@ -13164,42 +13152,42 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GcCrashDialog</name>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="78"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="74"/>
         <source>%1 Crash Recovery</source>
         <translation>Восстановление данных после падения %1</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="116"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="112"/>
         <source>&lt;b&gt;GoldenCheetah appears to have PREVIOUSLY crashed for this athlete. &lt;/b&gt;&lt;br&gt;&lt;br&gt;The report below gives some diagnostic information that will be useful to the developers. Feel free to post this with a short description of what was occurring when the crash happened to the &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah forums&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;We respect privacy - this log does NOT contain ids, passwords or personal information.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;When this dialog is closed the athlete will be opened.&lt;/b&gt;</source>
         <translation type="unfinished">&lt;b&gt;GoldenCheetah похоже аварийно завершился на этом спортсмене. &lt;/b&gt;&lt;br&gt;&lt;br&gt;В приведенном ниже отчете содержится некоторая диагностическая информация, которая будет полезна разработчикам. Не стесняйтесь публиковать это с кратким описанием того, что происходило, на &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;форуме GoldenCheetah&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;Мы уважаем конфиденциальность - этот журнал НЕ содержит идентификаторов, паролей или личной информации.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;Когда это диалоговое окно будет закрыто, работа будет продолжена.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="141"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="137"/>
         <source>Save Crash Report...</source>
         <translation>Сохранить отчёт о падении...</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="143"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="139"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="225"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="221"/>
         <source>&lt;p&gt;Build date: %1 %2&lt;br&gt;Build id: %3&lt;br&gt;Version: %4&lt;br&gt;DB Schema: %5&lt;br&gt;Metrics: %7&lt;br&gt;OS: %6&lt;br&gt;OpenGL: %10&lt;br&gt;UI: dpi scale (%8) font size (%9)&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="255"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="251"/>
         <source>&lt;table&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QT&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QWT&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;%3&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SRMIO&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;D2XX&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;ICAL&lt;/td&gt;&lt;td&gt;%9&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;USBXPRESS&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LIBUSB&lt;/td&gt;&lt;td&gt;%11&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VLC&lt;/td&gt;&lt;td&gt;%12&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VIDEO&lt;/td&gt;&lt;td&gt;%13&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SAMPLERATE&lt;/td&gt;&lt;td&gt;%14&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SSL&lt;/td&gt;&lt;td&gt;%15&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;R&lt;/td&gt;&lt;td&gt;%16&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;Python&lt;/td&gt;&lt;td&gt;%18&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LMFIT&lt;/td&gt;&lt;td&gt;7.0&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;GSL&lt;/td&gt;&lt;td&gt;%19&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Save Diagnostics</source>
         <translation>Сохранить диагностику</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Text File (*.txt)</source>
         <translation>Текстовый файл (*.txt)</translation>
     </message>
@@ -13534,167 +13522,172 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GcWindowRegistry</name>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
         <source>Performance</source>
         <translation>Результативность</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="89"/>
         <source>Histogram</source>
         <translation>Гистограмма</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
         <source>Distribution</source>
         <translation>Распределение</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
         <source>Pedal Force vs Velocity</source>
         <translation>Сила педалирования и скорость</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
         <source>Heartrate vs Power</source>
         <translation>ЧСС и мощность</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
         <source>Python Chart</source>
         <translation>График Python</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
         <source>Python Chart </source>
         <translation>График Python </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="113"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
         <source>Live Map</source>
         <translation type="unfinished">Живая карта</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="114"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <source>Elevation Chart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
         <source>Web page</source>
         <translation>Web страница</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="101"/>
         <source>Calendar</source>
         <translation>Календарь</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
         <source>Navigator</source>
         <translation>Навигатор</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="76"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="73"/>
         <source>User Chart</source>
         <translation>Пользовательский график</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
         <source>Trends</source>
         <translation>Динамика показателей</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="78"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
         <source>TreeMap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
         <source>Power Duration </source>
         <translation>Кривая мощности </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="85"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="82"/>
         <source>User Chart </source>
         <translation>Пользовательский график </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="88"/>
         <source>Power Duration</source>
         <translation>Кривая мощности</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
         <source>Scatter</source>
         <translation>Разброс</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="103"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
         <source>Aerolab</source>
         <translation>Анализ Aerolab</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
         <source>Telemetry</source>
         <translation>Телеметрия</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
         <source>Workout</source>
         <translation>Тренировка</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="106"/>
         <source>Realtime</source>
         <translation type="unfinished">Реальное время</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
         <source>Pedal Stroke</source>
         <translation>Частота педалирования</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
         <source>Map</source>
         <translation>Карта</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="71"/>
         <source>Season Overview</source>
         <translation>Обзор сезона</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="72"/>
         <source>Blank Overview </source>
         <translation>Пустой обзор </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="83"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
         <source>Activity Overview</source>
         <translation>Обзор тренировки</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="81"/>
         <source>Blank Overview</source>
         <translation>Пустой обзор</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
         <source>Data</source>
         <translation type="unfinished">Данные</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
         <source>R Chart</source>
         <translation>График R</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="98"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
         <source>R Chart </source>
         <translation>График R </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
         <source>Video Player</source>
         <translation>Видеопроигрыватель</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
         <source>Workout Editor</source>
         <translation>Редактор тренировок</translation>
     </message>
@@ -14797,142 +14790,147 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="296"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="294"/>
+        <source>Show elevation profile of instant position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
         <source>Predefined and configurable set of data ranges for selection of activities to be analysed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
         <source>Powerful filter and search engine to determine the activities which are considered in diagram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
         <source>Configurable list of activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="317"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
         <source>Configurable list of training devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
         <source>Configurable list of workout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
         <source>Configurable list of video files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="325"/>
         <source>Configurable list of video sync files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="327"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
         <source>Entry field for sophisticated Searching and Filtering of activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
         <source>Adding intervals to an activity using simple query methods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
         <source>To compare Activities/Intervals in Activity View and Date Ranges in Trends View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="335"/>
         <source>Workout Control, Intensity Adjustments and Notifications Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
         <source>Athlete Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
         <source>Athlete Measures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
         <source>Auto Import</source>
         <translation type="unfinished">Автоимпорт</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
         <source>Backup</source>
         <translation type="unfinished">Архивирование</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="355"/>
         <source>Cloud Accounts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <source>Automatic Interval Detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
         <source>Definition of coloring rules for activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
         <source>Metrics shown in &apos;Intervals&apos; and &apos;Summary&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
         <source>User/Custom Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
         <source>Create or Edit a User Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
         <source>Measures</source>
         <translation type="unfinished">Метрики</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
         <source>Train View devices configuration and preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
         <source>Train View Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
         <source>Remote Controls Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
         <source>Add/Remove Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
         <source>Add Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="394"/>
         <source>Virtual Bicycle configuration for simulation rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14966,8 +14964,8 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
     </message>
     <message>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="219"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
         <source>Calendar</source>
         <translation type="unfinished">Календарь</translation>
     </message>
@@ -15002,74 +15000,74 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
         <source>Definition of points in time &apos;Events&apos; which are marked explicitely on time related diagrams</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="316"/>
         <source>Simple summary view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
         <source>Alternative access to the charts created for the main view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
         <source>Display the available and add new intervals using simple query methods</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="356"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
         <source>General</source>
         <translation>Общие</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="337"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
         <source>Athlete</source>
         <translation>Спортсмен</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
         <source>Training Zone definition for power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
         <source>Training Zone definition for heartrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
         <source>Training Zone definition for Swim and Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
         <source>Appearance</source>
         <translation>Внешний вид</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="364"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
         <source>Data Fields</source>
         <translation>Поля данных</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
         <source>Definition of default value(s) for data fields</source>
         <translation>Описание значений по умолчанию для полей данных</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
         <source>Definition of processing default parameters for the fix, adjust,... tools</source>
         <translation>Описание процессов по умолчанию для исправления, коррекции и др. над  параметрами</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
         <source>Metrics</source>
         <translation>Показатели (метрики)</translation>
     </message>
@@ -15269,47 +15267,43 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2437"/>
         <source>Add</source>
-        <translation>Добавить</translation>
+        <translation type="vanished">Добавить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2438"/>
         <source>Delete</source>
-        <translation>Удалить</translation>
+        <translation type="vanished">Удалить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2431"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2432"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2447"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2332"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2458"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2343"/>
         <source>Short</source>
         <translation>Обозначение</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2459"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2344"/>
         <source>Long</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2460"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2345"/>
         <source>Percent of LT</source>
         <translation>Процент от ЛП</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2461"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2346"/>
         <source>Trimp k</source>
         <translation>TRIMP k</translation>
     </message>
@@ -15318,14 +15312,14 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">Достигнут предел в 10 зон.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2506"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2513"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2390"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2397"/>
         <source>New</source>
         <translation>Новое</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2508"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2515"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2392"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2399"/>
         <source>New (%1)</source>
         <translation>Новое (%1)</translation>
     </message>
@@ -15515,17 +15509,17 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2245"/>
         <source>Sport</source>
         <translation>Вид спорта</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2395"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2292"/>
         <source>Lactate Threshold</source>
         <translation>Лактатный порог</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2396"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2293"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
@@ -17678,548 +17672,545 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTMTool</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1303"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1272"/>
         <source>Metric</source>
         <translation>Показатель</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="74"/>
+        <location filename="../../Charts/LTMTool.cpp" line="75"/>
         <source>Filter</source>
         <translation>Фильтр</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="80"/>
+        <location filename="../../Charts/LTMTool.cpp" line="81"/>
         <source>Date range</source>
         <translation>Диапазон дат</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="84"/>
+        <location filename="../../Charts/LTMTool.cpp" line="85"/>
         <source>Days</source>
         <translation>Дни</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="85"/>
+        <location filename="../../Charts/LTMTool.cpp" line="86"/>
         <source>Weeks</source>
         <translation>Недели</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="86"/>
+        <location filename="../../Charts/LTMTool.cpp" line="87"/>
         <source>Months</source>
         <translation>Месяцы</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="87"/>
+        <location filename="../../Charts/LTMTool.cpp" line="88"/>
         <source>Years</source>
         <translation>Годы</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="88"/>
+        <location filename="../../Charts/LTMTool.cpp" line="89"/>
         <source>Time Of Day</source>
         <translation>Время дня</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="89"/>
+        <location filename="../../Charts/LTMTool.cpp" line="90"/>
         <source>All</source>
         <translation>Все</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="91"/>
+        <location filename="../../Charts/LTMTool.cpp" line="92"/>
         <source>Group by</source>
         <translation>Группировка</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="102"/>
+        <location filename="../../Charts/LTMTool.cpp" line="103"/>
         <source>Shade Zones</source>
         <translation>Показывать зоны на фоне</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="105"/>
+        <location filename="../../Charts/LTMTool.cpp" line="106"/>
         <source>Show Legend</source>
         <translation>Показывать легенду</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="109"/>
         <source>Show Events</source>
         <translation>Показывать события</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="112"/>
         <source>Show Banister Helper</source>
         <translation>Показывать помощника Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="351"/>
+        <location filename="../../Charts/LTMTool.cpp" line="325"/>
         <source>Skiba Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="353"/>
-        <location filename="../../Charts/LTMTool.cpp" line="368"/>
-        <location filename="../../Charts/LTMTool.cpp" line="429"/>
-        <location filename="../../Charts/LTMTool.cpp" line="444"/>
-        <location filename="../../Charts/LTMTool.cpp" line="505"/>
-        <location filename="../../Charts/LTMTool.cpp" line="520"/>
-        <location filename="../../Charts/LTMTool.cpp" line="580"/>
-        <location filename="../../Charts/LTMTool.cpp" line="595"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1080"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1095"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1156"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1171"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1309"/>
+        <location filename="../../Charts/LTMTool.cpp" line="327"/>
+        <location filename="../../Charts/LTMTool.cpp" line="342"/>
+        <location filename="../../Charts/LTMTool.cpp" line="403"/>
+        <location filename="../../Charts/LTMTool.cpp" line="418"/>
+        <location filename="../../Charts/LTMTool.cpp" line="479"/>
+        <location filename="../../Charts/LTMTool.cpp" line="494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="554"/>
+        <location filename="../../Charts/LTMTool.cpp" line="569"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1054"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1069"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1130"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1145"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1278"/>
         <source>Stress</source>
         <translation>Нагрузка</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="366"/>
+        <location filename="../../Charts/LTMTool.cpp" line="340"/>
         <source>Skiba Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="381"/>
+        <location filename="../../Charts/LTMTool.cpp" line="355"/>
         <source>Skiba Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="383"/>
-        <location filename="../../Charts/LTMTool.cpp" line="459"/>
-        <location filename="../../Charts/LTMTool.cpp" line="535"/>
-        <location filename="../../Charts/LTMTool.cpp" line="610"/>
-        <location filename="../../Charts/LTMTool.cpp" line="686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="762"/>
-        <location filename="../../Charts/LTMTool.cpp" line="838"/>
-        <location filename="../../Charts/LTMTool.cpp" line="914"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1110"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1186"/>
+        <location filename="../../Charts/LTMTool.cpp" line="357"/>
+        <location filename="../../Charts/LTMTool.cpp" line="433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="509"/>
+        <location filename="../../Charts/LTMTool.cpp" line="584"/>
+        <location filename="../../Charts/LTMTool.cpp" line="660"/>
+        <location filename="../../Charts/LTMTool.cpp" line="736"/>
+        <location filename="../../Charts/LTMTool.cpp" line="812"/>
+        <location filename="../../Charts/LTMTool.cpp" line="888"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1160"/>
         <source>Stress Balance</source>
         <translation type="unfinished">Баланс нагрузки</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="396"/>
+        <location filename="../../Charts/LTMTool.cpp" line="370"/>
         <source>Skiba STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="398"/>
-        <location filename="../../Charts/LTMTool.cpp" line="413"/>
-        <location filename="../../Charts/LTMTool.cpp" line="474"/>
-        <location filename="../../Charts/LTMTool.cpp" line="489"/>
-        <location filename="../../Charts/LTMTool.cpp" line="550"/>
-        <location filename="../../Charts/LTMTool.cpp" line="565"/>
-        <location filename="../../Charts/LTMTool.cpp" line="625"/>
-        <location filename="../../Charts/LTMTool.cpp" line="640"/>
-        <location filename="../../Charts/LTMTool.cpp" line="701"/>
-        <location filename="../../Charts/LTMTool.cpp" line="716"/>
-        <location filename="../../Charts/LTMTool.cpp" line="777"/>
-        <location filename="../../Charts/LTMTool.cpp" line="792"/>
-        <location filename="../../Charts/LTMTool.cpp" line="853"/>
-        <location filename="../../Charts/LTMTool.cpp" line="868"/>
-        <location filename="../../Charts/LTMTool.cpp" line="929"/>
-        <location filename="../../Charts/LTMTool.cpp" line="944"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1005"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1020"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1125"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1140"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1201"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1216"/>
+        <location filename="../../Charts/LTMTool.cpp" line="372"/>
+        <location filename="../../Charts/LTMTool.cpp" line="387"/>
+        <location filename="../../Charts/LTMTool.cpp" line="448"/>
+        <location filename="../../Charts/LTMTool.cpp" line="463"/>
+        <location filename="../../Charts/LTMTool.cpp" line="524"/>
+        <location filename="../../Charts/LTMTool.cpp" line="539"/>
+        <location filename="../../Charts/LTMTool.cpp" line="599"/>
+        <location filename="../../Charts/LTMTool.cpp" line="614"/>
+        <location filename="../../Charts/LTMTool.cpp" line="675"/>
+        <location filename="../../Charts/LTMTool.cpp" line="690"/>
+        <location filename="../../Charts/LTMTool.cpp" line="751"/>
+        <location filename="../../Charts/LTMTool.cpp" line="766"/>
+        <location filename="../../Charts/LTMTool.cpp" line="827"/>
+        <location filename="../../Charts/LTMTool.cpp" line="842"/>
+        <location filename="../../Charts/LTMTool.cpp" line="903"/>
+        <location filename="../../Charts/LTMTool.cpp" line="918"/>
+        <location filename="../../Charts/LTMTool.cpp" line="979"/>
+        <location filename="../../Charts/LTMTool.cpp" line="994"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1099"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1114"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1175"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1190"/>
         <source>Ramp</source>
         <translation type="unfinished">Изменение</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="411"/>
+        <location filename="../../Charts/LTMTool.cpp" line="385"/>
         <source>Skiba LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="427"/>
+        <location filename="../../Charts/LTMTool.cpp" line="401"/>
         <source>Aerobic TISS Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="442"/>
+        <location filename="../../Charts/LTMTool.cpp" line="416"/>
         <source>Aerobic TISS Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="457"/>
+        <location filename="../../Charts/LTMTool.cpp" line="431"/>
         <source>Aerobic TISS Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="472"/>
+        <location filename="../../Charts/LTMTool.cpp" line="446"/>
         <source>Aerobic TISS STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="487"/>
+        <location filename="../../Charts/LTMTool.cpp" line="461"/>
         <source>Aerobic TISS LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="503"/>
+        <location filename="../../Charts/LTMTool.cpp" line="477"/>
         <source>Anaerobic TISS Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="518"/>
+        <location filename="../../Charts/LTMTool.cpp" line="492"/>
         <source>Anaerobic TISS Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="533"/>
+        <location filename="../../Charts/LTMTool.cpp" line="507"/>
         <source>Anaerobic TISS Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="548"/>
+        <location filename="../../Charts/LTMTool.cpp" line="522"/>
         <source>Anaerobic TISS STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="537"/>
         <source>Anaerobic TISS LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="578"/>
+        <location filename="../../Charts/LTMTool.cpp" line="552"/>
         <source>Daniels Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="593"/>
+        <location filename="../../Charts/LTMTool.cpp" line="567"/>
         <source>Daniels Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="582"/>
         <source>Daniels Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="623"/>
+        <location filename="../../Charts/LTMTool.cpp" line="597"/>
         <source>Daniels STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="638"/>
+        <location filename="../../Charts/LTMTool.cpp" line="612"/>
         <source>Daniels LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="628"/>
         <source>Work (Kj) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="656"/>
-        <location filename="../../Charts/LTMTool.cpp" line="671"/>
-        <location filename="../../Charts/LTMTool.cpp" line="732"/>
-        <location filename="../../Charts/LTMTool.cpp" line="747"/>
-        <location filename="../../Charts/LTMTool.cpp" line="808"/>
-        <location filename="../../Charts/LTMTool.cpp" line="823"/>
+        <location filename="../../Charts/LTMTool.cpp" line="630"/>
+        <location filename="../../Charts/LTMTool.cpp" line="645"/>
+        <location filename="../../Charts/LTMTool.cpp" line="706"/>
+        <location filename="../../Charts/LTMTool.cpp" line="721"/>
+        <location filename="../../Charts/LTMTool.cpp" line="782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="797"/>
         <source>Stress (Kj)</source>
         <translation>Нагрузка (кДж)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="669"/>
+        <location filename="../../Charts/LTMTool.cpp" line="643"/>
         <source>Work (Kj) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="684"/>
+        <location filename="../../Charts/LTMTool.cpp" line="658"/>
         <source>Work (Kj) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="699"/>
+        <location filename="../../Charts/LTMTool.cpp" line="673"/>
         <source>Work (Kj) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="714"/>
+        <location filename="../../Charts/LTMTool.cpp" line="688"/>
         <source>Work (Kj) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="730"/>
+        <location filename="../../Charts/LTMTool.cpp" line="704"/>
         <source>W&apos; Work (Kj) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="745"/>
+        <location filename="../../Charts/LTMTool.cpp" line="719"/>
         <source>W&apos; Work (Kj) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="760"/>
+        <location filename="../../Charts/LTMTool.cpp" line="734"/>
         <source>W&apos; Work (Kj) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="775"/>
+        <location filename="../../Charts/LTMTool.cpp" line="749"/>
         <source>W&apos; Work (Kj) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="790"/>
+        <location filename="../../Charts/LTMTool.cpp" line="764"/>
         <source>W&apos; Work (Kj) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="806"/>
+        <location filename="../../Charts/LTMTool.cpp" line="780"/>
         <source>Below CP Work (Kj) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="821"/>
+        <location filename="../../Charts/LTMTool.cpp" line="795"/>
         <source>Below CP Work (Kj) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="836"/>
+        <location filename="../../Charts/LTMTool.cpp" line="810"/>
         <source>Below CP Work (Kj) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="851"/>
+        <location filename="../../Charts/LTMTool.cpp" line="825"/>
         <source>Below CP Work (Kj) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="866"/>
+        <location filename="../../Charts/LTMTool.cpp" line="840"/>
         <source>Below CP Work (Kj) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="882"/>
+        <location filename="../../Charts/LTMTool.cpp" line="856"/>
         <source>Distance (km|mi) Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="884"/>
-        <location filename="../../Charts/LTMTool.cpp" line="899"/>
+        <location filename="../../Charts/LTMTool.cpp" line="858"/>
+        <location filename="../../Charts/LTMTool.cpp" line="873"/>
         <source>Stress (km|mi)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="897"/>
+        <location filename="../../Charts/LTMTool.cpp" line="871"/>
         <source>Distance (km|mi) Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="912"/>
+        <location filename="../../Charts/LTMTool.cpp" line="886"/>
         <source>Distance (km|mi) Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="927"/>
+        <location filename="../../Charts/LTMTool.cpp" line="901"/>
         <source>Distance (km|mi) STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="942"/>
+        <location filename="../../Charts/LTMTool.cpp" line="916"/>
         <source>Distance (km|mi) LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="958"/>
+        <location filename="../../Charts/LTMTool.cpp" line="932"/>
         <source>Coggan Chronic Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="973"/>
+        <location filename="../../Charts/LTMTool.cpp" line="947"/>
         <source>Coggan Acute Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="988"/>
+        <location filename="../../Charts/LTMTool.cpp" line="962"/>
         <source>Coggan Training Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1003"/>
+        <location filename="../../Charts/LTMTool.cpp" line="977"/>
         <source>Coggan STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1018"/>
+        <location filename="../../Charts/LTMTool.cpp" line="992"/>
         <source>Coggan LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1033"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1007"/>
         <source>Coggan Expected Chronic Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1048"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1022"/>
         <source>Coggan Expected Acute Training Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1063"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1037"/>
         <source>Coggan Expected Training Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1053"/>
         <source>TRIMP Long Term Stress</source>
         <translatorcomment>Уровень тренированности (база)</translatorcomment>
         <translation>TRIMP долговременный стресс</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1067"/>
         <source>TRIMP Short Term Stress</source>
         <translatorcomment>Уровень усталости</translatorcomment>
         <translation>TRIMP кратковременный стресс</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1082"/>
         <source>TRIMP Stress Balance</source>
         <translatorcomment>Уровень формы</translatorcomment>
         <translation>TRIMP баланс стресса</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1123"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1097"/>
         <source>TRIMP STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1138"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1112"/>
         <source>TRIMP LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="268"/>
         <source>Edit</source>
-        <translation>Изменить</translation>
+        <translation type="vanished">Изменить</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="124"/>
+        <location filename="../../Charts/LTMTool.cpp" line="125"/>
         <source>Use sidebar chart settings</source>
         <translation>Использовать параметры из графика в боковой панели</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Basic</source>
         <translation>Основные параметры</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="314"/>
+        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Preset</source>
         <translation>Предустановка</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1307"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1276"/>
         <source>Estimate</source>
         <translation>Оценка</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1311"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1280"/>
         <source>Formula</source>
         <translation>Формула</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1282"/>
         <source>Measure</source>
         <translation>Измерение</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1284"/>
         <source>Performance</source>
         <translation>Результативность</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1317"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1286"/>
         <source>Banister</source>
         <translation>модель Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1463"/>
         <source>Chart %1</source>
         <translation>График %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="94"/>
+        <location filename="../../Charts/LTMTool.cpp" line="95"/>
         <source>Data Table</source>
         <translation>Таблица вместо графиков</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="98"/>
+        <location filename="../../Charts/LTMTool.cpp" line="99"/>
         <source>Show Stack</source>
         <translation>Показывать раздельно</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="121"/>
+        <location filename="../../Charts/LTMTool.cpp" line="122"/>
         <source>Stack Zoom</source>
         <translation>Масштаб раздельного просмотра</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="155"/>
+        <location filename="../../Charts/LTMTool.cpp" line="156"/>
         <source>Add Current</source>
         <translation>Добавить график</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="146"/>
+        <location filename="../../Charts/LTMTool.cpp" line="147"/>
         <source>Charts</source>
         <translation>Графики</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="155"/>
         <source>Apply</source>
         <translation>Применить</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Up</source>
-        <translation>Поднять</translation>
+        <translation type="vanished">Поднять</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Down</source>
-        <translation>Опустить</translation>
+        <translation type="vanished">Опустить</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="289"/>
         <source>Curves</source>
         <translation>Показатели</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1128"/>
         <source>TriScore Long Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1169"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1143"/>
         <source>TriScore Short Term Stress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1184"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1158"/>
         <source>TriScore Stress Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1173"/>
         <source>TriScore STS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1214"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1188"/>
         <source>TriScore LTS Ramp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Details</source>
         <translation>Подробности</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1305"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1274"/>
         <source>Peak</source>
         <translation>Пик</translation>
     </message>
@@ -18422,31 +18413,23 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">Обновить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2590"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2602"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2591"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2603"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2596"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2608"/>
         <source>Add</source>
-        <translation>Добавить</translation>
+        <translation type="vanished">Добавить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2597"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2609"/>
         <source>Delete</source>
-        <translation>Удалить</translation>
+        <translation type="vanished">Удалить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2599"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2467"/>
         <source>Def</source>
         <translation>По умолчанию</translation>
     </message>
@@ -18455,14 +18438,14 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">Дата замера</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2651"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2790"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2494"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2631"/>
         <source>Lactate Threshold</source>
         <translation>Лактатный порог</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2652"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2791"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2495"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2632"/>
         <source>Aerobic Threshold</source>
         <translation>Аэробный порог</translation>
     </message>
@@ -18475,45 +18458,45 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">Достигнут предел в 10 зон.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2967"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2974"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2804"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2811"/>
         <source>New</source>
         <translation>Новое</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2969"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2976"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2806"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2813"/>
         <source>New (%1)</source>
         <translation>Новое (%1)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2653"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2496"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
         <source>Rest HR</source>
         <translation>ЧСС в покое</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2628"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2690"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2770"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2775"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2780"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2785"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2473"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2478"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2488"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2611"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2621"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2626"/>
         <source>bpm</source>
         <translation type="unfinished">уд/мин</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2650"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2493"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2630"/>
         <source>Start Date</source>
         <translation type="unfinished">Дата начала</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2654"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2497"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2634"/>
         <source>Max HR</source>
         <translation>Максимальная ЧСС</translation>
     </message>
@@ -18522,22 +18505,22 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">d MMM yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2701"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2544"/>
         <source>Short</source>
         <translation>Обозначение</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2702"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2545"/>
         <source>Long</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2703"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2546"/>
         <source>From BPM</source>
         <translation>От уд/мин</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2704"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2547"/>
         <source>Trimp k</source>
         <translation>Тренировочный импульс (TRIMP)</translation>
     </message>
@@ -19278,62 +19261,62 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>Library</name>
     <message>
+        <location filename="../../Train/Library.cpp" line="126"/>
         <location filename="../../Train/Library.cpp" line="130"/>
-        <location filename="../../Train/Library.cpp" line="134"/>
         <source>Import Videos, VideoSyncs and Workouts</source>
         <translation>Импортировать тренировки, видео и видеоролики VideoSyncs</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="127"/>
         <location filename="../../Train/Library.cpp" line="131"/>
-        <location filename="../../Train/Library.cpp" line="135"/>
         <source>No supported videos, videoSyncs or workouts were found to import</source>
         <translation>Не найдено поддерживаемых видео, видеороликов VideoSyncs  и тренировок для импорта</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="189"/>
         <location filename="../../Train/Library.cpp" line="193"/>
-        <location filename="../../Train/Library.cpp" line="197"/>
+        <location filename="../../Train/Library.cpp" line="198"/>
         <location filename="../../Train/Library.cpp" line="202"/>
-        <location filename="../../Train/Library.cpp" line="206"/>
         <source>Copy VideoSync Failed</source>
         <translation>Копирование видеоролика VideoSyncs не удалось</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="190"/>
         <location filename="../../Train/Library.cpp" line="194"/>
-        <location filename="../../Train/Library.cpp" line="198"/>
         <source>%1 already exists in videoSync library: %2</source>
         <translation>%1 уже находится в библиотеке видеороликов VideoSyncs: %2</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="203"/>
+        <location filename="../../Train/Library.cpp" line="199"/>
         <source>%1 cannot be written to videoSync library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="207"/>
+        <location filename="../../Train/Library.cpp" line="203"/>
         <source>%1 cannot be written to videoSync library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="253"/>
+        <location filename="../../Train/Library.cpp" line="249"/>
         <source>%1 cannot be written to workout library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="257"/>
+        <location filename="../../Train/Library.cpp" line="253"/>
         <source>%1 cannot be written to workout library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="239"/>
         <location filename="../../Train/Library.cpp" line="243"/>
-        <location filename="../../Train/Library.cpp" line="247"/>
+        <location filename="../../Train/Library.cpp" line="248"/>
         <location filename="../../Train/Library.cpp" line="252"/>
-        <location filename="../../Train/Library.cpp" line="256"/>
         <source>Copy Workout Failed</source>
         <translation>Не удалось скопировать план тренировки</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="240"/>
         <location filename="../../Train/Library.cpp" line="244"/>
-        <location filename="../../Train/Library.cpp" line="248"/>
         <source>%1 already exists in workout library: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19341,89 +19324,89 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LibrarySearchDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="330"/>
+        <location filename="../../Train/Library.cpp" line="326"/>
         <source>Search for Workouts, Syncs and Media</source>
         <translation type="unfinished">Сканировать и искать тренировки, видеоролики и VideoSync</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="337"/>
+        <location filename="../../Train/Library.cpp" line="333"/>
         <source>Workout files (.erg, .mrc, .zwo etc)</source>
         <translation>файлы тренировок (.erg, .mrc, .zwo etc)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="339"/>
+        <location filename="../../Train/Library.cpp" line="335"/>
         <source>Video files (.mp4, .avi etc)</source>
         <translation>Видеофайлы (.mp4, .avi и т.д.)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="341"/>
+        <location filename="../../Train/Library.cpp" line="337"/>
         <source>VideoSync files (.rlv, .tts etc)</source>
         <translation>файлы VideoSync (.rlv, .tts)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="359"/>
+        <location filename="../../Train/Library.cpp" line="353"/>
         <source>Search Path</source>
         <translation>Где искать</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="379"/>
+        <location filename="../../Train/Library.cpp" line="373"/>
         <source>Video references</source>
         <translation>Видеоролики</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="391"/>
+        <location filename="../../Train/Library.cpp" line="385"/>
         <source>Searching...</source>
         <translation>Выполняется поиск...</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="394"/>
+        <location filename="../../Train/Library.cpp" line="388"/>
         <source>Videos</source>
         <translation>Видео</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="396"/>
+        <location filename="../../Train/Library.cpp" line="390"/>
         <source>Workouts</source>
         <translation>Тренировки</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="398"/>
+        <location filename="../../Train/Library.cpp" line="392"/>
         <source>VideoSyncs</source>
         <translation>VideoSyncs</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="407"/>
-        <location filename="../../Train/Library.cpp" line="494"/>
+        <location filename="../../Train/Library.cpp" line="401"/>
+        <location filename="../../Train/Library.cpp" line="484"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="409"/>
+        <location filename="../../Train/Library.cpp" line="403"/>
         <source>Search</source>
         <translation>Найти</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="412"/>
+        <location filename="../../Train/Library.cpp" line="406"/>
         <source>Files to search for:</source>
         <translation>Какие файлы искать:</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="475"/>
+        <location filename="../../Train/Library.cpp" line="466"/>
         <source>Abort Search</source>
         <translation>Прервать поиск</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="515"/>
-        <location filename="../../Train/Library.cpp" line="559"/>
+        <location filename="../../Train/Library.cpp" line="504"/>
+        <location filename="../../Train/Library.cpp" line="548"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="557"/>
+        <location filename="../../Train/Library.cpp" line="546"/>
         <source>Search completed.</source>
         <translation>Поиск завершён.</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="645"/>
+        <location filename="../../Train/Library.cpp" line="634"/>
         <source>Select Directory</source>
         <translation>Выбрать каталог</translation>
     </message>
@@ -19431,12 +19414,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>ListEditWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="623"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="654"/>
         <source>New</source>
         <translation type="unfinished">Новое</translation>
     </message>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="625"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="656"/>
         <source>New (%1)</source>
         <translation type="unfinished">Новое (%1)</translation>
     </message>
@@ -19449,7 +19432,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="unfinished">Базовый URL OpenStreetMap</translation>
     </message>
     <message>
-        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="90"/>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="85"/>
+        <source>Initial Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="98"/>
         <source>Apply changes</source>
         <translation type="unfinished">Применить изменения</translation>
     </message>
@@ -19668,7 +19656,7 @@ on and that its display says, &quot;PC Link&quot;</source>
         <translation>Переключить боковую панель</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>Delete Activity</source>
         <translation>Удалить тренировку</translation>
     </message>
@@ -19734,70 +19722,70 @@ on and that its display says, &quot;PC Link&quot;</source>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Activity Import</source>
         <translation>Импорт тренировки</translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Closing of athlete window not possible while background activity import is in progress...</source>
         <translation>Невозможно закрыть аккаунт спортсмена, пока не будет завершён импорт...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Chart Import</source>
         <translation>Импорт графика</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1778"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1788"/>
         <source>Failed to export activity, please check permissions</source>
         <translation>Не удалось экспортировать тренировку, пожалуйста проверьте разрешения</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1814"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1824"/>
         <source>No Activity To Save</source>
         <translation>Нет тренировки для сохранения</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1815"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1825"/>
         <source>There is no currently selected activity to save.</source>
         <translation>Не выбрана тренировка для сохранения.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
         <location filename="../../Gui/MainWindow.cpp" line="1886"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Split Activity</source>
         <translation>Разделить тренировку</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
         <source>No activity selected</source>
         <translation>Тренировка не выбрана</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
         <source>Current activity contains no data to split</source>
         <translation>Данная тренировка не содержит данных, которые можно разделить</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Current activity contains no data to merge</source>
         <translation>Данная тренировка не содержит данных, которые можно объеденить</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1904"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1914"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation>Вы уверены, что хотите удалить эту тренировку:</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2400"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2421"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2410"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2431"/>
         <source>The workout directory is not configured, or the directory selected no longer exists.
 
 Please check your preference settings.</source>
@@ -19806,7 +19794,7 @@ Please check your preference settings.</source>
 Пожалуйста, проверьте настройки.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2611"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2621"/>
         <source>Loading activities: %1%</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19819,14 +19807,14 @@ Please check your preference settings.</source>
         <translation type="vanished">Управление исправлениями на Python...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>CloudDB</source>
         <translation>CloudDB</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>Current athlete is not registered as curator - please contact the GoldenCheetah team</source>
         <translation>Текущий спортсмен не зарегистрирован как куратор, свяжитесь с командой GoldenCheetah</translation>
     </message>
@@ -19911,7 +19899,7 @@ Please check your preference settings.</source>
         <translation>Продолжить?</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2165"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2175"/>
         <source>&amp;New Athlete...</source>
         <translation>&amp;Добавить спортсмена...</translation>
     </message>
@@ -19926,23 +19914,23 @@ Please check your preference settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
         <source>Select Activity</source>
         <translation>Выбрать тренировку</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>No activity selected!</source>
         <translation>Тренировка не выбрана!</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1724"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1734"/>
         <source>Export Activity</source>
         <translation>Экспортировать тренировку</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1777"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1787"/>
         <source>Export Failed</source>
         <translation>Не удалось выполнить экспорт</translation>
     </message>
@@ -20304,59 +20292,59 @@ Please check your preference settings.</source>
         <translation>Импорт представления</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Imported %1 metric charts</source>
         <translation>Импортировано графиков: %1</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>Import Images Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>You can only import images on the activities view with an activity selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>Import Images to Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>%1 images imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1799"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2369"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1809"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2379"/>
         <source>Import from File</source>
         <translation>Импорт из файла</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2342"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2352"/>
         <source>Refresh in Progress</source>
         <translation>Выполняется обновление</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Export Metrics</source>
         <translation>Экспортировать показатели</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation>Тестовый файл с разделителем (*.csv)</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2399"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2420"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2409"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2430"/>
         <source>Workout Directory Invalid</source>
         <translation>Директория для тренировок не правильная</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1906"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1916"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
@@ -21268,23 +21256,23 @@ Please check your preference settings.</source>
         <translation type="vanished">Измерения %1, зависящие от времени</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="656"/>
+        <location filename="../../Gui/AthletePages.cpp" line="641"/>
         <source>From Date - Time</source>
         <translation>Дата и время измерения</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="780"/>
+        <location filename="../../Gui/AthletePages.cpp" line="751"/>
         <source>Start Date</source>
         <translation type="unfinished">Дата начала</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="893"/>
+        <location filename="../../Gui/AthletePages.cpp" line="864"/>
         <source>MMM d, yyyy - hh:mm:ss</source>
         <translation>dd.MM.yyyy hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="659"/>
-        <location filename="../../Gui/AthletePages.cpp" line="807"/>
+        <location filename="../../Gui/AthletePages.cpp" line="644"/>
+        <location filename="../../Gui/AthletePages.cpp" line="778"/>
         <source>Comment</source>
         <translation>Комментарий</translation>
     </message>
@@ -21293,32 +21281,28 @@ Please check your preference settings.</source>
         <translation type="vanished">Обновить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="662"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="663"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">Добавить</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">Удалить</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="668"/>
-        <source>Add</source>
-        <translation>Добавить</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="669"/>
-        <source>Delete</source>
-        <translation>Удалить</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="698"/>
         <source>Source</source>
         <translation>Источник</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="699"/>
+        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Original Source</source>
         <translation>Оригинальный источник</translation>
     </message>
@@ -22020,17 +22004,17 @@ No rides found to import.
 <context>
     <name>MultiDeviceDialog</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3048"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3060"/>
         <source>Multiple Device Configuration</source>
         <translation>Настройка нескольких устройств</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3103"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3115"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3106"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3118"/>
         <source>Apply</source>
         <translation>Применить</translation>
     </message>
@@ -23047,42 +23031,38 @@ No rides found to import.
 <context>
     <name>PaceSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3154"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3155"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3160"/>
         <source>Add</source>
-        <translation>Добавить</translation>
+        <translation type="vanished">Добавить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3161"/>
         <source>Delete</source>
-        <translation>Удалить</translation>
+        <translation type="vanished">Удалить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3176"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2987"/>
         <source>Short</source>
         <translation>Обозначение</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3177"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2988"/>
         <source>Long</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3178"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2989"/>
         <source>Percent of CV</source>
         <translation>Процент от критической скорости</translation>
     </message>
@@ -23091,14 +23071,14 @@ No rides found to import.
         <translation type="vanished">Достигнут предел в 10 зон.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3220"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3227"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3037"/>
         <source>New</source>
         <translation>Новое</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3222"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3229"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3032"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3039"/>
         <source>New (%1)</source>
         <translation>Новое (%1)</translation>
     </message>
@@ -23298,27 +23278,27 @@ No rides found to import.
 <context>
     <name>PaceZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3082"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2905"/>
         <source>Sport</source>
         <translation>Вид спорта</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3084"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2907"/>
         <source>Run</source>
         <translation>Бег</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3085"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2908"/>
         <source>Swim</source>
         <translation>Плавание</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3126"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2949"/>
         <source>Critical Velocity</source>
         <translation>Критический темп</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2950"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
@@ -25463,78 +25443,79 @@ Do you want to continue?</source>
 <context>
     <name>PerspectiveDialog</name>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="34"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="35"/>
         <source>Manage Perspectives</source>
         <translation>Управление представлениями</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="43"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="44"/>
         <source>Perspectives</source>
         <translation>Представления отображения</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="60"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="61"/>
         <source>Charts</source>
         <translation>Графики</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Edit</source>
-        <translation>Правка</translation>
+        <translation type="vanished">Правка</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="83"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="78"/>
         <source>Import</source>
         <translation>Импорт</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="84"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="77"/>
         <source>Export</source>
         <translation>Экспорт</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="90"/>
         <source>Add</source>
-        <translation>Добавить</translation>
+        <translation type="vanished">Добавить</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="91"/>
         <source>Delete</source>
-        <translation>Удалить</translation>
+        <translation type="vanished">Удалить</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="98"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Drag charts to move to a perspective</source>
         <translation>Перетащие графики в представление</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="287"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="256"/>
         <source>Export Persepctive</source>
         <translation>Экспортировать представление</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
         <source>Export Perspective</source>
         <translation>Экспортировать представление</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>No perspective file selected!</source>
         <translation>Не выбран файл представления!</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
         <source>Select Perspective file to export</source>
-        <translation>Выбрать файл для экспорта представления отображения</translation>
+        <translation type="vanished">Выбрать файл для экспорта представления отображения</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
         <source>GoldenCheetah Perspective Files (*.gchartset)</source>
         <translation>Файлы представлений GoldenCheetah (*.gchartset)</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
+        <source>Select Perspective file to import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>Import Perspective</source>
         <translation>Импорт представления</translation>
     </message>
@@ -26697,309 +26678,309 @@ Python disabled in preferences.</source>
 <context>
     <name>RealtimeData</name>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="621"/>
+        <location filename="../../Train/RealtimeData.cpp" line="623"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="624"/>
+        <location filename="../../Train/RealtimeData.cpp" line="626"/>
         <source>Time</source>
         <translation>Время</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="627"/>
+        <location filename="../../Train/RealtimeData.cpp" line="629"/>
         <source>Lap</source>
         <translation>Круг</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="630"/>
+        <location filename="../../Train/RealtimeData.cpp" line="632"/>
         <source>Lap Time</source>
         <translation>Время круга</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="633"/>
+        <location filename="../../Train/RealtimeData.cpp" line="635"/>
         <source>Lap Time Remaining</source>
         <translation>Оставшееся время круга</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="636"/>
+        <location filename="../../Train/RealtimeData.cpp" line="638"/>
         <source>Section Time Remaining</source>
         <translation>Оставшееся время отрезка</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="639"/>
+        <location filename="../../Train/RealtimeData.cpp" line="641"/>
         <source>BikeStress</source>
         <translation>BikeStress</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="645"/>
+        <location filename="../../Train/RealtimeData.cpp" line="647"/>
         <source>kJoules</source>
         <translation>кДж</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="648"/>
+        <location filename="../../Train/RealtimeData.cpp" line="650"/>
         <source>W&apos; bal</source>
         <translation>W&apos; bal</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="651"/>
+        <location filename="../../Train/RealtimeData.cpp" line="653"/>
         <source>XPower</source>
         <translation>XPower</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="654"/>
+        <location filename="../../Train/RealtimeData.cpp" line="656"/>
         <source>Iso Power</source>
         <translation>Нормализованная мощность</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="657"/>
+        <location filename="../../Train/RealtimeData.cpp" line="659"/>
         <source>Intensity Factor</source>
         <translation>Фактор интенсивности</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="660"/>
+        <location filename="../../Train/RealtimeData.cpp" line="662"/>
         <source>Relative Intensity</source>
         <translation>Относительная интенсивность</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="663"/>
+        <location filename="../../Train/RealtimeData.cpp" line="665"/>
         <source>Skiba Variability Index</source>
         <translation>Индекс вариабельности по Скиба</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="666"/>
+        <location filename="../../Train/RealtimeData.cpp" line="668"/>
         <source>Variability Index</source>
         <translation>Индекс вариабельности</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="669"/>
+        <location filename="../../Train/RealtimeData.cpp" line="671"/>
         <source>Distance</source>
         <translation>Дистанция</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="672"/>
+        <location filename="../../Train/RealtimeData.cpp" line="674"/>
         <source>Route Distance</source>
         <translation type="unfinished">Дистанция маршрута</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="675"/>
+        <location filename="../../Train/RealtimeData.cpp" line="677"/>
         <source>Distance Remaining</source>
         <translation type="unfinished">Оставшаяся дистанция</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="678"/>
+        <location filename="../../Train/RealtimeData.cpp" line="680"/>
         <source>Alternate Power</source>
         <translation>Альтернативная мощность</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="681"/>
+        <location filename="../../Train/RealtimeData.cpp" line="683"/>
         <source>Power</source>
         <translation>Мощность</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="684"/>
+        <location filename="../../Train/RealtimeData.cpp" line="686"/>
         <source>Speed</source>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="687"/>
+        <location filename="../../Train/RealtimeData.cpp" line="689"/>
         <source>Virtual Speed</source>
         <translation>Виртуальная скорость</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="690"/>
+        <location filename="../../Train/RealtimeData.cpp" line="692"/>
         <source>Cadence</source>
         <translation>Каденс</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="693"/>
+        <location filename="../../Train/RealtimeData.cpp" line="695"/>
         <source>Heart Rate</source>
         <translation>ЧСС</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="696"/>
+        <location filename="../../Train/RealtimeData.cpp" line="698"/>
         <source>Target Power</source>
         <translation>Целевая мощность</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="699"/>
+        <location filename="../../Train/RealtimeData.cpp" line="701"/>
         <source>Average Power</source>
         <translation>Средняя мощность</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="702"/>
+        <location filename="../../Train/RealtimeData.cpp" line="704"/>
         <source>Average Speed</source>
         <translation>Средняя скорость</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="705"/>
+        <location filename="../../Train/RealtimeData.cpp" line="707"/>
         <source>Average Heartrate</source>
         <translation>Средняя ЧСС</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="708"/>
+        <location filename="../../Train/RealtimeData.cpp" line="710"/>
         <source>Average Cadence</source>
         <translation>Средний каденс</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="711"/>
+        <location filename="../../Train/RealtimeData.cpp" line="713"/>
         <source>Lap Power</source>
         <translation>Мощность на круг</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="714"/>
+        <location filename="../../Train/RealtimeData.cpp" line="716"/>
         <source>Lap Speed</source>
         <translation>Скорость на круг</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="717"/>
+        <location filename="../../Train/RealtimeData.cpp" line="719"/>
         <source>Lap Heartrate</source>
         <translation>ЧСС на круг</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="720"/>
+        <location filename="../../Train/RealtimeData.cpp" line="722"/>
         <source>Lap Cadence</source>
         <translation>Каденс на круг</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="723"/>
+        <location filename="../../Train/RealtimeData.cpp" line="725"/>
         <source>Left/Right Balance</source>
         <translation>Левый/правый баланс</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="726"/>
+        <location filename="../../Train/RealtimeData.cpp" line="728"/>
         <source>Total Hb Mass</source>
         <translation>Общая масса ГГ</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="729"/>
+        <location filename="../../Train/RealtimeData.cpp" line="731"/>
         <source>Hb O2 Saturation</source>
         <translation>Насыщение Hb O2</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="732"/>
+        <location filename="../../Train/RealtimeData.cpp" line="734"/>
         <source>Deoxy Hb</source>
         <translation>Неокисл. ГГ</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="735"/>
+        <location filename="../../Train/RealtimeData.cpp" line="737"/>
         <source>Oxy Hb</source>
         <translation>Окисл. ГГ</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="738"/>
+        <location filename="../../Train/RealtimeData.cpp" line="740"/>
         <source>Left Torque Effectiveness</source>
         <translation>Эффективность крутящего момента слева</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="741"/>
+        <location filename="../../Train/RealtimeData.cpp" line="743"/>
         <source>Right Torque Effectiveness</source>
         <translation>Эффективность крутящего момента справа</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="744"/>
+        <location filename="../../Train/RealtimeData.cpp" line="746"/>
         <source>Left Pedal Smoothness</source>
         <translation>Плавность педалирования левой</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="747"/>
+        <location filename="../../Train/RealtimeData.cpp" line="749"/>
         <source>Right Pedal Smoothness</source>
         <translation>Плавность педалирования правой</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="750"/>
+        <location filename="../../Train/RealtimeData.cpp" line="752"/>
         <source>Right Power Phase Start</source>
         <translation type="unfinished">Начало фазы мощности справа</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="753"/>
+        <location filename="../../Train/RealtimeData.cpp" line="755"/>
         <source>Right Power Phase End</source>
         <translation type="unfinished">Конец фазы мощности справа</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="756"/>
+        <location filename="../../Train/RealtimeData.cpp" line="758"/>
         <source>Right Power Phase Peak Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="759"/>
+        <location filename="../../Train/RealtimeData.cpp" line="761"/>
         <source>Right Power Phase Peak End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="762"/>
+        <location filename="../../Train/RealtimeData.cpp" line="764"/>
         <source>Slope</source>
         <translation>Наклон</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="765"/>
+        <location filename="../../Train/RealtimeData.cpp" line="767"/>
         <source>Lap Distance</source>
         <translation>Дистанция круга</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="768"/>
+        <location filename="../../Train/RealtimeData.cpp" line="770"/>
         <source>Lap Distance Remaining</source>
         <translation>Оставшаяся дистанция круга</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="771"/>
+        <location filename="../../Train/RealtimeData.cpp" line="773"/>
         <source>Latitude</source>
         <translation>Широта</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="774"/>
+        <location filename="../../Train/RealtimeData.cpp" line="776"/>
         <source>Longitude</source>
         <translation>Долгота</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="777"/>
+        <location filename="../../Train/RealtimeData.cpp" line="779"/>
         <source>Altitude</source>
         <translation>Высота</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="780"/>
+        <location filename="../../Train/RealtimeData.cpp" line="782"/>
         <source>Respiratory Frequency</source>
         <translation>Частота дыхания</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="783"/>
+        <location filename="../../Train/RealtimeData.cpp" line="785"/>
         <source>Ventilation</source>
         <translation>Вентиляция</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="786"/>
+        <location filename="../../Train/RealtimeData.cpp" line="788"/>
         <source>VO2</source>
         <translation>VO₂</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="789"/>
+        <location filename="../../Train/RealtimeData.cpp" line="791"/>
         <source>VCO2</source>
         <translation>VCO₂</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="792"/>
+        <location filename="../../Train/RealtimeData.cpp" line="794"/>
         <source>Respiratory Exchange Ratio</source>
         <translatorcomment>RER = VCO₂ / VO₂</translatorcomment>
         <translation>Коэффициент дыхательного обмена (RER)</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="795"/>
+        <location filename="../../Train/RealtimeData.cpp" line="797"/>
         <source>Tidal Volume</source>
         <translation>Дыхательный объем</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="798"/>
+        <location filename="../../Train/RealtimeData.cpp" line="800"/>
         <source>Fraction O2 Expired</source>
         <translatorcomment>Fraction Expired O₂ (FEO₂), Fraction Inspired O₂ (FIO₂)</translatorcomment>
         <translation>Фракция выдыхаемого O₂ (FEO₂)</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="801"/>
+        <location filename="../../Train/RealtimeData.cpp" line="803"/>
         <source>Temperature</source>
         <translation type="unfinished">Температура</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="804"/>
+        <location filename="../../Train/RealtimeData.cpp" line="806"/>
         <source>CoreTemp</source>
         <translation type="unfinished"></translation>
     </message>
@@ -27095,22 +27076,22 @@ Python disabled in preferences.</source>
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Series</source>
         <translation>Серия</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="172"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
         <source>Power</source>
         <translation>Мощность</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="176"/>
         <source>Heart Rate</source>
         <translation>ЧСС</translation>
     </message>
@@ -29410,317 +29391,317 @@ native format. Should we do so?
 <context>
     <name>ScatterPlot</name>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="113"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
         <source>Power (watts)</source>
         <translation>Мощность (Вт)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
         <source>Cadence (rpm)</source>
         <translation>Каденс (об/мин)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="116"/>
         <source>Heartrate (bpm)</source>
         <translation>ЧСС (уд/мин)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="118"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="119"/>
         <source>Speed (kph)</source>
         <translation>Скорость (км/ч)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="120"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="121"/>
         <source>Speed (mph)</source>
         <translation>Скорость (миль/ч)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="124"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="125"/>
         <source>Altitude (meters)</source>
         <translation>Высота (метры)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="126"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="127"/>
         <source>Altitude (feet)</source>
         <translation>Высота (футы)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="128"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
         <source>Torque (N)</source>
         <translation>Крутящий момент (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="130"/>
         <source>Elapsed Time (secs)</source>
         <translation>Прошло времени (с)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="132"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="133"/>
         <source>Elapsed Distance (km)</source>
         <translation>Пройденная дистанция (км)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="134"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="135"/>
         <source>Elapsed Distance (mi)</source>
         <translation>Пройденная дистанция (миль)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="136"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
         <source>Interval Number</source>
         <translation>Номер интервала</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
         <source>Latitude (degree offset)</source>
         <translation>Широта (смещение градуса)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
         <source>Longitude (degree offset)</source>
         <translation>Долгота (смещение градуса)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
         <source>Circumferential Pedal Velocity (m/s)</source>
         <translation>Периферическая скорость педалирования (м/с)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="141"/>
         <source>Average Effective Pedal Force (N)</source>
         <translation>Средняя эффективная сила педалирования (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="144"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
         <source>Time at X/Y (%)</source>
         <translation>Время в X/Y (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
         <source>Power Zone</source>
         <translation>Зона мощности</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
         <source>Headwind (kph)</source>
         <translation>Встречный ветер (км/ч)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
         <source>Slope (gradient)</source>
         <translation>Наклон (градиент)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
         <source>Temperature (C)</source>
         <translation>Температура (°С)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
         <source>L/R Balance</source>
         <translation>Баланс Л/П</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
         <source>Torque Efficiency</source>
         <translation>Эффективность крутящего момента</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
         <source>Pedal Smoothness</source>
         <translation>Плавность педалирования</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
         <source>Running Vertical Oscillation</source>
         <translation>Вертикальное колебание (бег)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
         <source>Running Ground Contact Time</source>
         <translation>Время контакта с землёй (бег)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
         <source>Running Cadence</source>
         <translation>Каденс (бег)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
         <source>Gear Ratio</source>
         <translation>Передаточное отношение</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
         <source>Muscle Oxygen</source>
         <translation>Кислород в мышцах</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
         <source>Haemoglobin Mass</source>
         <translation>Масса гемоглобина</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
         <source>Deoxygenated Haemoglobin</source>
         <translation>Неокисленный гемоглобин</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="160"/>
         <source>Oxygenated Haemoglobin</source>
         <translation>Окисленный гемоглобин</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="161"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="162"/>
         <source>Unknown</source>
         <translation>Неизвестно</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="165"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
         <source>Power</source>
         <translation>Мощность</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
         <source>Cadence</source>
         <translation>Каденс</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
         <source>Heartrate</source>
         <translation>ЧСС</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
         <source>Speed</source>
         <translation>Скорость</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
         <source>Altitude</source>
         <translation>Высота</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
         <source>Pedal Force</source>
         <translation>Сила педалирования</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
         <source>Time</source>
         <translation>Время</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
         <source>Distance</source>
         <translation>Дистанция</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
         <source>Interval</source>
         <translation>Интервал</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
         <source>Latitude</source>
         <translation>Широта</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
         <source>Longitude</source>
         <translation>Долгота</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
         <source>Time at X/Y</source>
         <translation>Время в X/Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
         <source>Zone</source>
         <translation>Зона</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
         <source>CPV</source>
         <translation>CPV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
         <source>AEPF</source>
         <translation>AEPF</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
         <source>Headwind</source>
         <translation>Встречный ветер</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
         <source>Slope</source>
         <translation>Наклон</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
         <source>Temp</source>
         <translation>Темп.</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
         <source>Balance</source>
         <translation>Баланс</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
         <source>TE</source>
         <translation>TE</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
         <source>PS</source>
         <translation>PS</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
         <source>RV</source>
         <translation>RV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
         <source>GCT</source>
         <translation>GCT</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
         <source>Run Cad</source>
         <translation>Кад. бега</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
         <source>Gear</source>
         <translation>Передача</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
         <source>SmO2</source>
         <translation>SmO₂</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
         <source>O2Hb</source>
         <translation>O₂Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="194"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="195"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="196"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
@@ -29958,42 +29939,38 @@ native format. Should we do so?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1012"/>
         <source>Add</source>
-        <translation>Добавить</translation>
+        <translation type="vanished">Добавить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1013"/>
         <source>Delete</source>
-        <translation>Удалить</translation>
+        <translation type="vanished">Удалить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1006"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1007"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1023"/>
+        <location filename="../../Gui/AthletePages.cpp" line="982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="988"/>
         <source>Short</source>
         <translation>Обозначение</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="989"/>
         <source>Long</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1031"/>
+        <location filename="../../Gui/AthletePages.cpp" line="990"/>
         <source>Percent of CP</source>
         <translation>Процент от CP</translation>
     </message>
@@ -30002,14 +29979,14 @@ native format. Should we do so?
         <translation type="vanished">Достигнут предел в 10 зон.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1069"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1076"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1034"/>
         <source>New</source>
         <translation>Новое</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1071"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1078"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1036"/>
         <source>New (%1)</source>
         <translation>Новое (%1)</translation>
     </message>
@@ -30182,64 +30159,64 @@ native format. Should we do so?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3821"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3569"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3822"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3570"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3823"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3571"/>
         <source>Up</source>
         <translation>Поднять</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3824"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3572"/>
         <source>Down</source>
         <translation>Опустить</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3870"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3872"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3963"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3965"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3711"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3713"/>
         <source>ddd MMM d, yyyy</source>
         <translation>d MMM yyyy, ddd</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3557"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3810"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3558"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3804"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3835"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3583"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3805"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3836"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3553"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3584"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3806"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3837"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3554"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3585"/>
         <source>From</source>
         <translation>От</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3807"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3838"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3555"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3586"/>
         <source>To</source>
         <translation>До</translation>
     </message>
@@ -32652,25 +32629,25 @@ tab.</source>
 <context>
     <name>TrainSidebar</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="253"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="257"/>
         <source>Save workout data</source>
         <translation>Сохранить данные тренировки</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="259"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="263"/>
         <source>Devices</source>
         <translation>Устройства</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="262"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="267"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="311"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="321"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="271"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="315"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="325"/>
         <source>Menu</source>
         <translation>Меню</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="270"/>
         <source>Workouts</source>
         <translation>Тренировки</translation>
     </message>
@@ -32679,178 +32656,178 @@ tab.</source>
         <translation type="obsolete">Фильтр...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="303"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="307"/>
         <source>Workout Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="310"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="314"/>
         <source>Media</source>
         <translation>Медиафайлы</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="320"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="324"/>
         <source>VideoSync</source>
         <translation>ролики VideoSync</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="506"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
         <source>Import Workout from File</source>
         <translation>Импортировать тренировку из файла</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="507"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="511"/>
         <source>Get Workouts from TrainerDay</source>
         <translation>Скачать тренировки из TrainerDay</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="509"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="513"/>
         <source>Create Workout via Wizard</source>
         <translation>Создать тренировку используя мастер</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="514"/>
         <source>Scan for Workouts</source>
         <translation>Сканировать и искать тренировки локально</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="534"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="538"/>
         <source>Delete selected Workout</source>
         <translation>Удалить выбранную тренировку</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="541"/>
         <source>Delete %1 selected Workouts</source>
         <translation>Удалить выбранные тренировки (%1)</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Train mode active</source>
         <translation>Режим тренировки активен</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Please stop the train mode before closing the window or application.</source>
         <translation>Пожалуйста остановите тренировку перед тем как закрыть приложение.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="635"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="639"/>
         <source>Remove reference to selected video</source>
         <translation>Удалить ссылку на выбранное видео</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="650"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="654"/>
         <source>Import VideoSync from File</source>
         <translation>Импорт VideoSync из файла</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="651"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="655"/>
         <source>Scan for VideoSyncs</source>
         <translation>Сканировать и искать VideoSync</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="668"/>
         <source>Delete selected VideoSync</source>
         <translation>Удалить выбранный VideoSync</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1064"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1068"/>
         <source>Are you sure you want to remove the reference to this video?</source>
         <translation>Вы действительно хотите удалить ссылку на это видео?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1066"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1128"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1204"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1070"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1132"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1208"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1099"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1103"/>
         <source>Are you sure you want to delete this VideoSync?</source>
         <translation>Вы действительно хотите удалить этот VideoSync?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1126"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1130"/>
         <source>The VideoSync file is either not valid or not existing and will be removed from the library.</source>
         <translation>Файл VideoSync отсутствует или повреждён и будет удалён только из списка библиотеки.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1160"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1164"/>
         <source>Are you sure you want to delete this Workout?</source>
         <translation>Вы действительно хотите удалить эту тренировку?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1163"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1167"/>
         <source>Are you sure you want to delete this %1 workouts?</source>
         <translation>Вы действительно хотите удалить эти тренировки (%1)?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1202"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1206"/>
         <source>The Workout file is either not valid or not existing and will be removed from the library.</source>
         <translation>Файл тренировки отсутствует или повреждён и будет удалён только из списка библиотеки.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1309"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1313"/>
         <source>Resuming..</source>
         <translation>Продолжение..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1336"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1340"/>
         <source>Paused..</source>
         <translation>Пауза..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1347"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1351"/>
         <source>Starting in %1</source>
         <translation>Старт через %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1465"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1469"/>
         <source>Starting..</source>
         <translation>Запуск..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1673"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1677"/>
         <source>Stopped..</source>
         <translation>Остановлен..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1763"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1769"/>
         <source>Connected..</source>
         <translation>Подключен..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1787"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1793"/>
         <source>Disconnected..</source>
         <translation>Отключен..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2198"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2210"/>
         <source>New lap..</source>
         <translation>Новый круг..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2225"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2237"/>
         <source>Recalibrating steering..</source>
         <translation>Перекалибровка рулевого управления..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2521"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2525"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2594"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2645"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2649"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2533"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2606"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2657"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2661"/>
         <source>Requesting calibration..</source>
         <translation>Запрос калибровки..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2532"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2544"/>
         <source>Calibrating...</source>
         <translation>Калибровка...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2536"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2548"/>
         <source>Calibrating...
 Current speed %1 kph
 Increase speed to %2 kph</source>
@@ -32859,14 +32836,14 @@ Increase speed to %2 kph</source>
 Увеличьте скорость до %2 км/ч</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2540"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2552"/>
         <source>Calibrating...
 Stop pedalling until speed drops to 0</source>
         <translation>Калибровка...
 Прекратите крутить педали, пока скорость не упадёт до нуля</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2545"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2557"/>
         <source>Calibration completed successfully!
 Spindown %1 ms
 Zero Offset %2</source>
@@ -32875,30 +32852,30 @@ Zero Offset %2</source>
 Смещение нуля: %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2553"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2620"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2672"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2565"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2632"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2684"/>
         <source>Calibration failed!</source>
         <translation>Калибровка завершилась с ошибкой!</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2573"/>
         <source>Calibration Failed: Loosen Roller</source>
         <translation>Ошибка калибровки: ослабьте ролик</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2569"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2581"/>
         <source>Calibration Failed: Tighten Roller</source>
         <translation>Ошибка калибровки: затяните ролик</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2588"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2639"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2600"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2651"/>
         <source>Unclip or stop pedalling to begin calibration..</source>
         <translation>Остановите вращение педалей и отстегните педали для калибровки..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2607"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2619"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Torque %1</source>
@@ -32907,7 +32884,7 @@ Torque %1</source>
 Крутящий момент: %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2612"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2624"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Torque %2</source>
@@ -32916,7 +32893,7 @@ Torque %2</source>
 Крутящий момент: %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2659"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2671"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Zero Offset %1</source>
@@ -32925,7 +32902,7 @@ Zero Offset %1</source>
 Смещение нуля: %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2676"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Slope %2</source>
@@ -32934,140 +32911,140 @@ Slope %2</source>
 Наклон: %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2693"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2705"/>
         <source>Give the pedal a kick to start calibration...
 The motor will run until calibration is complete.</source>
         <translation>Нажмите на педаль, чтобы начать калибровку...
 Двигатель будет работать до завершения калибровки.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2695"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
         <source>Allow wheel speed to settle, DO NOT PEDAL...
 The motor will run until calibration is complete.</source>
         <translation>Позвольте скорости вращения колеса установиться, НЕ КРУТИТЕ ПЕДАЛИ...
 Двигатель будет работать до завершения калибровки.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2700"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2712"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Gathering enough samples to calculate average: %1</source>
         <translation>Калибровка... НЕ КРУТИ ПЕДАЛИ, оставайтесь на месте...
 Сбор достаточного количества измерений для расчета среднего значения:%1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2719"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Waiting for value to stabilize (max %1s): %2 (%3W @ %4kph)</source>
         <translation>Калибровка... НЕ КРУТИ ПЕДАЛИ, оставайтесь на месте...
 Ожидание стабилизации значения (макс %1 с): %2 (%3 Вт @ %4 км/ч)</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2722"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
         <source>Calibration completed successfully!
 Final calibration value %1 (%2W @ %3kph)</source>
         <translation>Калибровка успешно завершена!
 Итоговое значение калибровки %1 (%2 Вт @ %3 км/ч)</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2746"/>
         <source>Calibration failed! Do not pedal while calibration is taking place.
 Allow wheel to run freely.</source>
         <translation>Ошибка калибровки! Не нажимайте на педали во время калибровки.
 Позвольте колесу свободно вращаться.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2780"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2792"/>
         <source>Fast forward..</source>
         <translation>Перемотка вперёд..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2813"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2825"/>
         <source>Rewind..</source>
         <translation>Перемотка назад..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2843"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2855"/>
         <source>Next Lap..</source>
         <translation>Следующий круг..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2876"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2888"/>
         <source>Back Lap..</source>
         <translation>Предыдущий круг..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2902"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2914"/>
         <source>Increasing intensity..</source>
         <translation>Увеличить нагрузку..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2928"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2940"/>
         <source>Decreasing intensity..</source>
         <translation>Уменьшить нагрузку..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="621"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="625"/>
         <source>Import Video from File</source>
         <translation>Импорт видео из файла</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="508"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="512"/>
         <source>Get Workouts from Strava Routes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="622"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="626"/>
         <source>Scan for Videos</source>
         <translation>Сканировать и искать видео локально</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1101"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1173"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3183"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1105"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1177"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3195"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>No Devices Configured</source>
         <translation>Нет настроенных устройств</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>Please configure a device in Preferences.</source>
         <translation>Пожалуйста настройте устройства в Параметрах.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2483"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2495"/>
         <source>Exiting calibration..</source>
         <translation>Выход из калибровки..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2498"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2510"/>
         <source>Calibration not supported for this device.</source>
         <translation>Калибровка не поддерживается для этого устройства.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2505"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2517"/>
         <source>Calibrating...
 Press F3 on Controller when done.</source>
         <translation>Выполняется калибровка...
 После завершения нажмите F3 на контроллере.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3135"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3153"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3147"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3165"/>
         <source>Add Device</source>
         <translation>Добавить устройство</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3140"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3158"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3152"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3170"/>
         <source>Delete Device</source>
         <translation>Удалить устройство</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3181"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3193"/>
         <source>Are you sure you want to delete this device?</source>
         <translation>Вы действительно хотите удалить это устройство?</translation>
     </message>
@@ -33384,7 +33361,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>UniqueLabelEditDelegate</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="77"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="108"/>
         <source>The given value &quot;%1&quot; is not unique</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33400,171 +33377,167 @@ Press F3 on Controller when done.</source>
 <context>
     <name>UserChartSettings</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="772"/>
+        <location filename="../../Charts/UserChart.cpp" line="773"/>
         <source>Chart</source>
         <translation>График</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="782"/>
+        <location filename="../../Charts/UserChart.cpp" line="783"/>
         <source>Sub-title</source>
         <translation>Подзаголовок</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="785"/>
+        <location filename="../../Charts/UserChart.cpp" line="786"/>
         <source>Description</source>
         <translation>Описание</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="791"/>
+        <location filename="../../Charts/UserChart.cpp" line="792"/>
         <source>Line Chart</source>
         <translation>Линейный график</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="792"/>
+        <location filename="../../Charts/UserChart.cpp" line="793"/>
         <source>Scatter Chart</source>
         <translation>Диаграмма разброса</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="793"/>
+        <location filename="../../Charts/UserChart.cpp" line="794"/>
         <source>Bar Chart</source>
         <translation>Столбчатая диаграмма</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="794"/>
+        <location filename="../../Charts/UserChart.cpp" line="795"/>
         <source>Stacked Bar Chart</source>
         <translation>Столбчатая диаграмма</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="795"/>
+        <location filename="../../Charts/UserChart.cpp" line="796"/>
         <source>Stacked Percent Chart</source>
         <translation>Столбчатая диаграмма в процентах</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="796"/>
+        <location filename="../../Charts/UserChart.cpp" line="797"/>
         <source>Pie Chart</source>
         <translation>Круговая диаграмма</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="800"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="801"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="804"/>
+        <location filename="../../Charts/UserChart.cpp" line="805"/>
         <source>Vertical</source>
         <translation>Вертикально</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="805"/>
+        <location filename="../../Charts/UserChart.cpp" line="806"/>
         <source>Horizontal</source>
         <translation>Горизонтально</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="808"/>
+        <location filename="../../Charts/UserChart.cpp" line="809"/>
         <source>Layout</source>
         <translation>Ориентация</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="812"/>
+        <location filename="../../Charts/UserChart.cpp" line="813"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="813"/>
+        <location filename="../../Charts/UserChart.cpp" line="814"/>
         <source>Top</source>
         <translation>Вверху</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="814"/>
+        <location filename="../../Charts/UserChart.cpp" line="815"/>
         <source>Left</source>
         <translation>Слева</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="815"/>
+        <location filename="../../Charts/UserChart.cpp" line="816"/>
         <source>Right</source>
         <translation>Справа</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="816"/>
+        <location filename="../../Charts/UserChart.cpp" line="817"/>
         <source>Bottom</source>
         <translation>Снизу</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="820"/>
+        <location filename="../../Charts/UserChart.cpp" line="821"/>
         <source>Legend</source>
         <translation>Легенда</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="829"/>
+        <location filename="../../Charts/UserChart.cpp" line="830"/>
         <source>Font scaling</source>
         <translation>Масштаб текста</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="831"/>
-        <location filename="../../Charts/UserChart.cpp" line="833"/>
+        <location filename="../../Charts/UserChart.cpp" line="832"/>
+        <location filename="../../Charts/UserChart.cpp" line="834"/>
         <source>Background</source>
         <translation>Фон</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="836"/>
+        <location filename="../../Charts/UserChart.cpp" line="837"/>
         <source>Animate</source>
         <translation>Анимация</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="838"/>
+        <location filename="../../Charts/UserChart.cpp" line="839"/>
         <source>Single series per plot</source>
         <translation>По одной серии на график</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="841"/>
+        <location filename="../../Charts/UserChart.cpp" line="842"/>
         <source>Refresh for intervals</source>
         <translation>Обновлять для интервалов</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="848"/>
+        <location filename="../../Charts/UserChart.cpp" line="849"/>
         <source>Series</source>
         <translation>Серия</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Group</source>
         <translation>Группа</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Y Formula</source>
         <translation>Формула значений Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="870"/>
-        <location filename="../../Charts/UserChart.cpp" line="932"/>
         <source>Edit</source>
-        <translation>Изменить</translation>
+        <translation type="vanished">Изменить</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="889"/>
         <source>Up</source>
-        <translation>Поднять</translation>
+        <translation type="vanished">Поднять</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="890"/>
         <source>Down</source>
-        <translation>Опустить</translation>
+        <translation type="vanished">Опустить</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="911"/>
+        <location filename="../../Charts/UserChart.cpp" line="885"/>
         <source>Axes</source>
         <translation>Оси</translation>
     </message>
@@ -34230,72 +34203,72 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VideoWindow</name>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> kph</source>
         <translation> км/ч</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="119"/>
+        <location filename="../../Train/VideoWindow.cpp" line="144"/>
         <source>Meters layout</source>
         <translation>Расположение индикаторов</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="127"/>
+        <location filename="../../Train/VideoWindow.cpp" line="152"/>
         <source>Reset Meters layout to default</source>
         <translation>Сбросить расположение индикаторов по умолчанию</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> mph</source>
         <translation> миль/ч</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> m</source>
         <translation> м</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> feet</source>
         <translation> футы</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="625"/>
+        <location filename="../../Train/VideoWindow.cpp" line="681"/>
         <source>w</source>
         <translation>Вт</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="629"/>
+        <location filename="../../Train/VideoWindow.cpp" line="685"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> km</source>
         <translation> км</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> mi</source>
         <translation> миль</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="673"/>
+        <location filename="../../Train/VideoWindow.cpp" line="729"/>
         <source>Calibration required</source>
         <translation>Необходима калибровка</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="678"/>
+        <location filename="../../Train/VideoWindow.cpp" line="734"/>
         <source>Configuration required</source>
         <translation>Необходима настройка</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="683"/>
+        <location filename="../../Train/VideoWindow.cpp" line="739"/>
         <source>brake fault</source>
         <translation>ошибка тормоза</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="688"/>
+        <location filename="../../Train/VideoWindow.cpp" line="744"/>
         <source>Ready</source>
         <translation>Готово</translation>
     </message>
@@ -34732,27 +34705,27 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WheelSizeCalculator</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="202"/>
+        <location filename="../../Gui/AthletePages.cpp" line="187"/>
         <source>Wheel Size Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="221"/>
+        <location filename="../../Gui/AthletePages.cpp" line="206"/>
         <source>Rim Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="222"/>
+        <location filename="../../Gui/AthletePages.cpp" line="207"/>
         <source>Tire Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="223"/>
+        <location filename="../../Gui/AthletePages.cpp" line="208"/>
         <source>Wheel Size</source>
         <translation type="unfinished">Диаметр колёс</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="227"/>
         <source>mm</source>
         <translation type="unfinished">мм</translation>
     </message>
@@ -34864,12 +34837,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutFilterBox</name>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="34"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="44"/>
         <source>Filter...</source>
         <translation type="unfinished">Фильтр...</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="64"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="95"/>
         <source>ERROR: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34877,36 +34850,119 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutImportDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="820"/>
+        <location filename="../../Train/Library.cpp" line="809"/>
         <source>Import to Library</source>
         <translation>Импортировать в библиотеку</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="854"/>
+        <location filename="../../Train/Library.cpp" line="843"/>
         <source>Please note, that when importing or drag and dropping videos into the library we DO NOT copy the file into the GoldenCheetah library, instead we add a REFERENCE to it. We DO copy workout and videoSync files, since they are smaller.
 
 You can remove references when managing the library via the context menu options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="868"/>
+        <location filename="../../Train/Library.cpp" line="857"/>
         <source>Files</source>
         <translation>Файлы</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="878"/>
+        <location filename="../../Train/Library.cpp" line="867"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="880"/>
+        <location filename="../../Train/Library.cpp" line="869"/>
         <source>OK</source>
         <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="884"/>
+        <location filename="../../Train/Library.cpp" line="873"/>
         <source>Overwite existing files</source>
         <translation>Перезаписать существующие файлы</translation>
+    </message>
+</context>
+<context>
+    <name>WorkoutMenuProvider</name>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="271"/>
+        <source>Select Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="274"/>
+        <source>Manage Filters</source>
+        <translation type="unfinished">Управление фильтрами</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="275"/>
+        <source>Add Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="289"/>
+        <source>Add Tag to Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="292"/>
+        <source>Filter Tags...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="310"/>
+        <source>Match all selected tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="353"/>
+        <source>Manage Workout Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="360"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="361"/>
+        <source>Filter</source>
+        <translation type="unfinished">Фильтр</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="362"/>
+        <source>_index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="370"/>
+        <source>Execute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="371"/>
+        <source>Update</source>
+        <translation type="unfinished">Обновить</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="423"/>
+        <source>Add Workout Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="426"/>
+        <source>Name of the Filter...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="467"/>
+        <source>New</source>
+        <translation type="unfinished">Новое</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="469"/>
+        <source>New (%1)</source>
+        <translation type="unfinished">Новое (%1)</translation>
     </message>
 </context>
 <context>
@@ -34921,41 +34977,41 @@ You can remove references when managing the library via the context menu options
     <name>WorkoutPlotWindow</name>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="40"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="104"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
         <source>Ergmode specific settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="46"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
         <source>Color power zones</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="48"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="56"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="49"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="50"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="57"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="109"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="113"/>
         <source>When stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="54"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="110"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
         <source>Show tooltip</source>
         <translation type="unfinished"></translation>
     </message>
@@ -35049,12 +35105,12 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>WorkoutWidget</name>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="1531"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="1532"/>
         <source>File save failed.</source>
         <translation>Ошибка сохранения файла.</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="2367"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="2368"/>
         <source>Intensity</source>
         <translation>Интенсивность</translation>
     </message>
@@ -35208,26 +35264,22 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="44"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="45"/>
         <source>xData</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="58"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="59"/>
         <source>Data Series</source>
         <translation type="unfinished">Серия данных</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="78"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="80"/>
         <source>Add</source>
-        <translation type="unfinished">Добавить</translation>
+        <translation type="obsolete">Добавить</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="79"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="81"/>
         <source>Delete</source>
-        <translation type="unfinished">Удалить</translation>
+        <translation type="obsolete">Удалить</translation>
     </message>
 </context>
 <context>
@@ -35304,32 +35356,32 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataSeriesSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="333"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="315"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="338"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="320"/>
         <source>Units</source>
         <translation>Единицы измерения</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="346"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="328"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="347"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="329"/>
         <source>OK</source>
         <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Name is blank</source>
         <translation>Название не указано</translation>
     </message>
@@ -35337,48 +35389,48 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="262"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="244"/>
         <source>xData</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="269"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="251"/>
         <source>Data Series</source>
         <translation type="unfinished">Серия данных</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="270"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="252"/>
         <source>Units</source>
         <translation type="unfinished">Единицы измерения</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="274"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="256"/>
         <source>Series %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="281"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="263"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="282"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="264"/>
         <source>OK</source>
         <translation>ОК</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
         <source>XData name is blank</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Must have at least one data series.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -35699,17 +35751,17 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="915"/>
+        <location filename="../../Gui/AthletePages.cpp" line="886"/>
         <source>Sport</source>
         <translation>Вид спорта</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="962"/>
+        <location filename="../../Gui/AthletePages.cpp" line="933"/>
         <source>Critical Power</source>
         <translation>Критическая мощность (CP)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="963"/>
+        <location filename="../../Gui/AthletePages.cpp" line="934"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>

--- a/src/Resources/translations/gc_sv.ts
+++ b/src/Resources/translations/gc_sv.ts
@@ -107,38 +107,38 @@ Det kan behövas göras manuellt.</translation>
         <translation type="vanished">LTS medel (dagar)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="504"/>
+        <location filename="../../Gui/AthletePages.cpp" line="489"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="517"/>
-        <location filename="../../Gui/AthletePages.cpp" line="522"/>
+        <location filename="../../Gui/AthletePages.cpp" line="502"/>
+        <location filename="../../Gui/AthletePages.cpp" line="507"/>
         <source>days</source>
         <translation type="unfinished">Dagar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="525"/>
+        <location filename="../../Gui/AthletePages.cpp" line="510"/>
         <source>PMC Stress Balance Today</source>
         <translation>PMC Stress Balance Idag</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="528"/>
+        <location filename="../../Gui/AthletePages.cpp" line="513"/>
         <source>Restore Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="517"/>
         <source>W&apos;bal tau</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="518"/>
         <source>Short Term Stress (STS) average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="534"/>
+        <location filename="../../Gui/AthletePages.cpp" line="519"/>
         <source>Long Term Stress (LTS) average</source>
         <translation type="unfinished"></translation>
     </message>
@@ -154,96 +154,96 @@ Det kan behövas göras manuellt.</translation>
 <context>
     <name>AboutRiderPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="372"/>
+        <location filename="../../Gui/AthletePages.cpp" line="357"/>
         <source>Nickname</source>
         <translation>Smeknamn</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="373"/>
+        <location filename="../../Gui/AthletePages.cpp" line="358"/>
         <source>Date of Birth</source>
         <translation>Födelsedatum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="374"/>
+        <location filename="../../Gui/AthletePages.cpp" line="359"/>
         <source>Sex</source>
         <translation>Kön</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="376"/>
+        <location filename="../../Gui/AthletePages.cpp" line="361"/>
         <source>Weight</source>
         <translation type="unfinished">Kroppsvikt</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="375"/>
+        <location filename="../../Gui/AthletePages.cpp" line="360"/>
         <source>Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="279"/>
+        <location filename="../../Gui/AthletePages.cpp" line="264"/>
         <source>Male</source>
         <translation>Man</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="280"/>
+        <location filename="../../Gui/AthletePages.cpp" line="265"/>
         <source>Female</source>
         <translation>Kvinna</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> kg</source>
         <translation type="unfinished"> kg</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> lb</source>
         <translation type="unfinished"> lbm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> cm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="359"/>
+        <location filename="../../Gui/AthletePages.cpp" line="344"/>
         <source>Calculate...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="378"/>
+        <location filename="../../Gui/AthletePages.cpp" line="363"/>
         <source>Bike</source>
         <translation type="unfinished">Cykla</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="379"/>
+        <location filename="../../Gui/AthletePages.cpp" line="364"/>
         <source>Crank Length</source>
         <translation>Vevarmslängd</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="380"/>
+        <location filename="../../Gui/AthletePages.cpp" line="365"/>
         <source>Wheelsize</source>
         <translation>Hjulstorlek</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="438"/>
+        <location filename="../../Gui/AthletePages.cpp" line="423"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="356"/>
+        <location filename="../../Gui/AthletePages.cpp" line="341"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="437"/>
+        <location filename="../../Gui/AthletePages.cpp" line="422"/>
         <source>Choose Picture</source>
         <translation>Välj foto</translation>
     </message>
@@ -2277,397 +2277,394 @@ För att gå vidare välj &quot;Fortsätt&quot;
 <context>
     <name>AllPlotWindow</name>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="190"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="444"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="165"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
         <source>Smooth</source>
         <translation>Jämna till</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="198"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="173"/>
         <source>Stacked</source>
         <translation>Stapla</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="199"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="174"/>
         <source>by series</source>
         <translation>efter serie</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="200"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="175"/>
         <source>Fullplot</source>
         <translation>Visa allt</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="201"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="176"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="239"/>
         <source>Overlay</source>
         <translation>Intervallfönster</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="229"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="204"/>
         <source>View</source>
         <translation>Vy</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="206"/>
         <source>Stack</source>
         <translation>Stapla</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="210"/>
         <source>By Series</source>
         <translation>efter serie</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="246"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="221"/>
         <source>Stack Zoom</source>
         <translation>Stack Zoom</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="248"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="223"/>
         <source>Full plot</source>
         <translation>Visa allt</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="227"/>
         <source>Show Interval Markers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="256"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
         <source>Interval Navigator</source>
         <translation>Intervall Navigator</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="260"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
         <source>Hover intervals</source>
         <translation>Mushovra intervaller</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="268"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="243"/>
         <source>Fill Curves</source>
         <translation>Fyll kurvor</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="247"/>
         <source>Grid</source>
         <translation>Stödlinjer</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="277"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
         <source>Acceleration</source>
         <translation>Acceleration</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="279"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="254"/>
         <source>Delta Series</source>
         <translation>Delta Serier</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="280"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="255"/>
         <source>Power %1</source>
         <translation>Effekt %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="283"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="258"/>
         <source>Cadence %1</source>
         <translation>Kadens %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="261"/>
         <source>Torque %1</source>
         <translation>Vridmoment %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="289"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
         <source>Heartrate %1</source>
         <translation>Hjärtfrekvens %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="295"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="270"/>
         <source>Balance</source>
         <translation>Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
         <source>Left/Right</source>
         <translation>Vänster/Höger</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="274"/>
         <source>Torque Effectiveness</source>
         <translation>Rundtrampseffektivitet</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="303"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="278"/>
         <source>Smoothness</source>
         <translation>Jämnhet</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="282"/>
         <source>Pedal Center Offset</source>
         <translation>PCO</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="290"/>
         <source>Peak Power Phase</source>
         <translation>Toppkraftsfas</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="322"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
         <source>Vertical Oscillation</source>
         <translation>Vertikal rörelse</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="324"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
         <source>Running</source>
         <translation>Löpning</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="326"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="301"/>
         <source>Ground Contact Time</source>
         <translation>Stöttid</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
         <source>Cadence </source>
         <translation>Kadens </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="313"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="340"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
         <source>Moxy</source>
         <translation>Moxy</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="317"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="321"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="325"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="355"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="330"/>
         <source>Heart Rate</source>
         <translation>Hjärtfrekvens</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="357"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
         <source>Data series</source>
         <translation>Data serie</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="359"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="334"/>
         <source>Core Temperature</source>
         <translation>Kroppstemperatur</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="363"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
         <source>Speed</source>
         <translation>Fart</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="367"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
         <source>Cadence</source>
         <translation>Kadens</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="94"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="95"/>
         <source>Basic</source>
         <translation>Grundläggande</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="109"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="110"/>
         <source>Curves</source>
         <translation>Kurvor</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="116"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="117"/>
         <source>User Data</source>
         <translation>Användar Data</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="132"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Name</source>
         <translation>Namn</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="134"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Formula</source>
         <translation>Formel</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="144"/>
         <source>Edit</source>
-        <translation>Editera</translation>
+        <translation type="vanished">Editera</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="163"/>
         <source>Up</source>
-        <translation>Upp</translation>
+        <translation type="vanished">Upp</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="164"/>
         <source>Down</source>
-        <translation>Ner</translation>
+        <translation type="vanished">Ner</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="311"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
         <source>Power Phase</source>
         <translation>Kraftfas</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="371"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
         <source>Altitude</source>
         <translation>Höjd</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
         <source>Temperature</source>
         <translation>Temperatur</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="379"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="354"/>
         <source>Headwind</source>
         <translation>Motvind</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="383"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="358"/>
         <source>Torque</source>
         <translation>Vridmoment</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="387"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="362"/>
         <source>Gear Ratio</source>
         <translation>Utväxling</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="391"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="366"/>
         <source>Slope</source>
         <translation>Lutning</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="373"/>
         <source>No Alt/Slope</source>
         <translation>Ingen Höjd/Lutning</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="399"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="374"/>
         <source>0.1km|mi -  1min</source>
         <translation>0.1km|mi -  1min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="400"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
         <source>0.5km|mi -  5min</source>
         <translation>0.5km|mi -  5min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="401"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="376"/>
         <source>1.0km|mi - 10min</source>
         <translation>1.0km|mi - 10min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1528"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="377"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="1503"/>
         <source>Alt/Slope</source>
         <translation>Höjd/Lutning</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="382"/>
         <source>Anaerobic TISS</source>
         <translation>Anaerob TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="384"/>
         <source>Metrics</source>
         <translation>Mätetal</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="411"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="386"/>
         <source>Aerobic TISS</source>
         <translation>Aerob TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="390"/>
         <source>Iso Power</source>
         <translation>Normaliserad Effekt</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="394"/>
         <source>Skiba xPower</source>
         <translation>Skiba xPower</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="423"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
         <source>Altitude Power</source>
         <translation>Höjdkorrigerad Effekt (watt)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="427"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
         <source>W&apos; balance</source>
         <translation>W&apos; Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="441"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="416"/>
         <source>Time of day</source>
         <translation>Klockslag</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="742"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="717"/>
         <source>Intervals</source>
         <translation>Intervall</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="2253"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="2228"/>
         <source>Selection #%1 </source>
         <translation>Val #%1 </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="432"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
         <source>Power + shade</source>
         <translation>Visa Effektzoner</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="433"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="408"/>
         <source>Power - shade</source>
         <translation>Göm Effektzoner</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="434"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
         <source>No Power</source>
         <translation>Göm Effekt</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="435"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="410"/>
         <source>Shading</source>
         <translation>Effektzoner</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="439"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="414"/>
         <source>Time</source>
         <translation>Tid</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="440"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
         <source>Distance</source>
         <translation>Distans</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="442"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="417"/>
         <source>X Axis</source>
         <translation>x-Axel</translation>
     </message>
@@ -3476,51 +3473,45 @@ För att gå vidare välj &quot;Fortsätt&quot;
 <context>
     <name>AutoImportPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4028"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4029"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
         <source>Browse</source>
         <translation type="vanished">Bläddra</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4040"/>
         <source>Add</source>
-        <translation>Lägg till</translation>
+        <translation type="vanished">Lägg till</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4041"/>
         <source>Delete</source>
-        <translation>Radera</translation>
+        <translation type="vanished">Radera</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4042"/>
         <source>Up</source>
-        <translation>Upp</translation>
+        <translation type="vanished">Upp</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4043"/>
         <source>Down</source>
-        <translation>Ner</translation>
+        <translation type="vanished">Ner</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4054"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3779"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4059"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3784"/>
         <source>Directory</source>
         <translation>Mapp</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4060"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3785"/>
         <source>Import Rule</source>
         <translation>Import Regel</translation>
     </message>
@@ -4338,37 +4329,37 @@ För att gå vidare välj &quot;Fortsätt&quot;
 <context>
     <name>BackupPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="608"/>
+        <location filename="../../Gui/AthletePages.cpp" line="593"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="601"/>
         <source>every</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="617"/>
+        <location filename="../../Gui/AthletePages.cpp" line="602"/>
         <source>times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="603"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="605"/>
         <source>Backup now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="623"/>
+        <location filename="../../Gui/AthletePages.cpp" line="608"/>
         <source>Auto Backup Folder</source>
         <translation>Mapp för säkerhetskopia</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="624"/>
+        <location filename="../../Gui/AthletePages.cpp" line="609"/>
         <source>Auto Backup after closing the athlete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5194,41 +5185,33 @@ Går till inställningar.</translation>
         <translation type="vanished">Uppdatera</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1202"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1203"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1204"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1150"/>
         <source>Review...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1206"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1152"/>
         <source>Changed power estimates are available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1213"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1225"/>
         <source>Add</source>
-        <translation>Lägg till</translation>
+        <translation type="vanished">Lägg till</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1214"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1226"/>
         <source>Delete</source>
-        <translation>Radera</translation>
+        <translation type="vanished">Radera</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1216"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1158"/>
         <source>Def</source>
         <translatorcomment>???</translatorcomment>
         <translation>Default</translation>
@@ -5238,27 +5221,27 @@ Går till inställningar.</translation>
         <translation type="vanished">Start Datum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1218"/>
         <source>Critical Power</source>
         <translation>Critical Power</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1305"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>AeTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1306"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>FTP</source>
         <translation>FTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1307"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1221"/>
         <source>W&apos;</source>
         <translation>W&apos;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1308"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1222"/>
         <source>Pmax</source>
         <translation>Pmax</translation>
     </message>
@@ -5268,208 +5251,208 @@ Går till inställningar.</translation>
         <translation type="vanished">dd.MMM yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1347"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1261"/>
         <source>Short</source>
         <translation>Short</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1247"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1169"/>
         <source>Use CP for all metrics</source>
         <translation>Använd CP för alla mätetal</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1240"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1162"/>
         <source>Manual</source>
         <translation type="unfinished">Manuell</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1241"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1163"/>
         <source>Semi-Automatic (CP2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1164"/>
         <source>Semi-Automatic (CP3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1243"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1165"/>
         <source>Semi-Automatic (Extended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1170"/>
         <source>Use FTP for Coggan metrics</source>
         <translation>Använd FTP till Coggan Mätetalen</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1273"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1279"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1285"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1342"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1618"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1631"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2283"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2289"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2310"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1187"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1193"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1199"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1211"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1537"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1545"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2180"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2186"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2194"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2207"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1205"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1547"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2201"/>
         <source>J</source>
         <translation type="unfinished">J</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1303"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1217"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2145"/>
         <source>Start Date</source>
         <translation type="unfinished">Startdatum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1309"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1223"/>
         <source>Model Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1262"/>
         <source>Long</source>
         <translatorcomment>??</translatorcomment>
         <translation>Long</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1349"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1263"/>
         <source>From Watts</source>
         <translation>Nedre effekt gräns</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1598"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1512"/>
         <source>Review range starting on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1614"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1528"/>
         <source>Current</source>
         <translation type="unfinished">Nyvarande</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1615"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1529"/>
         <source>Estimate</source>
         <translation type="unfinished">Uppskattning</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1530"/>
         <source>Accept</source>
         <translation type="unfinished">Accepterar</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1788"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1691"/>
         <source>🗹</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1692"/>
         <source>Estimate and settings &lt;b&gt;match&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1695"/>
         <source>☐</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1696"/>
         <source>Estimate and settings &lt;b&gt;differ&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1797"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1700"/>
         <source>⏲</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1800"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1703"/>
         <source>Range is %1 days older than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1802"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1705"/>
         <source>Range is %1 days younger than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1808"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1711"/>
         <source>∅</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1712"/>
         <source>No estimate available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1902"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1805"/>
         <source>New range from estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2237"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2134"/>
         <source>The proposed value for AeTP is a very rough estimate, assuming %1 % of CP. Usually it is determined by a&lt;ul&gt;&lt;li&gt;Metabolic test&lt;/li&gt;&lt;li&gt;Lactate ramp test&lt;/li&gt;&lt;li&gt;Run / Cycling ‘conversational’ test&lt;/li&gt;&lt;li&gt;Run Decoupling test&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2239"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2136"/>
         <source>Updating FTP internally to match CP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2139"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2244"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2141"/>
         <source>Your selected model does not deliver values for PMax, using default value of %1 W instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2246"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2143"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;li&gt;PMax, assuming a default of %1 W&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2250"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2147"/>
         <source>Critical Power (CP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2252"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2149"/>
         <source>Aerobic Threshold Power (AeTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2254"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2151"/>
         <source>Functional Threshold Power (FTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2153"/>
         <source>Anaerobic Work Capacity (W&apos;)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2258"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2155"/>
         <source>Maximum Power (PMax)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2270"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2167"/>
         <source>Manual range</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5478,14 +5461,14 @@ Går till inställningar.</translation>
         <translation type="vanished">Maximala antalet zoner (10) har nåtts.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2018"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2025"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1917"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1924"/>
         <source>New</source>
         <translation>Ny</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2020"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1919"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1926"/>
         <source>New (%1)</source>
         <translation>Ny (%1)</translation>
     </message>
@@ -5938,52 +5921,44 @@ ddd, dd.MMM yyyy</translation>
         <translation type="vanished">Uppdatera</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3307"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3319"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3308"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3320"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3313"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3325"/>
         <source>Add</source>
-        <translation>Lägg till</translation>
+        <translation type="vanished">Lägg till</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3314"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3326"/>
         <source>Delete</source>
-        <translation>Radera</translation>
+        <translation type="vanished">Radera</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3316"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3109"/>
         <source>Def</source>
         <translation>Default</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3359"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3506"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3272"/>
         <source>Start Date</source>
         <translation type="unfinished">Startdatum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3249"/>
         <source>New range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3507"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3273"/>
         <source>Critical Velocity (CV)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3508"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3274"/>
         <source>Aerobic Threshold (AeT)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5992,12 +5967,12 @@ ddd, dd.MMM yyyy</translation>
         <translation type="vanished">Start Datum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3360"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3128"/>
         <source>Critical Velocity</source>
         <translation>Critical Velocity</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3361"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3129"/>
         <source>Aerobic Threshold</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6006,17 +5981,17 @@ ddd, dd.MMM yyyy</translation>
         <translation type="vanished">dd.MMM yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3403"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
         <source>Short</source>
         <translation>Short</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3404"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3172"/>
         <source>Long</source>
         <translation>Long</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3405"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3173"/>
         <source>From</source>
         <translation>Början</translation>
     </message>
@@ -6025,14 +6000,14 @@ ddd, dd.MMM yyyy</translation>
         <translation type="vanished">Maximalt antal zoner (10) nått.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3679"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3686"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3441"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3448"/>
         <source>New</source>
         <translation>Ny</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3681"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3688"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3443"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3450"/>
         <source>New (%1)</source>
         <translation>Ny (%1)</translation>
     </message>
@@ -7567,37 +7542,32 @@ Skall ändringen genomföras och Golden Cheetah startas om?</translation>
 <context>
     <name>CredentialsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="67"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
+    </message>
+    <message>
+        <source>-</source>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="vanished">Ändra</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">Lägg till</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">Radera</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="68"/>
-        <source>-</source>
-        <translation>-</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="69"/>
-        <source>Edit</source>
-        <translation>Ändra</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="74"/>
-        <source>Add</source>
-        <translation>Lägg till</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="75"/>
-        <source>Delete</source>
-        <translation>Radera</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="86"/>
         <source>Service</source>
         <translation>Tjänst</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="87"/>
+        <location filename="../../Gui/AthletePages.cpp" line="69"/>
         <source>Description</source>
         <translation>Beskrivning</translation>
     </message>
@@ -8284,7 +8254,7 @@ Skall ändringen genomföras och Golden Cheetah startas om?</translation>
 <context>
     <name>DataFilterEdit</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2743"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2712"/>
         <source>Warning: sample() is slow -- update code to use samples()</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8643,7 +8613,7 @@ Skall ändringen genomföras och Golden Cheetah startas om?</translation>
 <context>
     <name>DirectoryPathWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="277"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="308"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8880,28 +8850,28 @@ välj sedan &quot;Sök igen&quot;för ett nytt försök.</translation>
 <context>
     <name>Dropbox</name>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="68"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="77"/>
         <source>Problem accessing Dropbox data</source>
         <translation>Kommer inte åt Dropbox data</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="130"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="139"/>
         <source>You must authorise with Dropbox first</source>
         <translation>Du måste först auktorisera med Dropbox</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="205"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="214"/>
         <source>Parsing Error: %1</source>
         <translation>Behandlingsfel: %1</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="293"/>
-        <location filename="../../Cloud/Dropbox.cpp" line="312"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="302"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="321"/>
         <source>Completed.</source>
         <translation>Klart.</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="297"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="306"/>
         <source>Network Error - Upload failed.</source>
         <translation>Nätverksfel - Uppladdningen misslyckades.</translation>
     </message>
@@ -9046,136 +9016,136 @@ välj sedan &quot;Sök igen&quot;för ett nytt försök.</translation>
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2064"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2033"/>
         <source>Name</source>
         <translation>Namn</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2034"/>
         <source>Axis Label / Units</source>
         <translation>Axeletikett och  Enheter</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1597"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1566"/>
         <source>Curve Settings</source>
         <translation>Kurvinställningar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1558"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1527"/>
         <source>Estimate %1 %2 Power</source>
         <translation>Skattning %1 %2 Effekt</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1562"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1531"/>
         <source>Endurance Index</source>
         <translation>Uthållighetsindex</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1532"/>
         <source>Vo2Max Estimate</source>
         <translation>Vo2Max Skattning</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1605"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1574"/>
         <source>Metric</source>
         <translation>Mätetal</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1606"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1575"/>
         <source>Best</source>
         <translation>Personbästa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1607"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1576"/>
         <source>Estimate</source>
         <translation>Uppskattning</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1577"/>
         <source>PMC</source>
         <translation>PMC</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1609"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1578"/>
         <source>Formula</source>
         <translation>Formel</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1610"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1579"/>
         <source>Measure</source>
         <translation>Mått</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1611"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1580"/>
         <source>Performance</source>
         <translation>Prestation</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1612"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1581"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1684"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1767"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1653"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1736"/>
         <source>seconds</source>
         <translation>sekunder</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1685"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1768"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1737"/>
         <source>minutes</source>
         <translation>minuter</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1769"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1655"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1738"/>
         <source>hours</source>
         <translation>timmar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1723"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1816"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1692"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1785"/>
         <source>Peak</source>
         <translation>Topp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1781"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1750"/>
         <source>Absolute</source>
         <translation>Absolut</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1751"/>
         <source>Per Kilogram</source>
         <translation>Per Kilogram</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1813"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
         <source>Total</source>
         <translation>Totalumma</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1814"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1783"/>
         <source>Running Total</source>
         <translation>Totalsumma Löpning</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1815"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1784"/>
         <source>Average</source>
         <translation>Genomsnitt</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1817"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1786"/>
         <source>Low</source>
         <translation>Lägsta</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1820"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1789"/>
         <source>Aggregate:</source>
         <translation>Aggregat:</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1828"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1797"/>
         <source># type in a formula to use
 # for e.g. BikeStress / Duration
 # as you type the available metrics
@@ -9189,295 +9159,295 @@ välj sedan &quot;Sök igen&quot;för ett nytt försök.</translation>
 </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1839"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1808"/>
         <source>Weekly Best Performances</source>
         <translation>Personbästa per vecka</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1840"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1809"/>
         <source>Submaximal Weekly Best</source>
         <translation>Submaximala Personbästa per vecka</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1841"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1810"/>
         <source>Performance Tests</source>
         <translation>Prestationstest</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1933"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1902"/>
         <source>Short Term Stress (STS/ATL)</source>
         <translation>Kortsiktig Stress (STS/ATL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1934"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1903"/>
         <source>Long Term Stress  (LTS/CTL)</source>
         <translation>Långsiktig Stress  (LTS/CTL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1935"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1904"/>
         <source>Stress Balance    (SB/TSB)</source>
         <translation>Stress Balans (SB/TSB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1936"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1905"/>
         <source>Stress Ramp Rate  (RR)</source>
         <translation>Stress Ökningstakt (RR)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1944"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1913"/>
         <source>Stress Type</source>
         <translation>Stresstyp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1949"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1918"/>
         <source>Negative Training Effect (NTE)</source>
         <translation>Negative Training Effect (NTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1950"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1919"/>
         <source>Positive Training Effect (PTE)</source>
         <translation>Positive Training Effect (PTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1951"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1920"/>
         <source>Performance (Power Index)</source>
         <translation>Prestation (Power Index)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1952"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1921"/>
         <source>Predicted CP (Watts)</source>
         <translation>Uppskattad CP (W)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1969"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1938"/>
         <source>Curve Type</source>
         <translation>Kurvtyp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1945"/>
         <source>Perf. Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2006"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1975"/>
         <source>Metadata Field</source>
         <translation>Metadatafält</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2007"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
         <source>PMC metric</source>
         <translation>PMC mätetal</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2032"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2001"/>
         <source>Measure Group</source>
         <translation>Måttgrupp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2009"/>
         <source>Measure Field</source>
         <translation>Måttfält</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2029"/>
         <source>Filter</source>
         <translation>Filter</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2071"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
         <source>Style</source>
         <translation>Stil</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2042"/>
         <source>Bar</source>
         <translation>Stapel</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2074"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2043"/>
         <source>Line</source>
         <translation>Linje</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2075"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2044"/>
         <source>Sticks</source>
         <translatorcomment>???</translatorcomment>
         <translation>Candlestick</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2076"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2045"/>
         <source>Dots</source>
         <translation>Punkt</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2048"/>
         <source>Stack</source>
         <translation>Stapla</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2053"/>
         <source>Symbol</source>
         <translation>Symbol</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2086"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2055"/>
         <source>None</source>
         <translation>Inga</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2087"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2056"/>
         <source>Circle</source>
         <translation>Cirkel</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2057"/>
         <source>Square</source>
         <translation>Kvadrat</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2089"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2058"/>
         <source>Diamond</source>
         <translation>Diamant</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2090"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2059"/>
         <source>Triangle</source>
         <translation>Triangel</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2091"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
         <source>Cross</source>
         <translation>Kors</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2092"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2061"/>
         <source>Hexagon</source>
         <translation>Hexagon</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2062"/>
         <source>Star</source>
         <translation>Stjärna</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
         <source>Color</source>
         <translation>Färg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2100"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2069"/>
         <source>Fill curve</source>
         <translation>Fyll kurva</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
         <source>Data labels</source>
         <translatorcomment>???</translatorcomment>
         <translation>Dataetiketter</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2080"/>
         <source>Highlight Highest</source>
         <translation>Framhäv Högsta</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
         <source>Highlight Lowest</source>
         <translation>Framhäv Lägsta</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2127"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
         <source>Highlight Outliers</source>
         <translation>Framhäv Outliers</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2135"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
         <source>Baseline</source>
         <translatorcomment>???</translatorcomment>
         <translation>Referens</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2143"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2112"/>
         <source>Smooth Curve</source>
         <translation>Jämna ut kurva</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2147"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2116"/>
         <source>No trend Line</source>
         <translation>Ingen Trendlinje</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2148"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2117"/>
         <source>Linear Trend</source>
         <translation>Linjär</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2149"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2118"/>
         <source>Quadratic Trend</source>
         <translation>Kvadratisk</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2150"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
         <source>Moving Average</source>
         <translation>Glidande Genomsnitt</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2151"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2120"/>
         <source>Simple Average</source>
         <translation>Medelvärde</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2123"/>
         <source>Ignore Zeros</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2168"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2201"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2170"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Avbryt</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2431"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2400"/>
         <source>Peak %1</source>
         <translation>Topp %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2402"/>
         <source> second </source>
         <translation> sekund </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2434"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2403"/>
         <source> minute </source>
         <translation> minut </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2436"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2405"/>
         <source> hour </source>
         <translation> timme </translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2456"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2425"/>
         <source>%1 - %2</source>
         <translation>%1 - %2</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2470"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2439"/>
         <source>Performances</source>
         <translation>Prestationer</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2471"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2440"/>
         <source>Power Index</source>
         <translation>Power Index</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2588"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2557"/>
         <source>Performances_%1_%2_%3</source>
         <translation>Prestationer_%1_%2_%3</translation>
     </message>
@@ -9807,93 +9777,93 @@ välj sedan &quot;Sök igen&quot;för ett nytt försök.</translation>
 <context>
     <name>EditUserAxisDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1731"/>
+        <location filename="../../Charts/UserChart.cpp" line="1689"/>
         <source>Edit Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1741"/>
+        <location filename="../../Charts/UserChart.cpp" line="1699"/>
         <source>&amp;OK</source>
         <translation type="unfinished">&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1742"/>
+        <location filename="../../Charts/UserChart.cpp" line="1700"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Avbryt</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1750"/>
+        <location filename="../../Charts/UserChart.cpp" line="1708"/>
         <source>Units</source>
         <translation type="unfinished">Enheter</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1760"/>
+        <location filename="../../Charts/UserChart.cpp" line="1718"/>
         <source>Logarithmic Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1757"/>
+        <location filename="../../Charts/UserChart.cpp" line="1715"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1761"/>
-        <location filename="../../Charts/UserChart.cpp" line="1780"/>
+        <location filename="../../Charts/UserChart.cpp" line="1719"/>
+        <location filename="../../Charts/UserChart.cpp" line="1738"/>
         <source> </source>
         <translation type="unfinished"> </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1763"/>
+        <location filename="../../Charts/UserChart.cpp" line="1721"/>
         <source>Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1774"/>
+        <location filename="../../Charts/UserChart.cpp" line="1732"/>
         <source> from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1776"/>
+        <location filename="../../Charts/UserChart.cpp" line="1734"/>
         <source> to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1779"/>
+        <location filename="../../Charts/UserChart.cpp" line="1737"/>
         <source>Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1787"/>
+        <location filename="../../Charts/UserChart.cpp" line="1745"/>
         <source>Smoothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1792"/>
+        <location filename="../../Charts/UserChart.cpp" line="1750"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1793"/>
+        <location filename="../../Charts/UserChart.cpp" line="1751"/>
         <source>Day</source>
         <translation type="unfinished">Dag</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1794"/>
+        <location filename="../../Charts/UserChart.cpp" line="1752"/>
         <source>Week</source>
         <translation type="unfinished">Vecka</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1795"/>
+        <location filename="../../Charts/UserChart.cpp" line="1753"/>
         <source>Month</source>
         <translation type="unfinished">Månad</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1796"/>
+        <location filename="../../Charts/UserChart.cpp" line="1754"/>
         <source>Year</source>
         <translation type="unfinished">År</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1798"/>
+        <location filename="../../Charts/UserChart.cpp" line="1756"/>
         <source>Group By</source>
         <translation type="unfinished">Gruppera efter</translation>
     </message>
@@ -10091,158 +10061,158 @@ välj sedan &quot;Sök igen&quot;för ett nytt försök.</translation>
 <context>
     <name>EditUserSeriesDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1398"/>
+        <location filename="../../Charts/UserChart.cpp" line="1356"/>
         <source>Edit Data Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1414"/>
+        <location filename="../../Charts/UserChart.cpp" line="1372"/>
         <source>&amp;OK</source>
         <translation type="unfinished">&amp;OK</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1415"/>
+        <location filename="../../Charts/UserChart.cpp" line="1373"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Avbryt</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1422"/>
+        <location filename="../../Charts/UserChart.cpp" line="1380"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1430"/>
+        <location filename="../../Charts/UserChart.cpp" line="1388"/>
         <source>Series Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1519"/>
+        <location filename="../../Charts/UserChart.cpp" line="1477"/>
         <source>Y units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1524"/>
+        <location filename="../../Charts/UserChart.cpp" line="1482"/>
         <source>X units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1528"/>
+        <location filename="../../Charts/UserChart.cpp" line="1486"/>
         <source>Sum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1529"/>
+        <location filename="../../Charts/UserChart.cpp" line="1487"/>
         <source>Average</source>
         <translation type="unfinished">Genomsnitt</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1530"/>
+        <location filename="../../Charts/UserChart.cpp" line="1488"/>
         <source>Peak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1531"/>
+        <location filename="../../Charts/UserChart.cpp" line="1489"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1532"/>
+        <location filename="../../Charts/UserChart.cpp" line="1490"/>
         <source>Running Total</source>
         <translation type="unfinished">Totalsumma Löpning</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1533"/>
+        <location filename="../../Charts/UserChart.cpp" line="1491"/>
         <source>Mean Square Root</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1534"/>
+        <location filename="../../Charts/UserChart.cpp" line="1492"/>
         <source>Std Deviation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1537"/>
+        <location filename="../../Charts/UserChart.cpp" line="1495"/>
         <source>Aggregate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1541"/>
-        <location filename="../../Charts/UserChart.cpp" line="1557"/>
+        <location filename="../../Charts/UserChart.cpp" line="1499"/>
+        <location filename="../../Charts/UserChart.cpp" line="1515"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1542"/>
+        <location filename="../../Charts/UserChart.cpp" line="1500"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1543"/>
+        <location filename="../../Charts/UserChart.cpp" line="1501"/>
         <source>Dashed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1544"/>
+        <location filename="../../Charts/UserChart.cpp" line="1502"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1545"/>
+        <location filename="../../Charts/UserChart.cpp" line="1503"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1546"/>
+        <location filename="../../Charts/UserChart.cpp" line="1504"/>
         <source>Fast Graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1547"/>
+        <location filename="../../Charts/UserChart.cpp" line="1505"/>
         <source>Show on Legend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1548"/>
+        <location filename="../../Charts/UserChart.cpp" line="1506"/>
         <source>Show Data Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1554"/>
+        <location filename="../../Charts/UserChart.cpp" line="1512"/>
         <source>Line Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1558"/>
+        <location filename="../../Charts/UserChart.cpp" line="1516"/>
         <source>Circle</source>
         <translation type="unfinished">Cirkel</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1559"/>
+        <location filename="../../Charts/UserChart.cpp" line="1517"/>
         <source>Rectangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1564"/>
+        <location filename="../../Charts/UserChart.cpp" line="1522"/>
         <source>Symbol</source>
         <translation type="unfinished">Symbol</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1572"/>
+        <location filename="../../Charts/UserChart.cpp" line="1530"/>
         <source>Color</source>
         <translation type="unfinished">Färg</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1575"/>
+        <location filename="../../Charts/UserChart.cpp" line="1533"/>
         <source>Fill curve</source>
         <translation type="unfinished">Fyll kurva</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1583"/>
+        <location filename="../../Charts/UserChart.cpp" line="1541"/>
         <source>Opacity (%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1589"/>
+        <location filename="../../Charts/UserChart.cpp" line="1547"/>
         <source>Size/Width</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10289,6 +10259,24 @@ välj sedan &quot;Sök igen&quot;för ett nytt försök.</translation>
         <location filename="../../Metrics/BasicRideMetrics.cpp" line="144"/>
         <source>Only useful for intervals, time the interval started</source>
         <translation>Endast användbart vid intervall, tid då intervallet började</translation>
+    </message>
+</context>
+<context>
+    <name>ElevationChartWindow</name>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="221"/>
+        <source>Profile Distance (m)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="229"/>
+        <source>Seconds for delta slope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="237"/>
+        <source>Elevation window size (%) relative to current altitude</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10727,7 +10715,7 @@ välj sedan &quot;Sök igen&quot;för ett nytt försök.</translation>
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ExhaustionDialog.cpp" line="160"/>
+        <location filename="../../Charts/ExhaustionDialog.cpp" line="162"/>
         <source>Time</source>
         <translation>Tid</translation>
     </message>
@@ -13126,42 +13114,42 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
 <context>
     <name>GcCrashDialog</name>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="78"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="74"/>
         <source>%1 Crash Recovery</source>
         <translation>%1 Crash Återställning</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="116"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="112"/>
         <source>&lt;b&gt;GoldenCheetah appears to have PREVIOUSLY crashed for this athlete. &lt;/b&gt;&lt;br&gt;&lt;br&gt;The report below gives some diagnostic information that will be useful to the developers. Feel free to post this with a short description of what was occurring when the crash happened to the &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah forums&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;We respect privacy - this log does NOT contain ids, passwords or personal information.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;When this dialog is closed the athlete will be opened.&lt;/b&gt;</source>
         <translation>&lt;b&gt;GoldenCheetah verkar tidigare ha crashat för denna idrottare. &lt;/b&gt;&lt;br&gt;&lt;br&gt;Rapporten nedan innehåller diagnostisk information som är användbar för programutvecklare. Vänligen publicera rapporten tillsammans med en kort beskrivning av vad som gjordes i samband med crashen på &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah Forum&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;Personlig integritet: Denna rapport innehåller inte IDs, lösenord eller personlig information.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;Efter att denna dialog stängts kommer idrottaren i GoldenCheetah att öppnas.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="141"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="137"/>
         <source>Save Crash Report...</source>
         <translation>Spara Crashrapport...</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="143"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="139"/>
         <source>Close</source>
         <translation>Stäng</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="225"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="221"/>
         <source>&lt;p&gt;Build date: %1 %2&lt;br&gt;Build id: %3&lt;br&gt;Version: %4&lt;br&gt;DB Schema: %5&lt;br&gt;Metrics: %7&lt;br&gt;OS: %6&lt;br&gt;OpenGL: %10&lt;br&gt;UI: dpi scale (%8) font size (%9)&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="255"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="251"/>
         <source>&lt;table&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QT&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QWT&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;%3&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SRMIO&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;D2XX&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;ICAL&lt;/td&gt;&lt;td&gt;%9&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;USBXPRESS&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LIBUSB&lt;/td&gt;&lt;td&gt;%11&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VLC&lt;/td&gt;&lt;td&gt;%12&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VIDEO&lt;/td&gt;&lt;td&gt;%13&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SAMPLERATE&lt;/td&gt;&lt;td&gt;%14&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SSL&lt;/td&gt;&lt;td&gt;%15&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;R&lt;/td&gt;&lt;td&gt;%16&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;Python&lt;/td&gt;&lt;td&gt;%18&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LMFIT&lt;/td&gt;&lt;td&gt;7.0&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;GSL&lt;/td&gt;&lt;td&gt;%19&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Save Diagnostics</source>
         <translation>Spara Diagnostik</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Text File (*.txt)</source>
         <translation>Textfil (*.txt)</translation>
     </message>
@@ -13497,168 +13485,173 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
 <context>
     <name>GcWindowRegistry</name>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
         <source>Performance</source>
         <translation>Prestation</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="89"/>
         <source>Histogram</source>
         <translation>Histogram</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
         <source>Distribution</source>
         <translation>Distribution</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
         <source>Pedal Force vs Velocity</source>
         <translation>Pedalkraft mot Fart</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
         <source>Heartrate vs Power</source>
         <translation>Hjärtfrekvens mot Effekt</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
         <source>Python Chart</source>
         <translation>Python Diagram</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
         <source>Python Chart </source>
         <translation>Python Diagram </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="101"/>
         <source>Calendar</source>
         <translation>Kalender</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
         <source>Navigator</source>
         <translation>Navigator</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="76"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="73"/>
         <source>User Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
         <source>Trends</source>
         <translation type="unfinished">Trender</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="78"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
         <source>TreeMap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
         <source>Power Duration </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="83"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
         <source>Activity Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="81"/>
         <source>Blank Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="85"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="82"/>
         <source>User Chart </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
         <source>Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="88"/>
         <source>Power Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
         <source>Scatter</source>
         <translation type="unfinished">Spridning</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="103"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
         <source>Aerolab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
         <source>Telemetry</source>
         <translation>Telemetri</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
         <source>Workout</source>
         <translation>Träningspass</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="106"/>
         <source>Realtime</source>
         <translation>Realtid</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
         <source>Pedal Stroke</source>
         <translatorcomment>???</translatorcomment>
         <translation>Tramptag</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="113"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
         <source>Live Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="114"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <source>Elevation Chart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
         <source>Web page</source>
         <translation>Hemsida</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
         <source>Map</source>
         <translation>Karta</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="71"/>
         <source>Season Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="72"/>
         <source>Blank Overview </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
         <source>R Chart</source>
         <translation>R Diagram</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="98"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
         <source>R Chart </source>
         <translation>R Diagram </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
         <source>Video Player</source>
         <translation>Video Spelare</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
         <source>Workout Editor</source>
         <translation>Träningspass Editor</translation>
     </message>
@@ -14760,142 +14753,147 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="296"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="294"/>
+        <source>Show elevation profile of instant position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
         <source>Predefined and configurable set of data ranges for selection of activities to be analysed</source>
         <translation>Förinställda och konfigurerbara tidsperioder för att välja vilka aktiviteter som skall analyseras</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
         <source>Powerful filter and search engine to determine the activities which are considered in diagram</source>
         <translation>Kraftfull sök och filtrerings funktion för att välja vilka aktiviteter som skall analyseras för diagram</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
         <source>Configurable list of activities</source>
         <translation>Konfigurerbar aktivitetslista</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="317"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
         <source>Configurable list of training devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
         <source>Configurable list of workout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
         <source>Configurable list of video files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="325"/>
         <source>Configurable list of video sync files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="327"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
         <source>Entry field for sophisticated Searching and Filtering of activities</source>
         <translation>Inmatningsfält för avancerad Sök och Filtrering av aktiviteter</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
         <source>Adding intervals to an activity using simple query methods</source>
         <translation>Lägg till intervaller till en aktivitet genom enkla sökmetoder</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
         <source>To compare Activities/Intervals in Activity View and Date Ranges in Trends View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="335"/>
         <source>Workout Control, Intensity Adjustments and Notifications Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
         <source>Athlete Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
         <source>Athlete Measures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
         <source>Auto Import</source>
         <translation type="unfinished">Auto Import</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
         <source>Backup</source>
         <translation type="unfinished">Säkerhetskopia</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="355"/>
         <source>Cloud Accounts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <source>Automatic Interval Detection</source>
         <translation>Automatisk Intervallidentifiering</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
         <source>Definition of coloring rules for activities</source>
         <translation>Inställning av aktiviteters färgscheman</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
         <source>Metrics shown in &apos;Intervals&apos; and &apos;Summary&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
         <source>User/Custom Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
         <source>Create or Edit a User Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
         <source>Measures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
         <source>Train View devices configuration and preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
         <source>Train View Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
         <source>Remote Controls Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
         <source>Add/Remove Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
         <source>Add Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="394"/>
         <source>Virtual Bicycle configuration for simulation rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14929,8 +14927,8 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
     </message>
     <message>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="219"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
         <source>Calendar</source>
         <translation>Kalender</translation>
     </message>
@@ -14965,74 +14963,74 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
         <translation>Diagramspecifika sök/filtrering och tidsperiods inställningar</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
         <source>Definition of points in time &apos;Events&apos; which are marked explicitely on time related diagrams</source>
         <translation>Definition av tidpunkter &apos;Händelser&apos; vilka markeras i tidsdiagram</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="316"/>
         <source>Simple summary view</source>
         <translation>Enkel sammanfattningsvy</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
         <source>Alternative access to the charts created for the main view</source>
         <translation>Alternativ åtkomst till diagram skapade för huvudvyn</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
         <source>Display the available and add new intervals using simple query methods</source>
         <translation>Visa de tillgängliga och lägg till nya intervall med hjälp av enkla sökmetoder</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="356"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
         <source>General</source>
         <translation>Generella</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="337"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
         <source>Athlete</source>
         <translation>Idrottare</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
         <source>Training Zone definition for power</source>
         <translation>Träningszoner för effekt</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
         <source>Training Zone definition for heartrate</source>
         <translation>Träningszoner för hjärtfrekvens</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
         <source>Training Zone definition for Swim and Run</source>
         <translation>Träningszoner för Simning och Löpning</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
         <source>Appearance</source>
         <translation>Utseende</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="364"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
         <source>Data Fields</source>
         <translation>Datafält</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
         <source>Definition of default value(s) for data fields</source>
         <translation>Inställning av datafältens utgångsvärden</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
         <source>Definition of processing default parameters for the fix, adjust,... tools</source>
         <translation>Inställning av behandlingsutgångsvärden för reparation, justering,... verktyg</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
         <source>Metrics</source>
         <translation>Mätetal</translation>
     </message>
@@ -15232,47 +15230,43 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2437"/>
         <source>Add</source>
-        <translation>Lägg till</translation>
+        <translation type="vanished">Lägg till</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2438"/>
         <source>Delete</source>
-        <translation>Radera</translation>
+        <translation type="vanished">Radera</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2431"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2432"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2447"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2332"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2458"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2343"/>
         <source>Short</source>
         <translation>Kort</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2459"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2344"/>
         <source>Long</source>
         <translation>Lång</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2460"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2345"/>
         <source>Percent of LT</source>
         <translation>Procent avr iLT</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2461"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2346"/>
         <source>Trimp k</source>
         <translation>TRIMP k</translation>
     </message>
@@ -15281,14 +15275,14 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
         <translation type="vanished">Maximalt antal zoner (10) nått.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2506"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2513"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2390"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2397"/>
         <source>New</source>
         <translation>Ny</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2508"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2515"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2392"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2399"/>
         <source>New (%1)</source>
         <translation>Ny (%1)</translation>
     </message>
@@ -15478,17 +15472,17 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2245"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2395"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2292"/>
         <source>Lactate Threshold</source>
         <translation>Laktattröskel (LT)l</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2396"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2293"/>
         <source>Default</source>
         <translation>Utgångsvärde</translation>
     </message>
@@ -17736,545 +17730,542 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
 <context>
     <name>LTMTool</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1303"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1272"/>
         <source>Metric</source>
         <translation>Mätetal</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="74"/>
+        <location filename="../../Charts/LTMTool.cpp" line="75"/>
         <source>Filter</source>
         <translation>Filter</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="80"/>
+        <location filename="../../Charts/LTMTool.cpp" line="81"/>
         <source>Date range</source>
         <translation>Tidsperiod</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="84"/>
+        <location filename="../../Charts/LTMTool.cpp" line="85"/>
         <source>Days</source>
         <translation>Dagar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="85"/>
+        <location filename="../../Charts/LTMTool.cpp" line="86"/>
         <source>Weeks</source>
         <translation>Veckor</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="86"/>
+        <location filename="../../Charts/LTMTool.cpp" line="87"/>
         <source>Months</source>
         <translation>Månader</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="87"/>
+        <location filename="../../Charts/LTMTool.cpp" line="88"/>
         <source>Years</source>
         <translation>År</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="88"/>
+        <location filename="../../Charts/LTMTool.cpp" line="89"/>
         <source>Time Of Day</source>
         <translation>Klockslag</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="89"/>
+        <location filename="../../Charts/LTMTool.cpp" line="90"/>
         <source>All</source>
         <translation>Alla</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="91"/>
+        <location filename="../../Charts/LTMTool.cpp" line="92"/>
         <source>Group by</source>
         <translation>Gruppera efter</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="102"/>
+        <location filename="../../Charts/LTMTool.cpp" line="103"/>
         <source>Shade Zones</source>
         <translation>Färglägg Zoner</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="105"/>
+        <location filename="../../Charts/LTMTool.cpp" line="106"/>
         <source>Show Legend</source>
         <translation>Visa Förklaring</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="109"/>
         <source>Show Events</source>
         <translation>Visa Tävlingar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="112"/>
         <source>Show Banister Helper</source>
         <translation>Visa Banister Helper</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="121"/>
+        <location filename="../../Charts/LTMTool.cpp" line="122"/>
         <source>Stack Zoom</source>
         <translation>Stabeldiagramzoom</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="146"/>
+        <location filename="../../Charts/LTMTool.cpp" line="147"/>
         <source>Charts</source>
         <translation>Diagram</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Up</source>
-        <translation>Upp</translation>
+        <translation type="vanished">Upp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Down</source>
-        <translation>Ner</translation>
+        <translation type="vanished">Ner</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="351"/>
+        <location filename="../../Charts/LTMTool.cpp" line="325"/>
         <source>Skiba Long Term Stress</source>
         <translation>Skiba Långtids Stress (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="353"/>
-        <location filename="../../Charts/LTMTool.cpp" line="368"/>
-        <location filename="../../Charts/LTMTool.cpp" line="429"/>
-        <location filename="../../Charts/LTMTool.cpp" line="444"/>
-        <location filename="../../Charts/LTMTool.cpp" line="505"/>
-        <location filename="../../Charts/LTMTool.cpp" line="520"/>
-        <location filename="../../Charts/LTMTool.cpp" line="580"/>
-        <location filename="../../Charts/LTMTool.cpp" line="595"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1080"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1095"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1156"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1171"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1309"/>
+        <location filename="../../Charts/LTMTool.cpp" line="327"/>
+        <location filename="../../Charts/LTMTool.cpp" line="342"/>
+        <location filename="../../Charts/LTMTool.cpp" line="403"/>
+        <location filename="../../Charts/LTMTool.cpp" line="418"/>
+        <location filename="../../Charts/LTMTool.cpp" line="479"/>
+        <location filename="../../Charts/LTMTool.cpp" line="494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="554"/>
+        <location filename="../../Charts/LTMTool.cpp" line="569"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1054"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1069"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1130"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1145"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1278"/>
         <source>Stress</source>
         <translation>Stress</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="366"/>
+        <location filename="../../Charts/LTMTool.cpp" line="340"/>
         <source>Skiba Short Term Stress</source>
         <translation>Skiba Korttids Stress (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="381"/>
+        <location filename="../../Charts/LTMTool.cpp" line="355"/>
         <source>Skiba Stress Balance</source>
         <translation>Skiba Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="383"/>
-        <location filename="../../Charts/LTMTool.cpp" line="459"/>
-        <location filename="../../Charts/LTMTool.cpp" line="535"/>
-        <location filename="../../Charts/LTMTool.cpp" line="610"/>
-        <location filename="../../Charts/LTMTool.cpp" line="686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="762"/>
-        <location filename="../../Charts/LTMTool.cpp" line="838"/>
-        <location filename="../../Charts/LTMTool.cpp" line="914"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1110"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1186"/>
+        <location filename="../../Charts/LTMTool.cpp" line="357"/>
+        <location filename="../../Charts/LTMTool.cpp" line="433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="509"/>
+        <location filename="../../Charts/LTMTool.cpp" line="584"/>
+        <location filename="../../Charts/LTMTool.cpp" line="660"/>
+        <location filename="../../Charts/LTMTool.cpp" line="736"/>
+        <location filename="../../Charts/LTMTool.cpp" line="812"/>
+        <location filename="../../Charts/LTMTool.cpp" line="888"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1160"/>
         <source>Stress Balance</source>
         <translation>Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="396"/>
+        <location filename="../../Charts/LTMTool.cpp" line="370"/>
         <source>Skiba STS Ramp</source>
         <translation>Skiba STS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="398"/>
-        <location filename="../../Charts/LTMTool.cpp" line="413"/>
-        <location filename="../../Charts/LTMTool.cpp" line="474"/>
-        <location filename="../../Charts/LTMTool.cpp" line="489"/>
-        <location filename="../../Charts/LTMTool.cpp" line="550"/>
-        <location filename="../../Charts/LTMTool.cpp" line="565"/>
-        <location filename="../../Charts/LTMTool.cpp" line="625"/>
-        <location filename="../../Charts/LTMTool.cpp" line="640"/>
-        <location filename="../../Charts/LTMTool.cpp" line="701"/>
-        <location filename="../../Charts/LTMTool.cpp" line="716"/>
-        <location filename="../../Charts/LTMTool.cpp" line="777"/>
-        <location filename="../../Charts/LTMTool.cpp" line="792"/>
-        <location filename="../../Charts/LTMTool.cpp" line="853"/>
-        <location filename="../../Charts/LTMTool.cpp" line="868"/>
-        <location filename="../../Charts/LTMTool.cpp" line="929"/>
-        <location filename="../../Charts/LTMTool.cpp" line="944"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1005"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1020"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1125"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1140"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1201"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1216"/>
+        <location filename="../../Charts/LTMTool.cpp" line="372"/>
+        <location filename="../../Charts/LTMTool.cpp" line="387"/>
+        <location filename="../../Charts/LTMTool.cpp" line="448"/>
+        <location filename="../../Charts/LTMTool.cpp" line="463"/>
+        <location filename="../../Charts/LTMTool.cpp" line="524"/>
+        <location filename="../../Charts/LTMTool.cpp" line="539"/>
+        <location filename="../../Charts/LTMTool.cpp" line="599"/>
+        <location filename="../../Charts/LTMTool.cpp" line="614"/>
+        <location filename="../../Charts/LTMTool.cpp" line="675"/>
+        <location filename="../../Charts/LTMTool.cpp" line="690"/>
+        <location filename="../../Charts/LTMTool.cpp" line="751"/>
+        <location filename="../../Charts/LTMTool.cpp" line="766"/>
+        <location filename="../../Charts/LTMTool.cpp" line="827"/>
+        <location filename="../../Charts/LTMTool.cpp" line="842"/>
+        <location filename="../../Charts/LTMTool.cpp" line="903"/>
+        <location filename="../../Charts/LTMTool.cpp" line="918"/>
+        <location filename="../../Charts/LTMTool.cpp" line="979"/>
+        <location filename="../../Charts/LTMTool.cpp" line="994"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1099"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1114"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1175"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1190"/>
         <source>Ramp</source>
         <translation>Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="411"/>
+        <location filename="../../Charts/LTMTool.cpp" line="385"/>
         <source>Skiba LTS Ramp</source>
         <translation>Skiba LTS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="427"/>
+        <location filename="../../Charts/LTMTool.cpp" line="401"/>
         <source>Aerobic TISS Long Term Stress</source>
         <translation>Aerob TISS Långtidsstress (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="442"/>
+        <location filename="../../Charts/LTMTool.cpp" line="416"/>
         <source>Aerobic TISS Short Term Stress</source>
         <translation>Aerob TISS Korttidsstress (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="457"/>
+        <location filename="../../Charts/LTMTool.cpp" line="431"/>
         <source>Aerobic TISS Stress Balance</source>
         <translation>Aerob TISS Stress Balans (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="472"/>
+        <location filename="../../Charts/LTMTool.cpp" line="446"/>
         <source>Aerobic TISS STS Ramp</source>
         <translation>Aerob TISS STS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="487"/>
+        <location filename="../../Charts/LTMTool.cpp" line="461"/>
         <source>Aerobic TISS LTS Ramp</source>
         <translation>Aerob TISS LTS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="503"/>
+        <location filename="../../Charts/LTMTool.cpp" line="477"/>
         <source>Anaerobic TISS Long Term Stress</source>
         <translation>Anaerob TISS Långtidsstress (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="518"/>
+        <location filename="../../Charts/LTMTool.cpp" line="492"/>
         <source>Anaerobic TISS Short Term Stress</source>
         <translation>Anaerob TISS Korttidsstress (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="533"/>
+        <location filename="../../Charts/LTMTool.cpp" line="507"/>
         <source>Anaerobic TISS Stress Balance</source>
         <translation>Anerob TISS Stress Balans (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="548"/>
+        <location filename="../../Charts/LTMTool.cpp" line="522"/>
         <source>Anaerobic TISS STS Ramp</source>
         <translation>Anerob TISS STS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="537"/>
         <source>Anaerobic TISS LTS Ramp</source>
         <translation>Anaerob TISS LTS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="578"/>
+        <location filename="../../Charts/LTMTool.cpp" line="552"/>
         <source>Daniels Long Term Stress</source>
         <translation>Daniels Långtidsdtress (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="593"/>
+        <location filename="../../Charts/LTMTool.cpp" line="567"/>
         <source>Daniels Short Term Stress</source>
         <translation>Daniels Korttidsstress (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="582"/>
         <source>Daniels Stress Balance</source>
         <translation>Daniels Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="623"/>
+        <location filename="../../Charts/LTMTool.cpp" line="597"/>
         <source>Daniels STS Ramp</source>
         <translation>Daniels STS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="638"/>
+        <location filename="../../Charts/LTMTool.cpp" line="612"/>
         <source>Daniels LTS Ramp</source>
         <translation>Daniels LTS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="628"/>
         <source>Work (Kj) Long Term Stress</source>
         <translation>Arbete (kJ) Långtidsstress (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="656"/>
-        <location filename="../../Charts/LTMTool.cpp" line="671"/>
-        <location filename="../../Charts/LTMTool.cpp" line="732"/>
-        <location filename="../../Charts/LTMTool.cpp" line="747"/>
-        <location filename="../../Charts/LTMTool.cpp" line="808"/>
-        <location filename="../../Charts/LTMTool.cpp" line="823"/>
+        <location filename="../../Charts/LTMTool.cpp" line="630"/>
+        <location filename="../../Charts/LTMTool.cpp" line="645"/>
+        <location filename="../../Charts/LTMTool.cpp" line="706"/>
+        <location filename="../../Charts/LTMTool.cpp" line="721"/>
+        <location filename="../../Charts/LTMTool.cpp" line="782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="797"/>
         <source>Stress (Kj)</source>
         <translation>Stress (kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="669"/>
+        <location filename="../../Charts/LTMTool.cpp" line="643"/>
         <source>Work (Kj) Short Term Stress</source>
         <translation>Arbete (kJ) Korttidsstress (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="684"/>
+        <location filename="../../Charts/LTMTool.cpp" line="658"/>
         <source>Work (Kj) Stress Balance</source>
         <translation>Arbete (kJ) Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="699"/>
+        <location filename="../../Charts/LTMTool.cpp" line="673"/>
         <source>Work (Kj) STS Ramp</source>
         <translation>Arbete (kJ) STS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="714"/>
+        <location filename="../../Charts/LTMTool.cpp" line="688"/>
         <source>Work (Kj) LTS Ramp</source>
         <translation>Arbete (kJ) LTS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="730"/>
+        <location filename="../../Charts/LTMTool.cpp" line="704"/>
         <source>W&apos; Work (Kj) Long Term Stress</source>
         <translation>W&apos; Arbete (kJ) Långtidsstress (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="745"/>
+        <location filename="../../Charts/LTMTool.cpp" line="719"/>
         <source>W&apos; Work (Kj) Short Term Stress</source>
         <translation>W&apos; Arbete (kJ) Korttidsstress (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="760"/>
+        <location filename="../../Charts/LTMTool.cpp" line="734"/>
         <source>W&apos; Work (Kj) Stress Balance</source>
         <translation>W&apos; Arbete (kJ) Stress Balans (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="775"/>
+        <location filename="../../Charts/LTMTool.cpp" line="749"/>
         <source>W&apos; Work (Kj) STS Ramp</source>
         <translation>W&apos; Arbete (kJ) STS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="790"/>
+        <location filename="../../Charts/LTMTool.cpp" line="764"/>
         <source>W&apos; Work (Kj) LTS Ramp</source>
         <translation>W&apos; Arbete (kJ) LTS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="806"/>
+        <location filename="../../Charts/LTMTool.cpp" line="780"/>
         <source>Below CP Work (Kj) Long Term Stress</source>
         <translation>Sub-CP-Arbete (kJ) Långtidsstress (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="821"/>
+        <location filename="../../Charts/LTMTool.cpp" line="795"/>
         <source>Below CP Work (Kj) Short Term Stress</source>
         <translation>Sub-CP-Arbete (kJ) Korttidsstress (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="836"/>
+        <location filename="../../Charts/LTMTool.cpp" line="810"/>
         <source>Below CP Work (Kj) Stress Balance</source>
         <translation>Sub-CP-Arbete CP (kJ) Stress Balans (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="851"/>
+        <location filename="../../Charts/LTMTool.cpp" line="825"/>
         <source>Below CP Work (Kj) STS Ramp</source>
         <translation>Sub-CP-Arbete CP (kJ) STS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="866"/>
+        <location filename="../../Charts/LTMTool.cpp" line="840"/>
         <source>Below CP Work (Kj) LTS Ramp</source>
         <translation>Sub-CP-Arbete (kJ) LTS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="882"/>
+        <location filename="../../Charts/LTMTool.cpp" line="856"/>
         <source>Distance (km|mi) Long Term Stress</source>
         <translation>Distans (km|mi) LTS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="884"/>
-        <location filename="../../Charts/LTMTool.cpp" line="899"/>
+        <location filename="../../Charts/LTMTool.cpp" line="858"/>
+        <location filename="../../Charts/LTMTool.cpp" line="873"/>
         <source>Stress (km|mi)</source>
         <translation>Stress (km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="897"/>
+        <location filename="../../Charts/LTMTool.cpp" line="871"/>
         <source>Distance (km|mi) Short Term Stress</source>
         <translation>Distans (km|mi) STS</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="912"/>
+        <location filename="../../Charts/LTMTool.cpp" line="886"/>
         <source>Distance (km|mi) Stress Balance</source>
         <translation>Distans (km|mi) Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="927"/>
+        <location filename="../../Charts/LTMTool.cpp" line="901"/>
         <source>Distance (km|mi) STS Ramp</source>
         <translation>Distans (km|mi) STS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="942"/>
+        <location filename="../../Charts/LTMTool.cpp" line="916"/>
         <source>Distance (km|mi) LTS Ramp</source>
         <translation>Distans (km|mi) LTS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="958"/>
+        <location filename="../../Charts/LTMTool.cpp" line="932"/>
         <source>Coggan Chronic Training Load</source>
         <translation>Coggan Kronisk Träningsbelastning</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="973"/>
+        <location filename="../../Charts/LTMTool.cpp" line="947"/>
         <source>Coggan Acute Training Load</source>
         <translation>Coggan Akut Träningsbelastning</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="988"/>
+        <location filename="../../Charts/LTMTool.cpp" line="962"/>
         <source>Coggan Training Stress Balance</source>
         <translation>Coggan Träning Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1003"/>
+        <location filename="../../Charts/LTMTool.cpp" line="977"/>
         <source>Coggan STS Ramp</source>
         <translation>Coggan STS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1018"/>
+        <location filename="../../Charts/LTMTool.cpp" line="992"/>
         <source>Coggan LTS Ramp</source>
         <translation>Coggan LTS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1033"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1007"/>
         <source>Coggan Expected Chronic Training Load</source>
         <translation>Coggan Förväntad Kronisk-Träningsbelastning</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1048"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1022"/>
         <source>Coggan Expected Acute Training Load</source>
         <translation>Coggan Förväntad Akut-Träningsbelastning</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1063"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1037"/>
         <source>Coggan Expected Training Stress Balance</source>
         <translation>Coggan Förväntad Träningsstressbalans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1053"/>
         <source>TRIMP Long Term Stress</source>
         <translation>TRIMP Långtidsstress (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1067"/>
         <source>TRIMP Short Term Stress</source>
         <translation>TRIMP Korttidsstress (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1082"/>
         <source>TRIMP Stress Balance</source>
         <translation>TRIMP Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1123"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1097"/>
         <source>TRIMP STS Ramp</source>
         <translation>TRIMP STS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1138"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1112"/>
         <source>TRIMP LTS Ramp</source>
         <translation>TRIMP LTS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="268"/>
         <source>Edit</source>
-        <translation>Editera</translation>
+        <translation type="vanished">Editera</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="124"/>
+        <location filename="../../Charts/LTMTool.cpp" line="125"/>
         <source>Use sidebar chart settings</source>
         <translation>Använd diagraminställningar på sidopanel</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Basic</source>
         <translation>Grundläggande</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="314"/>
+        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Preset</source>
         <translation>Förinställningar</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1128"/>
         <source>TriScore Long Term Stress</source>
         <translation>TriScore Långtidsstress (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1169"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1143"/>
         <source>TriScore Short Term Stress</source>
         <translation>TriScore Korttidsstress (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1184"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1158"/>
         <source>TriScore Stress Balance</source>
         <translation>TriScore Stress Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1173"/>
         <source>TriScore STS Ramp</source>
         <translation>TriScore STS Anstieg</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1214"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1188"/>
         <source>TriScore LTS Ramp</source>
         <translation>TriScore LTS Ramp</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1307"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1276"/>
         <source>Estimate</source>
         <translation>Uppskattning</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1311"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1280"/>
         <source>Formula</source>
         <translation>Formel</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1282"/>
         <source>Measure</source>
         <translation>Mått</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1284"/>
         <source>Performance</source>
         <translation>Prestation</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1317"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1286"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1463"/>
         <source>Chart %1</source>
         <translation>Diagram %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="94"/>
+        <location filename="../../Charts/LTMTool.cpp" line="95"/>
         <source>Data Table</source>
         <translation>Diagramdata</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="98"/>
+        <location filename="../../Charts/LTMTool.cpp" line="99"/>
         <source>Show Stack</source>
         <translation>Visa Stapel</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="155"/>
+        <location filename="../../Charts/LTMTool.cpp" line="156"/>
         <source>Add Current</source>
         <translation>Lägg till aktuell</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="155"/>
         <source>Apply</source>
         <translation>Tillämpa</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="289"/>
         <source>Curves</source>
         <translation>Kurvor</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Details</source>
         <translation>Detaljer</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1305"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1274"/>
         <source>Peak</source>
         <translation>Topp</translation>
     </message>
@@ -18477,50 +18468,42 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
         <translation type="vanished">Uppdatera</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2590"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2602"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2591"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2603"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2596"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2608"/>
         <source>Add</source>
-        <translation>Lägg till</translation>
+        <translation type="vanished">Lägg till</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2597"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2609"/>
         <source>Delete</source>
-        <translation>Radera</translation>
+        <translation type="vanished">Radera</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2599"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2467"/>
         <source>Def</source>
         <translation>Default</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2628"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2690"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2770"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2775"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2780"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2785"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2473"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2478"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2488"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2611"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2621"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2626"/>
         <source>bpm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2650"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2493"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2630"/>
         <source>Start Date</source>
         <translation type="unfinished">Startdatum</translation>
     </message>
@@ -18529,27 +18512,27 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
         <translation type="vanished">Start Datum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2651"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2790"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2494"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2631"/>
         <source>Lactate Threshold</source>
         <translatorcomment>which one of all?</translatorcomment>
         <translation>Laktattröskel</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2652"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2791"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2495"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2632"/>
         <source>Aerobic Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2653"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2496"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
         <source>Rest HR</source>
         <translation>Vilopuls</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2654"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2497"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2634"/>
         <source>Max HR</source>
         <translation>Maxpuls</translation>
     </message>
@@ -18558,22 +18541,22 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
         <translation type="vanished">dd.MMM yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2701"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2544"/>
         <source>Short</source>
         <translation>Zon</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2702"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2545"/>
         <source>Long</source>
         <translation>Lång</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2703"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2546"/>
         <source>From BPM</source>
         <translation>Startpuls</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2704"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2547"/>
         <source>Trimp k</source>
         <translation>TRIMP K</translation>
     </message>
@@ -18582,14 +18565,14 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
         <translation type="vanished">Maximalt antal zoner (10) uppnått.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2967"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2974"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2804"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2811"/>
         <source>New</source>
         <translation>Ny</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2969"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2976"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2806"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2813"/>
         <source>New (%1)</source>
         <translation>Ny (%1)</translation>
     </message>
@@ -19330,62 +19313,62 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
 <context>
     <name>Library</name>
     <message>
+        <location filename="../../Train/Library.cpp" line="126"/>
         <location filename="../../Train/Library.cpp" line="130"/>
-        <location filename="../../Train/Library.cpp" line="134"/>
         <source>Import Videos, VideoSyncs and Workouts</source>
         <translation>Importera Videor, VideoSyncs och Träningspass</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="127"/>
         <location filename="../../Train/Library.cpp" line="131"/>
-        <location filename="../../Train/Library.cpp" line="135"/>
         <source>No supported videos, videoSyncs or workouts were found to import</source>
         <translation>Hittade inga stödda Videor, VideoSyncs eller Träningspass att importera</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="189"/>
         <location filename="../../Train/Library.cpp" line="193"/>
-        <location filename="../../Train/Library.cpp" line="197"/>
+        <location filename="../../Train/Library.cpp" line="198"/>
         <location filename="../../Train/Library.cpp" line="202"/>
-        <location filename="../../Train/Library.cpp" line="206"/>
         <source>Copy VideoSync Failed</source>
         <translation>Kopieringen av VideoSync gick fel</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="190"/>
         <location filename="../../Train/Library.cpp" line="194"/>
-        <location filename="../../Train/Library.cpp" line="198"/>
         <source>%1 already exists in videoSync library: %2</source>
         <translation>%1 finns redan i VideoSync biblioteket: %2</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="203"/>
+        <location filename="../../Train/Library.cpp" line="199"/>
         <source>%1 cannot be written to videoSync library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="207"/>
+        <location filename="../../Train/Library.cpp" line="203"/>
         <source>%1 cannot be written to videoSync library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="253"/>
+        <location filename="../../Train/Library.cpp" line="249"/>
         <source>%1 cannot be written to workout library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="257"/>
+        <location filename="../../Train/Library.cpp" line="253"/>
         <source>%1 cannot be written to workout library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="239"/>
         <location filename="../../Train/Library.cpp" line="243"/>
-        <location filename="../../Train/Library.cpp" line="247"/>
+        <location filename="../../Train/Library.cpp" line="248"/>
         <location filename="../../Train/Library.cpp" line="252"/>
-        <location filename="../../Train/Library.cpp" line="256"/>
         <source>Copy Workout Failed</source>
         <translation>Kopieringen av Träningpasset gick fel</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="240"/>
         <location filename="../../Train/Library.cpp" line="244"/>
-        <location filename="../../Train/Library.cpp" line="248"/>
         <source>%1 already exists in workout library: %2</source>
         <translation>%1 finns redan i Träningspass biblioteket: %2 vorhanden</translation>
     </message>
@@ -19393,89 +19376,89 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
 <context>
     <name>LibrarySearchDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="330"/>
+        <location filename="../../Train/Library.cpp" line="326"/>
         <source>Search for Workouts, Syncs and Media</source>
         <translation>Sök Träningspass, VideoSyncs och Media</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="337"/>
+        <location filename="../../Train/Library.cpp" line="333"/>
         <source>Workout files (.erg, .mrc, .zwo etc)</source>
         <translation>Träningspassfiler (.erg, .mrc, .zwo,...)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="339"/>
+        <location filename="../../Train/Library.cpp" line="335"/>
         <source>Video files (.mp4, .avi etc)</source>
         <translation>Videofiler (.mp4, .avi usw)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="341"/>
+        <location filename="../../Train/Library.cpp" line="337"/>
         <source>VideoSync files (.rlv, .tts etc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="359"/>
+        <location filename="../../Train/Library.cpp" line="353"/>
         <source>Search Path</source>
         <translation>Sök Path</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="379"/>
+        <location filename="../../Train/Library.cpp" line="373"/>
         <source>Video references</source>
         <translation>Video referenser</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="391"/>
+        <location filename="../../Train/Library.cpp" line="385"/>
         <source>Searching...</source>
         <translation>Söker...</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="394"/>
+        <location filename="../../Train/Library.cpp" line="388"/>
         <source>Videos</source>
         <translation>Videor</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="396"/>
+        <location filename="../../Train/Library.cpp" line="390"/>
         <source>Workouts</source>
         <translation>Träningspass</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="398"/>
+        <location filename="../../Train/Library.cpp" line="392"/>
         <source>VideoSyncs</source>
         <translation>VideoSyncs</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="407"/>
-        <location filename="../../Train/Library.cpp" line="494"/>
+        <location filename="../../Train/Library.cpp" line="401"/>
+        <location filename="../../Train/Library.cpp" line="484"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="409"/>
+        <location filename="../../Train/Library.cpp" line="403"/>
         <source>Search</source>
         <translation>Sök</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="412"/>
+        <location filename="../../Train/Library.cpp" line="406"/>
         <source>Files to search for:</source>
         <translation>Filer att söka:</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="475"/>
+        <location filename="../../Train/Library.cpp" line="466"/>
         <source>Abort Search</source>
         <translation>Avbryt Sökning</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="515"/>
-        <location filename="../../Train/Library.cpp" line="559"/>
+        <location filename="../../Train/Library.cpp" line="504"/>
+        <location filename="../../Train/Library.cpp" line="548"/>
         <source>Save</source>
         <translation>Spara</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="557"/>
+        <location filename="../../Train/Library.cpp" line="546"/>
         <source>Search completed.</source>
         <translation>Sökning klar.</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="645"/>
+        <location filename="../../Train/Library.cpp" line="634"/>
         <source>Select Directory</source>
         <translation>Välj Mapp</translation>
     </message>
@@ -19483,12 +19466,12 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
 <context>
     <name>ListEditWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="623"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="654"/>
         <source>New</source>
         <translation type="unfinished">Ny</translation>
     </message>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="625"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="656"/>
         <source>New (%1)</source>
         <translation type="unfinished">Ny (%1)</translation>
     </message>
@@ -19501,7 +19484,12 @@ Vridmomentsoffset - Anges i Nm (eller ibs*inch). Negativa tal minskarvridmomente
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="90"/>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="85"/>
+        <source>Initial Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="98"/>
         <source>Apply changes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19721,7 +19709,7 @@ och att det står &quot;PC Link&quot; på dess display</translation>
         <translation>Sidopanel av/på</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>Delete Activity</source>
         <translation>Radera Aktivitet</translation>
     </message>
@@ -19776,51 +19764,51 @@ och att det står &quot;PC Link&quot; på dess display</translation>
         <translation>Exportera mätetal som .CSV...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Chart Import</source>
         <translation>Diagram Import</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1778"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1788"/>
         <source>Failed to export activity, please check permissions</source>
         <translation>Mislyckades exportera aktivitet, vänligen kontrollera rättigheter</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1814"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1824"/>
         <source>No Activity To Save</source>
         <translation>Ingen Aktivitet Att Spara</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1815"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1825"/>
         <source>There is no currently selected activity to save.</source>
         <translation>Ingen vald aktivitet att spara.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
         <location filename="../../Gui/MainWindow.cpp" line="1886"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Split Activity</source>
         <translation>Dela upp Aktivitet</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
         <source>No activity selected</source>
         <translation>Ingen aktivitet vald</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
         <source>Current activity contains no data to split</source>
         <translation>Nuvarande aktivitet innehåller inget data att dela upp</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Current activity contains no data to merge</source>
         <translation>Nuvarande aktivitet innehåller inget data att foga samman</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1904"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1914"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation>Är du säker på att du vill radera aktiviteten:</translation>
     </message>
@@ -19865,23 +19853,23 @@ och att det står &quot;PC Link&quot; på dess display</translation>
         <translation>Vill du återställa?</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
         <source>Select Activity</source>
         <translation>Välj Aktivitet</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>No activity selected!</source>
         <translation>Ingen aktivitet vald!</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1724"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1734"/>
         <source>Export Activity</source>
         <translation>Exportera Aktivitet</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1777"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1787"/>
         <source>Export Failed</source>
         <translation>Export Misslyckades</translation>
     </message>
@@ -19957,26 +19945,26 @@ och att det står &quot;PC Link&quot; på dess display</translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Activity Import</source>
         <translation>Aktivitet Import</translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Closing of athlete window not possible while background activity import is in progress...</source>
         <translation>Går inte att stänga idrottarens fönster då en aktivitet fortfarande importerars (i bakgrunden)...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2165"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2175"/>
         <source>&amp;New Athlete...</source>
         <translation>&amp;Ny Idrottare...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2400"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2421"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2410"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2431"/>
         <source>The workout directory is not configured, or the directory selected no longer exists.
 
 Please check your preference settings.</source>
@@ -19985,19 +19973,19 @@ Please check your preference settings.</source>
 Vänligen kontrollera inställningarna.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2611"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2621"/>
         <source>Loading activities: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>CloudDB</source>
         <translation>CloudDB</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>Current athlete is not registered as curator - please contact the GoldenCheetah team</source>
         <translation>Nuvarande idrottare är inte registrerad som granskare - vänligen kontakta GoldenCheetah teamet</translation>
     </message>
@@ -20345,59 +20333,59 @@ Vänligen kontrollera inställningarna.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Imported %1 metric charts</source>
         <translation>Importerade %1 Mätetalsdiagram</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>Import Images Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>You can only import images on the activities view with an activity selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>Import Images to Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>%1 images imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1799"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2369"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1809"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2379"/>
         <source>Import from File</source>
         <translation>Importera från Fil</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2342"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2352"/>
         <source>Refresh in Progress</source>
         <translation>Uppdatering Pågår</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Export Metrics</source>
         <translation>Exportera Mätetal</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation>Comma Separated Values (*.csv)</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2399"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2420"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2409"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2430"/>
         <source>Workout Directory Invalid</source>
         <translation>Träningspassmappen Ogiltig</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1906"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1916"/>
         <source>Delete</source>
         <translation>Radera</translation>
     </message>
@@ -21301,23 +21289,23 @@ Vänligen kontrollera inställningarna.</translation>
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="656"/>
+        <location filename="../../Gui/AthletePages.cpp" line="641"/>
         <source>From Date - Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="780"/>
+        <location filename="../../Gui/AthletePages.cpp" line="751"/>
         <source>Start Date</source>
         <translation type="unfinished">Startdatum</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="893"/>
+        <location filename="../../Gui/AthletePages.cpp" line="864"/>
         <source>MMM d, yyyy - hh:mm:ss</source>
         <translation type="unfinished">MMM d, yyyy - hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="659"/>
-        <location filename="../../Gui/AthletePages.cpp" line="807"/>
+        <location filename="../../Gui/AthletePages.cpp" line="644"/>
+        <location filename="../../Gui/AthletePages.cpp" line="778"/>
         <source>Comment</source>
         <translation type="unfinished">Kommentar</translation>
     </message>
@@ -21326,32 +21314,28 @@ Vänligen kontrollera inställningarna.</translation>
         <translation type="obsolete">Uppdatera</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="662"/>
         <source>+</source>
-        <translation type="unfinished">+</translation>
+        <translation type="obsolete">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="663"/>
         <source>-</source>
-        <translation type="unfinished">-</translation>
+        <translation type="obsolete">-</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="obsolete">Lägg till</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="obsolete">Radera</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="668"/>
-        <source>Add</source>
-        <translation type="unfinished">Lägg till</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="669"/>
-        <source>Delete</source>
-        <translation type="unfinished">Radera</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="698"/>
         <source>Source</source>
         <translation type="unfinished">Källa</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="699"/>
+        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Original Source</source>
         <translation type="unfinished">Ursprunglig Källa</translation>
     </message>
@@ -22040,17 +22024,17 @@ Inga Aktiviteter att importera.
 <context>
     <name>MultiDeviceDialog</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3048"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3060"/>
         <source>Multiple Device Configuration</source>
         <translation>Konfigurera Flera Enheter</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3103"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3115"/>
         <source>Cancel</source>
         <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3106"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3118"/>
         <source>Apply</source>
         <translation type="unfinished">Tillämpa</translation>
     </message>
@@ -23060,42 +23044,38 @@ Inga Aktiviteter att importera.
 <context>
     <name>PaceSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3154"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3155"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3160"/>
         <source>Add</source>
-        <translation>Lägg till</translation>
+        <translation type="vanished">Lägg till</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3161"/>
         <source>Delete</source>
-        <translation>Radera</translation>
+        <translation type="vanished">Radera</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3176"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2987"/>
         <source>Short</source>
         <translation>Kort</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3177"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2988"/>
         <source>Long</source>
         <translation>Lång</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3178"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2989"/>
         <source>Percent of CV</source>
         <translation>Procent av CV</translation>
     </message>
@@ -23104,14 +23084,14 @@ Inga Aktiviteter att importera.
         <translation type="vanished">Maximala antalet zoner (10) uppnått.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3220"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3227"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3037"/>
         <source>New</source>
         <translation>Ny</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3222"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3229"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3032"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3039"/>
         <source>New (%1)</source>
         <translation>Ny (%1)</translation>
     </message>
@@ -23311,27 +23291,27 @@ Inga Aktiviteter att importera.
 <context>
     <name>PaceZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3082"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2905"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3084"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2907"/>
         <source>Run</source>
         <translation>Löpa</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3085"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2908"/>
         <source>Swim</source>
         <translation>Simma</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3126"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2949"/>
         <source>Critical Velocity</source>
         <translation>Critical Velocity (CV)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2950"/>
         <source>Default</source>
         <translation>Utgångsvärde</translation>
     </message>
@@ -25479,78 +25459,71 @@ Vill du göra detta?</translation>
 <context>
     <name>PerspectiveDialog</name>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="34"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="35"/>
         <source>Manage Perspectives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="43"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="44"/>
         <source>Perspectives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="60"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="61"/>
         <source>Charts</source>
         <translation type="unfinished">Diagram</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="83"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="78"/>
         <source>Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="84"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="77"/>
         <source>Export</source>
         <translation type="unfinished">Exportieren</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="90"/>
         <source>Add</source>
-        <translation type="unfinished">Lägg till</translation>
+        <translation type="obsolete">Lägg till</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="91"/>
         <source>Delete</source>
-        <translation type="unfinished">Radera</translation>
+        <translation type="obsolete">Radera</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="98"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Drag charts to move to a perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="287"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="256"/>
         <source>Export Persepctive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
         <source>Export Perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>No perspective file selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
-        <source>Select Perspective file to export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
         <source>GoldenCheetah Perspective Files (*.gchartset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
+        <source>Select Perspective file to import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>Import Perspective</source>
         <translation type="unfinished"></translation>
     </message>
@@ -26712,307 +26685,307 @@ Python stängs av i  inställningarna.</translation>
 <context>
     <name>RealtimeData</name>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="621"/>
+        <location filename="../../Train/RealtimeData.cpp" line="623"/>
         <source>None</source>
         <translation>Inga</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="624"/>
+        <location filename="../../Train/RealtimeData.cpp" line="626"/>
         <source>Time</source>
         <translation>Tid</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="627"/>
+        <location filename="../../Train/RealtimeData.cpp" line="629"/>
         <source>Lap</source>
         <translation>Varv</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="630"/>
+        <location filename="../../Train/RealtimeData.cpp" line="632"/>
         <source>Lap Time</source>
         <translation>Mellantid</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="633"/>
+        <location filename="../../Train/RealtimeData.cpp" line="635"/>
         <source>Lap Time Remaining</source>
         <translation>Kvarvarande Mellantid</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="636"/>
+        <location filename="../../Train/RealtimeData.cpp" line="638"/>
         <source>Section Time Remaining</source>
         <translation>Sektion kvarvarande tid</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="639"/>
+        <location filename="../../Train/RealtimeData.cpp" line="641"/>
         <source>BikeStress</source>
         <translation>BikeStress</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="645"/>
+        <location filename="../../Train/RealtimeData.cpp" line="647"/>
         <source>kJoules</source>
         <translation>kJoule</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="648"/>
+        <location filename="../../Train/RealtimeData.cpp" line="650"/>
         <source>W&apos; bal</source>
         <translation>W&apos;bal</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="651"/>
+        <location filename="../../Train/RealtimeData.cpp" line="653"/>
         <source>XPower</source>
         <translation>XPower</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="654"/>
+        <location filename="../../Train/RealtimeData.cpp" line="656"/>
         <source>Iso Power</source>
         <translation>Iso Power</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="657"/>
+        <location filename="../../Train/RealtimeData.cpp" line="659"/>
         <source>Intensity Factor</source>
         <translation>Intensity Factor</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="660"/>
+        <location filename="../../Train/RealtimeData.cpp" line="662"/>
         <source>Relative Intensity</source>
         <translation>Relative Intensity</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="663"/>
+        <location filename="../../Train/RealtimeData.cpp" line="665"/>
         <source>Skiba Variability Index</source>
         <translation>Skiba Variability Index</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="666"/>
+        <location filename="../../Train/RealtimeData.cpp" line="668"/>
         <source>Variability Index</source>
         <translation>Variability Index</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="669"/>
+        <location filename="../../Train/RealtimeData.cpp" line="671"/>
         <source>Distance</source>
         <translation>Distans</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="672"/>
+        <location filename="../../Train/RealtimeData.cpp" line="674"/>
         <source>Route Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="675"/>
+        <location filename="../../Train/RealtimeData.cpp" line="677"/>
         <source>Distance Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="678"/>
+        <location filename="../../Train/RealtimeData.cpp" line="680"/>
         <source>Alternate Power</source>
         <translation>Alternativ Effekt</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="681"/>
+        <location filename="../../Train/RealtimeData.cpp" line="683"/>
         <source>Power</source>
         <translation>Effekt</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="684"/>
+        <location filename="../../Train/RealtimeData.cpp" line="686"/>
         <source>Speed</source>
         <translation>Fart</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="687"/>
+        <location filename="../../Train/RealtimeData.cpp" line="689"/>
         <source>Virtual Speed</source>
         <translation>Virtuell Fart</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="690"/>
+        <location filename="../../Train/RealtimeData.cpp" line="692"/>
         <source>Cadence</source>
         <translation>Kadens</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="693"/>
+        <location filename="../../Train/RealtimeData.cpp" line="695"/>
         <source>Heart Rate</source>
         <translation>Hjärtfrekvens</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="696"/>
+        <location filename="../../Train/RealtimeData.cpp" line="698"/>
         <source>Target Power</source>
         <translation>Måleffekt</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="699"/>
+        <location filename="../../Train/RealtimeData.cpp" line="701"/>
         <source>Average Power</source>
         <translation>Medeleffekt</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="702"/>
+        <location filename="../../Train/RealtimeData.cpp" line="704"/>
         <source>Average Speed</source>
         <translation>Medelfart</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="705"/>
+        <location filename="../../Train/RealtimeData.cpp" line="707"/>
         <source>Average Heartrate</source>
         <translation>Medelpuls</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="708"/>
+        <location filename="../../Train/RealtimeData.cpp" line="710"/>
         <source>Average Cadence</source>
         <translation>Medelkadens</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="711"/>
+        <location filename="../../Train/RealtimeData.cpp" line="713"/>
         <source>Lap Power</source>
         <translation>Varv Effekt</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="714"/>
+        <location filename="../../Train/RealtimeData.cpp" line="716"/>
         <source>Lap Speed</source>
         <translation>Varv Fart</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="717"/>
+        <location filename="../../Train/RealtimeData.cpp" line="719"/>
         <source>Lap Heartrate</source>
         <translation>Varv Puls</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="720"/>
+        <location filename="../../Train/RealtimeData.cpp" line="722"/>
         <source>Lap Cadence</source>
         <translation>Varv Kadens</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="723"/>
+        <location filename="../../Train/RealtimeData.cpp" line="725"/>
         <source>Left/Right Balance</source>
         <translation>V/H-Balans</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="726"/>
+        <location filename="../../Train/RealtimeData.cpp" line="728"/>
         <source>Total Hb Mass</source>
         <translation>Total Hb Massa</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="729"/>
+        <location filename="../../Train/RealtimeData.cpp" line="731"/>
         <source>Hb O2 Saturation</source>
         <translation>Hb O2 Saturation</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="732"/>
+        <location filename="../../Train/RealtimeData.cpp" line="734"/>
         <source>Deoxy Hb</source>
         <translation>Hb utan syre</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="735"/>
+        <location filename="../../Train/RealtimeData.cpp" line="737"/>
         <source>Oxy Hb</source>
         <translation>Hb med syre</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="738"/>
+        <location filename="../../Train/RealtimeData.cpp" line="740"/>
         <source>Left Torque Effectiveness</source>
         <translation>Vä Rundtrampseffektivitet</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="741"/>
+        <location filename="../../Train/RealtimeData.cpp" line="743"/>
         <source>Right Torque Effectiveness</source>
         <translation>Hö Rundtrampseffektivitet</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="744"/>
+        <location filename="../../Train/RealtimeData.cpp" line="746"/>
         <source>Left Pedal Smoothness</source>
         <translation>Vä Pedaljämnhet</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="747"/>
+        <location filename="../../Train/RealtimeData.cpp" line="749"/>
         <source>Right Pedal Smoothness</source>
         <translation>Hö Pedaljämnhet</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="750"/>
+        <location filename="../../Train/RealtimeData.cpp" line="752"/>
         <source>Right Power Phase Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="753"/>
+        <location filename="../../Train/RealtimeData.cpp" line="755"/>
         <source>Right Power Phase End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="756"/>
+        <location filename="../../Train/RealtimeData.cpp" line="758"/>
         <source>Right Power Phase Peak Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="759"/>
+        <location filename="../../Train/RealtimeData.cpp" line="761"/>
         <source>Right Power Phase Peak End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="762"/>
+        <location filename="../../Train/RealtimeData.cpp" line="764"/>
         <source>Slope</source>
         <translation>Lutning</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="765"/>
+        <location filename="../../Train/RealtimeData.cpp" line="767"/>
         <source>Lap Distance</source>
         <translation>Varvdistans</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="768"/>
+        <location filename="../../Train/RealtimeData.cpp" line="770"/>
         <source>Lap Distance Remaining</source>
         <translation>Kvarvarande Varvdistans</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="771"/>
+        <location filename="../../Train/RealtimeData.cpp" line="773"/>
         <source>Latitude</source>
         <translation>Latitud</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="774"/>
+        <location filename="../../Train/RealtimeData.cpp" line="776"/>
         <source>Longitude</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="777"/>
+        <location filename="../../Train/RealtimeData.cpp" line="779"/>
         <source>Altitude</source>
         <translation>Höjd</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="780"/>
+        <location filename="../../Train/RealtimeData.cpp" line="782"/>
         <source>Respiratory Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="783"/>
+        <location filename="../../Train/RealtimeData.cpp" line="785"/>
         <source>Ventilation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="786"/>
+        <location filename="../../Train/RealtimeData.cpp" line="788"/>
         <source>VO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="789"/>
+        <location filename="../../Train/RealtimeData.cpp" line="791"/>
         <source>VCO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="792"/>
+        <location filename="../../Train/RealtimeData.cpp" line="794"/>
         <source>Respiratory Exchange Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="795"/>
+        <location filename="../../Train/RealtimeData.cpp" line="797"/>
         <source>Tidal Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="798"/>
+        <location filename="../../Train/RealtimeData.cpp" line="800"/>
         <source>Fraction O2 Expired</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="801"/>
+        <location filename="../../Train/RealtimeData.cpp" line="803"/>
         <source>Temperature</source>
         <translation type="unfinished">Temperatur</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="804"/>
+        <location filename="../../Train/RealtimeData.cpp" line="806"/>
         <source>CoreTemp</source>
         <translation type="unfinished"></translation>
     </message>
@@ -27108,22 +27081,22 @@ Python stängs av i  inställningarna.</translation>
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Series</source>
         <translation>Dataserie</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="172"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
         <source>Power</source>
         <translation>Effekt</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="176"/>
         <source>Heart Rate</source>
         <translation>Hjärtfrekvens</translation>
     </message>
@@ -29423,318 +29396,318 @@ Skall konvertering ske?
 <context>
     <name>ScatterPlot</name>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="113"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
         <source>Power (watts)</source>
         <translation>Effekt (watt)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
         <source>Cadence (rpm)</source>
         <translation>Kadens (varv/min)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="116"/>
         <source>Heartrate (bpm)</source>
         <translation>Hjärtfrekvens (1/min)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="118"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="119"/>
         <source>Speed (kph)</source>
         <translation>Fart (km/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="120"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="121"/>
         <source>Speed (mph)</source>
         <translation>Fart (mph)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="124"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="125"/>
         <source>Altitude (meters)</source>
         <translation>Höjd (m ö.h.)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="126"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="127"/>
         <source>Altitude (feet)</source>
         <translation>Höjd (fot)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="128"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
         <source>Torque (N)</source>
         <translatorcomment>??? N is Force, Torque is Nm</translatorcomment>
         <translation>Vridmoment (Nm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="130"/>
         <source>Elapsed Time (secs)</source>
         <translation>Använd Tid (sek)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="132"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="133"/>
         <source>Elapsed Distance (km)</source>
         <translation>Tillryggalagd Distans (km)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="134"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="135"/>
         <source>Elapsed Distance (mi)</source>
         <translation>Tillryggalagd Distans (mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="136"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
         <source>Interval Number</source>
         <translation>Intervallnummer</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
         <source>Latitude (degree offset)</source>
         <translation>Latitud (grad offset)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
         <source>Longitude (degree offset)</source>
         <translation>Longitud (grad offset)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
         <source>Circumferential Pedal Velocity (m/s)</source>
         <translation>Pedalens periferihastighet (m/s)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="141"/>
         <source>Average Effective Pedal Force (N)</source>
         <translation>Genomsnittlig Effektiv Pedalkraft (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="144"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
         <source>Time at X/Y (%)</source>
         <translation>Tid vid X/Y (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
         <source>Power Zone</source>
         <translation>Effektzon</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
         <source>Headwind (kph)</source>
         <translation>Motvind (km/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
         <source>Slope (gradient)</source>
         <translation>Lutning</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
         <source>Temperature (C)</source>
         <translation>Temperatur (C)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
         <source>L/R Balance</source>
         <translation>Vä/Hö Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
         <source>Torque Efficiency</source>
         <translation>Rundtrampseffektivitet</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
         <source>Pedal Smoothness</source>
         <translation>Pedaljämnhet</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
         <source>Running Vertical Oscillation</source>
         <translation>Löpning Vertikal Rörelse</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
         <source>Running Ground Contact Time</source>
         <translation>Löpning Stöttid</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
         <source>Running Cadence</source>
         <translation>Stegfrekvens</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
         <source>Gear Ratio</source>
         <translation>Utväxling</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
         <source>Muscle Oxygen</source>
         <translation>Muskelsyresättning</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
         <source>Haemoglobin Mass</source>
         <translation>Hemoglobinmassa</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
         <source>Deoxygenated Haemoglobin</source>
         <translation>Hemoglobin utan syre</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="160"/>
         <source>Oxygenated Haemoglobin</source>
         <translation>Hemoglobin med syre</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="161"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="162"/>
         <source>Unknown</source>
         <translation>Okänd</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="165"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
         <source>Power</source>
         <translation>Effekt</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
         <source>Cadence</source>
         <translation>Kadens</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
         <source>Heartrate</source>
         <translation>Hjärtfrekvens</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
         <source>Speed</source>
         <translation>Fart</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
         <source>Altitude</source>
         <translation>Höjd</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
         <source>Pedal Force</source>
         <translation>Pedalkraft</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
         <source>Time</source>
         <translation>Tid</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
         <source>Distance</source>
         <translation>Distans</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
         <source>Interval</source>
         <translation>Intervall</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
         <source>Latitude</source>
         <translation>Latitud</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
         <source>Longitude</source>
         <translation>Longitud</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
         <source>Time at X/Y</source>
         <translation>Tid vid X/Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
         <source>Zone</source>
         <translation>Zon</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
         <source>CPV</source>
         <translation>CPV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
         <source>AEPF</source>
         <translation>AEPF</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
         <source>Headwind</source>
         <translation>Motvind</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
         <source>Slope</source>
         <translation>Lutning</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
         <source>Temp</source>
         <translation>Temperatur</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
         <source>Balance</source>
         <translation>Balans</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
         <source>TE</source>
         <translation>TE</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
         <source>PS</source>
         <translation>PS</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
         <source>RV</source>
         <translation>RV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
         <source>GCT</source>
         <translation>GCT</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
         <source>Run Cad</source>
         <translation>Stegfrekvens</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
         <source>Gear</source>
         <translation>Växel</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="194"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="195"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="196"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
@@ -29972,42 +29945,38 @@ Skall konvertering ske?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1012"/>
         <source>Add</source>
-        <translation>Lägg till</translation>
+        <translation type="vanished">Lägg till</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1013"/>
         <source>Delete</source>
-        <translation>Radera</translation>
+        <translation type="vanished">Radera</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1006"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1007"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1023"/>
+        <location filename="../../Gui/AthletePages.cpp" line="982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="988"/>
         <source>Short</source>
         <translation>Kort</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="989"/>
         <source>Long</source>
         <translation>Lång</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1031"/>
+        <location filename="../../Gui/AthletePages.cpp" line="990"/>
         <source>Percent of CP</source>
         <translation>Procent av CP</translation>
     </message>
@@ -30016,14 +29985,14 @@ Skall konvertering ske?
         <translation type="vanished">Maximala antalet zoner (10) uppnått.</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1069"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1076"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1034"/>
         <source>New</source>
         <translation>Ny</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1071"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1078"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1036"/>
         <source>New (%1)</source>
         <translation>Ny (%1)</translation>
     </message>
@@ -30196,64 +30165,64 @@ Skall konvertering ske?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3821"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3569"/>
         <source>Add</source>
         <translation>Lägg till</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3822"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3570"/>
         <source>Delete</source>
         <translation>Radera</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3823"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3571"/>
         <source>Up</source>
         <translation>Upp</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3824"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3572"/>
         <source>Down</source>
         <translation>Ner</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3870"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3872"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3963"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3965"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3711"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3713"/>
         <source>ddd MMM d, yyyy</source>
         <translation>ddd, d.MMM yyyy</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3557"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3810"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3558"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3804"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3835"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3583"/>
         <source>Name</source>
         <translation>Namn</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3805"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3836"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3553"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3584"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3806"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3837"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3554"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3585"/>
         <source>From</source>
         <translation>Början</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3807"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3838"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3555"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3586"/>
         <source>To</source>
         <translation>Slut</translation>
     </message>
@@ -32559,25 +32528,25 @@ tab.</source>
 <context>
     <name>TrainSidebar</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="253"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="257"/>
         <source>Save workout data</source>
         <translation>Spara träningspassdata</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="259"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="263"/>
         <source>Devices</source>
         <translation>Enheter</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="262"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="267"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="311"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="321"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="271"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="315"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="325"/>
         <source>Menu</source>
         <translation>Meny</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="270"/>
         <source>Workouts</source>
         <translation>Träningspass</translation>
     </message>
@@ -32586,143 +32555,143 @@ tab.</source>
         <translation type="obsolete">Filter...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="303"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="307"/>
         <source>Workout Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="310"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="314"/>
         <source>Media</source>
         <translation>Media</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="320"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="324"/>
         <source>VideoSync</source>
         <translation>VideoSync</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="506"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
         <source>Import Workout from File</source>
         <translation>Importera Träningspass från Fil</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="507"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="511"/>
         <source>Get Workouts from TrainerDay</source>
         <translation>Hämta Träningspass från TrainerDay</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="509"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="513"/>
         <source>Create Workout via Wizard</source>
         <translation>Skapa Träningspass mha Guiden</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="514"/>
         <source>Scan for Workouts</source>
         <translation>Sök efter Träningspass</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="534"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="538"/>
         <source>Delete selected Workout</source>
         <translation>Radera valda Träningspass</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="541"/>
         <source>Delete %1 selected Workouts</source>
         <translation>Radera %1 valda Träningspass</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Train mode active</source>
         <translation>Täningsmod aktiv</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Please stop the train mode before closing the window or application.</source>
         <translation>Vänligen avsluta träningsmoden innan fönster eller applikationen stängs.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="635"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="639"/>
         <source>Remove reference to selected video</source>
         <translation>Ta bort referens till vald Video</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="650"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="654"/>
         <source>Import VideoSync from File</source>
         <translation>Importera VideoSync från Fil</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="651"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="655"/>
         <source>Scan for VideoSyncs</source>
         <translation>Sök efter VideoSyncs</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="668"/>
         <source>Delete selected VideoSync</source>
         <translation>Radera vald VideoSync</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1064"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1068"/>
         <source>Are you sure you want to remove the reference to this video?</source>
         <translation>Är du säker på att referensen till denna video skall tas bort?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1066"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1128"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1204"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1070"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1132"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1208"/>
         <source>Remove</source>
         <translation>Ta bort</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1099"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1103"/>
         <source>Are you sure you want to delete this VideoSync?</source>
         <translation>Är du säker att du vill radera denna VideoSync?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1126"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1130"/>
         <source>The VideoSync file is either not valid or not existing and will be removed from the library.</source>
         <translation>Denna VideoSyncfil är antingen inte godkänd eller finns inte och kommer därmed att tas bort från biblioteket.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1160"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1164"/>
         <source>Are you sure you want to delete this Workout?</source>
         <translation>Är du säker på att du vill radera detta Träningspass?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1163"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1167"/>
         <source>Are you sure you want to delete this %1 workouts?</source>
         <translation>Är du säker på att du vill radera denna %1 Workouts?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1202"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1206"/>
         <source>The Workout file is either not valid or not existing and will be removed from the library.</source>
         <translation>Träningspassfilen är antingen inte godkänd eller finns inte och kommer därmed att tas bort från biblioteket.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1347"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1351"/>
         <source>Starting in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2225"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2237"/>
         <source>Recalibrating steering..</source>
         <translation>Kalibrerar om styrning..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2521"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2525"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2594"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2645"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2649"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2533"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2606"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2657"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2661"/>
         <source>Requesting calibration..</source>
         <translation>Begär kalibrering..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2532"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2544"/>
         <source>Calibrating...</source>
         <translation>Kallibrerar...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2536"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2548"/>
         <source>Calibrating...
 Current speed %1 kph
 Increase speed to %2 kph</source>
@@ -32731,14 +32700,14 @@ Fart %1 km/h
 Öka den till minst %2 km/h</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2540"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2552"/>
         <source>Calibrating...
 Stop pedalling until speed drops to 0</source>
         <translation>Kalibrerar...
 Sluta trampa och vänta tills bakhjulet stannat helt</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2545"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2557"/>
         <source>Calibration completed successfully!
 Spindown %1 ms
 Zero Offset %2</source>
@@ -32747,30 +32716,30 @@ Stopptid %1 ms
 Nollställningsvärde %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2553"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2620"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2672"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2565"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2632"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2684"/>
         <source>Calibration failed!</source>
         <translation>Kalibreringen misslyckades!</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2573"/>
         <source>Calibration Failed: Loosen Roller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2569"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2581"/>
         <source>Calibration Failed: Tighten Roller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2588"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2639"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2600"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2651"/>
         <source>Unclip or stop pedalling to begin calibration..</source>
         <translation>Trampa inte under kalibreringen..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2607"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2619"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Torque %1</source>
@@ -32779,7 +32748,7 @@ Trampa inte tills det är klart..
 Vridmoment %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2612"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2624"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Torque %2</source>
@@ -32788,7 +32757,7 @@ Nollställningsvärde %1
 Vridmoment %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2659"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2671"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Zero Offset %1</source>
@@ -32797,7 +32766,7 @@ Förtsätt låt pedalerna vara fria från fötter tills det är klart..
 Nollkompensation %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2676"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Slope %2</source>
@@ -32806,169 +32775,169 @@ Nollkompensation %1
 Lutning %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2693"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2705"/>
         <source>Give the pedal a kick to start calibration...
 The motor will run until calibration is complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2695"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
         <source>Allow wheel speed to settle, DO NOT PEDAL...
 The motor will run until calibration is complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2700"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2712"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Gathering enough samples to calculate average: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2719"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Waiting for value to stabilize (max %1s): %2 (%3W @ %4kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2722"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
         <source>Calibration completed successfully!
 Final calibration value %1 (%2W @ %3kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2746"/>
         <source>Calibration failed! Do not pedal while calibration is taking place.
 Allow wheel to run freely.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2780"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2792"/>
         <source>Fast forward..</source>
         <translation>Snabbspola framåt..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2813"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2825"/>
         <source>Rewind..</source>
         <translation>Snabbspola bakåt..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2843"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2855"/>
         <source>Next Lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2876"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2888"/>
         <source>Back Lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2902"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2914"/>
         <source>Increasing intensity..</source>
         <translation>Ökande intensitet..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2928"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2940"/>
         <source>Decreasing intensity..</source>
         <translation>Minskande intensitet..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="621"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="625"/>
         <source>Import Video from File</source>
         <translation>Importera Video från fil</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="508"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="512"/>
         <source>Get Workouts from Strava Routes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="622"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="626"/>
         <source>Scan for Videos</source>
         <translation>Sök efter Videor</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1101"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1173"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3183"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1105"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1177"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3195"/>
         <source>Delete</source>
         <translation>Radera</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1309"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1313"/>
         <source>Resuming..</source>
         <translation>Återupptar..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1336"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1340"/>
         <source>Paused..</source>
         <translation>Pausad..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1465"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1469"/>
         <source>Starting..</source>
         <translation>Startar..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1673"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1677"/>
         <source>Stopped..</source>
         <translation>Stoppar..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1763"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1769"/>
         <source>Connected..</source>
         <translation>Ihopkopplad..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1787"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1793"/>
         <source>Disconnected..</source>
         <translation>Isärkopplad..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2198"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2210"/>
         <source>New lap..</source>
         <translation>Nytt varv..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>No Devices Configured</source>
         <translation>Inga Enheter Konfigurerade</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>Please configure a device in Preferences.</source>
         <translation>Vänligen konfigurera en enhet i Inställningarna.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2483"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2495"/>
         <source>Exiting calibration..</source>
         <translation>Lämnar kalibrering..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2498"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2510"/>
         <source>Calibration not supported for this device.</source>
         <translation>Kalibrering stöds inte av denna enhet.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2505"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2517"/>
         <source>Calibrating...
 Press F3 on Controller when done.</source>
         <translation>Kalibrerar...
 Tryck F3 när det är klart.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3135"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3153"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3147"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3165"/>
         <source>Add Device</source>
         <translation>Lägg till Enhet</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3140"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3158"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3152"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3170"/>
         <source>Delete Device</source>
         <translation>Ta bort Enhet</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3181"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3193"/>
         <source>Are you sure you want to delete this device?</source>
         <translation>Är du säker på att du vill radera denna enhet?</translation>
     </message>
@@ -33286,7 +33255,7 @@ Tryck F3 när det är klart.</translation>
 <context>
     <name>UniqueLabelEditDelegate</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="77"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="108"/>
         <source>The given value &quot;%1&quot; is not unique</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33302,171 +33271,163 @@ Tryck F3 när det är klart.</translation>
 <context>
     <name>UserChartSettings</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="772"/>
+        <location filename="../../Charts/UserChart.cpp" line="773"/>
         <source>Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="782"/>
+        <location filename="../../Charts/UserChart.cpp" line="783"/>
         <source>Sub-title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="785"/>
+        <location filename="../../Charts/UserChart.cpp" line="786"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="791"/>
+        <location filename="../../Charts/UserChart.cpp" line="792"/>
         <source>Line Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="792"/>
+        <location filename="../../Charts/UserChart.cpp" line="793"/>
         <source>Scatter Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="793"/>
+        <location filename="../../Charts/UserChart.cpp" line="794"/>
         <source>Bar Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="794"/>
+        <location filename="../../Charts/UserChart.cpp" line="795"/>
         <source>Stacked Bar Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="795"/>
+        <location filename="../../Charts/UserChart.cpp" line="796"/>
         <source>Stacked Percent Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="796"/>
+        <location filename="../../Charts/UserChart.cpp" line="797"/>
         <source>Pie Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="800"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="801"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="804"/>
+        <location filename="../../Charts/UserChart.cpp" line="805"/>
         <source>Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="805"/>
+        <location filename="../../Charts/UserChart.cpp" line="806"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="808"/>
+        <location filename="../../Charts/UserChart.cpp" line="809"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="812"/>
+        <location filename="../../Charts/UserChart.cpp" line="813"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="813"/>
+        <location filename="../../Charts/UserChart.cpp" line="814"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="814"/>
+        <location filename="../../Charts/UserChart.cpp" line="815"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="815"/>
+        <location filename="../../Charts/UserChart.cpp" line="816"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="816"/>
+        <location filename="../../Charts/UserChart.cpp" line="817"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="820"/>
+        <location filename="../../Charts/UserChart.cpp" line="821"/>
         <source>Legend</source>
         <translation type="unfinished">Förklaring</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="829"/>
+        <location filename="../../Charts/UserChart.cpp" line="830"/>
         <source>Font scaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="831"/>
-        <location filename="../../Charts/UserChart.cpp" line="833"/>
+        <location filename="../../Charts/UserChart.cpp" line="832"/>
+        <location filename="../../Charts/UserChart.cpp" line="834"/>
         <source>Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="836"/>
+        <location filename="../../Charts/UserChart.cpp" line="837"/>
         <source>Animate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="838"/>
+        <location filename="../../Charts/UserChart.cpp" line="839"/>
         <source>Single series per plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="841"/>
+        <location filename="../../Charts/UserChart.cpp" line="842"/>
         <source>Refresh for intervals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="848"/>
+        <location filename="../../Charts/UserChart.cpp" line="849"/>
         <source>Series</source>
         <translation type="unfinished">Dataserie</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Name</source>
         <translation type="unfinished">Namn</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Y Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="870"/>
-        <location filename="../../Charts/UserChart.cpp" line="932"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Charts/UserChart.cpp" line="889"/>
         <source>Up</source>
-        <translation type="unfinished">Upp</translation>
+        <translation type="obsolete">Upp</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="890"/>
         <source>Down</source>
-        <translation type="unfinished">Ner</translation>
+        <translation type="obsolete">Ner</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="911"/>
+        <location filename="../../Charts/UserChart.cpp" line="885"/>
         <source>Axes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34132,72 +34093,72 @@ Tryck F3 när det är klart.</translation>
 <context>
     <name>VideoWindow</name>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> kph</source>
         <translation> km/h</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="119"/>
+        <location filename="../../Train/VideoWindow.cpp" line="144"/>
         <source>Meters layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="127"/>
+        <location filename="../../Train/VideoWindow.cpp" line="152"/>
         <source>Reset Meters layout to default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> m</source>
         <translation type="unfinished"> m</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> feet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="625"/>
+        <location filename="../../Train/VideoWindow.cpp" line="681"/>
         <source>w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="629"/>
+        <location filename="../../Train/VideoWindow.cpp" line="685"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> km</source>
         <translation type="unfinished"> km</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> mi</source>
         <translation type="unfinished"> mile</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="673"/>
+        <location filename="../../Train/VideoWindow.cpp" line="729"/>
         <source>Calibration required</source>
         <translation>Kalibrering krävs</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="678"/>
+        <location filename="../../Train/VideoWindow.cpp" line="734"/>
         <source>Configuration required</source>
         <translation>Konfiguration krävs</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="683"/>
+        <location filename="../../Train/VideoWindow.cpp" line="739"/>
         <source>brake fault</source>
         <translation>bromsfel</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="688"/>
+        <location filename="../../Train/VideoWindow.cpp" line="744"/>
         <source>Ready</source>
         <translation>Färdig</translation>
     </message>
@@ -34633,27 +34594,27 @@ Tryck F3 när det är klart.</translation>
 <context>
     <name>WheelSizeCalculator</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="202"/>
+        <location filename="../../Gui/AthletePages.cpp" line="187"/>
         <source>Wheel Size Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="221"/>
+        <location filename="../../Gui/AthletePages.cpp" line="206"/>
         <source>Rim Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="222"/>
+        <location filename="../../Gui/AthletePages.cpp" line="207"/>
         <source>Tire Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="223"/>
+        <location filename="../../Gui/AthletePages.cpp" line="208"/>
         <source>Wheel Size</source>
         <translation type="unfinished">Hjulstorlek</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="227"/>
         <source>mm</source>
         <translation type="unfinished">mm</translation>
     </message>
@@ -34765,12 +34726,12 @@ Tryck F3 när det är klart.</translation>
 <context>
     <name>WorkoutFilterBox</name>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="34"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="44"/>
         <source>Filter...</source>
         <translation type="unfinished">Filter...</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="64"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="95"/>
         <source>ERROR: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34778,12 +34739,12 @@ Tryck F3 när det är klart.</translation>
 <context>
     <name>WorkoutImportDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="820"/>
+        <location filename="../../Train/Library.cpp" line="809"/>
         <source>Import to Library</source>
         <translation>Importera till Bibliotek</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="854"/>
+        <location filename="../../Train/Library.cpp" line="843"/>
         <source>Please note, that when importing or drag and dropping videos into the library we DO NOT copy the file into the GoldenCheetah library, instead we add a REFERENCE to it. We DO copy workout and videoSync files, since they are smaller.
 
 You can remove references when managing the library via the context menu options</source>
@@ -34792,24 +34753,107 @@ You can remove references when managing the library via the context menu options
 Det är möjligt att ta bort länkar via &quot;context menu&quot; inställningarna</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="868"/>
+        <location filename="../../Train/Library.cpp" line="857"/>
         <source>Files</source>
         <translation>Filer</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="878"/>
+        <location filename="../../Train/Library.cpp" line="867"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="880"/>
+        <location filename="../../Train/Library.cpp" line="869"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="884"/>
+        <location filename="../../Train/Library.cpp" line="873"/>
         <source>Overwite existing files</source>
         <translation>Skriv över befintliga filer</translation>
+    </message>
+</context>
+<context>
+    <name>WorkoutMenuProvider</name>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="271"/>
+        <source>Select Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="274"/>
+        <source>Manage Filters</source>
+        <translation type="unfinished">Hantera Filter</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="275"/>
+        <source>Add Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="289"/>
+        <source>Add Tag to Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="292"/>
+        <source>Filter Tags...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="310"/>
+        <source>Match all selected tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="353"/>
+        <source>Manage Workout Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="360"/>
+        <source>Name</source>
+        <translation type="unfinished">Namn</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="361"/>
+        <source>Filter</source>
+        <translation type="unfinished">Filter</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="362"/>
+        <source>_index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="370"/>
+        <source>Execute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="371"/>
+        <source>Update</source>
+        <translation type="unfinished">Uppdatera</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="423"/>
+        <source>Add Workout Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="426"/>
+        <source>Name of the Filter...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="467"/>
+        <source>New</source>
+        <translation type="unfinished">Ny</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="469"/>
+        <source>New (%1)</source>
+        <translation type="unfinished">Ny (%1)</translation>
     </message>
 </context>
 <context>
@@ -34824,41 +34868,41 @@ Det är möjligt att ta bort länkar via &quot;context menu&quot; inställningar
     <name>WorkoutPlotWindow</name>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="40"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="104"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
         <source>Ergmode specific settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="46"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
         <source>Color power zones</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="48"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="56"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="49"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="50"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="57"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="109"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="113"/>
         <source>When stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="54"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="110"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
         <source>Show tooltip</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34952,12 +34996,12 @@ Det är möjligt att ta bort länkar via &quot;context menu&quot; inställningar
 <context>
     <name>WorkoutWidget</name>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="1531"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="1532"/>
         <source>File save failed.</source>
         <translation>Filen kunde inte sparas.</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="2367"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="2368"/>
         <source>Intensity</source>
         <translation>Intensitet</translation>
     </message>
@@ -35111,26 +35155,22 @@ Det är möjligt att ta bort länkar via &quot;context menu&quot; inställningar
 <context>
     <name>XDataDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="44"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="45"/>
         <source>xData</source>
         <translation>xData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="58"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="59"/>
         <source>Data Series</source>
         <translation>Dataserie</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="78"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="80"/>
         <source>Add</source>
-        <translation>Lägg till</translation>
+        <translation type="vanished">Lägg till</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="79"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="81"/>
         <source>Delete</source>
-        <translation>Radera</translation>
+        <translation type="vanished">Radera</translation>
     </message>
 </context>
 <context>
@@ -35207,32 +35247,32 @@ Det är möjligt att ta bort länkar via &quot;context menu&quot; inställningar
 <context>
     <name>XDataSeriesSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="333"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="315"/>
         <source>Name</source>
         <translation>Namn</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="338"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="320"/>
         <source>Units</source>
         <translation>Enheter</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="346"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="328"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="347"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="329"/>
         <source>OK</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Name is blank</source>
         <translation>Namn är tom</translation>
     </message>
@@ -35240,48 +35280,48 @@ Det är möjligt att ta bort länkar via &quot;context menu&quot; inställningar
 <context>
     <name>XDataSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="262"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="244"/>
         <source>xData</source>
         <translation>xData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="269"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="251"/>
         <source>Data Series</source>
         <translation>Dataserie</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="270"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="252"/>
         <source>Units</source>
         <translation>Enheter</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="274"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="256"/>
         <source>Series %1</source>
         <translation>Serier %1</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="281"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="263"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="282"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="264"/>
         <source>OK</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
         <source>XData name is blank</source>
         <translation>XData Name är tom</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Must have at least one data series.</source>
         <translation>Behöver minst en dataserie.</translation>
     </message>
@@ -35603,17 +35643,17 @@ Det är möjligt att ta bort länkar via &quot;context menu&quot; inställningar
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="915"/>
+        <location filename="../../Gui/AthletePages.cpp" line="886"/>
         <source>Sport</source>
         <translation>Sport</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="962"/>
+        <location filename="../../Gui/AthletePages.cpp" line="933"/>
         <source>Critical Power</source>
         <translation>Critical Power</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="963"/>
+        <location filename="../../Gui/AthletePages.cpp" line="934"/>
         <source>Default</source>
         <translation>Utgångsvärde</translation>
     </message>

--- a/src/Resources/translations/gc_zh-cn.ts
+++ b/src/Resources/translations/gc_zh-cn.ts
@@ -107,38 +107,38 @@ It might be necessary to manually disable it.</source>
         <translation type="vanished">LTS平均 (天)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="504"/>
+        <location filename="../../Gui/AthletePages.cpp" line="489"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="517"/>
-        <location filename="../../Gui/AthletePages.cpp" line="522"/>
+        <location filename="../../Gui/AthletePages.cpp" line="502"/>
+        <location filename="../../Gui/AthletePages.cpp" line="507"/>
         <source>days</source>
         <translation type="unfinished">天</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="525"/>
+        <location filename="../../Gui/AthletePages.cpp" line="510"/>
         <source>PMC Stress Balance Today</source>
         <translation>今天PMC压力平衡</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="528"/>
+        <location filename="../../Gui/AthletePages.cpp" line="513"/>
         <source>Restore Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="517"/>
         <source>W&apos;bal tau</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="518"/>
         <source>Short Term Stress (STS) average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="534"/>
+        <location filename="../../Gui/AthletePages.cpp" line="519"/>
         <source>Long Term Stress (LTS) average</source>
         <translation type="unfinished"></translation>
     </message>
@@ -154,96 +154,96 @@ It might be necessary to manually disable it.</source>
 <context>
     <name>AboutRiderPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="372"/>
+        <location filename="../../Gui/AthletePages.cpp" line="357"/>
         <source>Nickname</source>
         <translation>昵称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="373"/>
+        <location filename="../../Gui/AthletePages.cpp" line="358"/>
         <source>Date of Birth</source>
         <translation>生日</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="374"/>
+        <location filename="../../Gui/AthletePages.cpp" line="359"/>
         <source>Sex</source>
         <translation>性别</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="376"/>
+        <location filename="../../Gui/AthletePages.cpp" line="361"/>
         <source>Weight</source>
         <translation>体重</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="375"/>
+        <location filename="../../Gui/AthletePages.cpp" line="360"/>
         <source>Height</source>
         <translation>身高</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="279"/>
+        <location filename="../../Gui/AthletePages.cpp" line="264"/>
         <source>Male</source>
         <translation>男性</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="280"/>
+        <location filename="../../Gui/AthletePages.cpp" line="265"/>
         <source>Female</source>
         <translation>女性</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> kg</source>
         <translation> kg</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> lb</source>
         <translation> 磅</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> cm</source>
         <translation> cm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> in</source>
         <translation> in</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="359"/>
+        <location filename="../../Gui/AthletePages.cpp" line="344"/>
         <source>Calculate...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="378"/>
+        <location filename="../../Gui/AthletePages.cpp" line="363"/>
         <source>Bike</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="379"/>
+        <location filename="../../Gui/AthletePages.cpp" line="364"/>
         <source>Crank Length</source>
         <translation>曲柄长度</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="380"/>
+        <location filename="../../Gui/AthletePages.cpp" line="365"/>
         <source>Wheelsize</source>
         <translation>车轮尺寸</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="438"/>
+        <location filename="../../Gui/AthletePages.cpp" line="423"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="356"/>
+        <location filename="../../Gui/AthletePages.cpp" line="341"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="437"/>
+        <location filename="../../Gui/AthletePages.cpp" line="422"/>
         <source>Choose Picture</source>
         <translation>选择照片</translation>
     </message>
@@ -2273,397 +2273,394 @@ Press Next to Continue
 <context>
     <name>AllPlotWindow</name>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="190"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="444"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="165"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
         <source>Smooth</source>
         <translation>平滑度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="198"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="173"/>
         <source>Stacked</source>
         <translation>堆叠</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="199"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="174"/>
         <source>by series</source>
         <translation>数据分类</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="200"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="175"/>
         <source>Fullplot</source>
         <translation>全图</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="201"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="176"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="239"/>
         <source>Overlay</source>
         <translation>层叠</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="229"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="204"/>
         <source>View</source>
         <translation>视图</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="206"/>
         <source>Stack</source>
         <translation>堆叠</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="210"/>
         <source>By Series</source>
         <translation>数据分类</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="246"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="221"/>
         <source>Stack Zoom</source>
         <translation>堆叠缩放</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="248"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="223"/>
         <source>Full plot</source>
         <translation>全图</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="227"/>
         <source>Show Interval Markers</source>
         <translation>显示间歇标记</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="256"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
         <source>Interval Navigator</source>
         <translation>间歇导航</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="260"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
         <source>Hover intervals</source>
         <translation>鼠标悬停显示间歇</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="268"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="243"/>
         <source>Fill Curves</source>
         <translation>填充曲线</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="247"/>
         <source>Grid</source>
         <translation>网格</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="277"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
         <source>Acceleration</source>
         <translation>加速度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="279"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="254"/>
         <source>Delta Series</source>
         <translation>差值系列</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="280"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="255"/>
         <source>Power %1</source>
         <translation>功率 %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="283"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="258"/>
         <source>Cadence %1</source>
         <translation>踏频 %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="261"/>
         <source>Torque %1</source>
         <translation>扭矩 %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="289"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
         <source>Heartrate %1</source>
         <translation>心率 %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="295"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="270"/>
         <source>Balance</source>
         <translation>平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
         <source>Left/Right</source>
         <translation>左/右</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="274"/>
         <source>Torque Effectiveness</source>
         <translation>扭矩效率</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="303"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="278"/>
         <source>Smoothness</source>
         <translation>平滑度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="282"/>
         <source>Pedal Center Offset</source>
         <translation>踏板偏移(Center Offset)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="311"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
         <source>Power Phase</source>
         <translation>功率相</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="290"/>
         <source>Peak Power Phase</source>
         <translation>功率相峰值</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="322"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
         <source>Vertical Oscillation</source>
         <translation>垂直振幅</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="324"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
         <source>Running</source>
         <translation>跑动</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="326"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="301"/>
         <source>Ground Contact Time</source>
         <translation>触地时间</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
         <source>Cadence </source>
         <translation>踏频 </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="313"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="340"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
         <source>Moxy</source>
         <translation>Moxy</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="317"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="321"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="325"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="355"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="330"/>
         <source>Heart Rate</source>
         <translation>心率</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="357"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
         <source>Data series</source>
         <translation>数据系列</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="359"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="334"/>
         <source>Core Temperature</source>
         <translation>核心温度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="363"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="367"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
         <source>Cadence</source>
         <translation>踏频</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="94"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="95"/>
         <source>Basic</source>
         <translation>基本</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="109"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="110"/>
         <source>Curves</source>
         <translation>曲线</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="116"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="117"/>
         <source>User Data</source>
         <translation>用户数据</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="132"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="134"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Formula</source>
         <translation>规则(Formula)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="144"/>
         <source>Edit</source>
-        <translation>编辑</translation>
+        <translation type="vanished">编辑</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="163"/>
         <source>Up</source>
-        <translation>上</translation>
+        <translation type="vanished">上</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="164"/>
         <source>Down</source>
-        <translation>下</translation>
+        <translation type="vanished">下</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="371"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
         <source>Altitude</source>
         <translation>海拔</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
         <source>Temperature</source>
         <translation>温度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="379"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="354"/>
         <source>Headwind</source>
         <translation>逆风</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="383"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="358"/>
         <source>Torque</source>
         <translation>扭矩</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="387"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="362"/>
         <source>Gear Ratio</source>
         <translation>齿比</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="391"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="366"/>
         <source>Slope</source>
         <translation>坡度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="373"/>
         <source>No Alt/Slope</source>
         <translation>无高度/坡度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="399"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="374"/>
         <source>0.1km|mi -  1min</source>
         <translation>0.1km|mi - 1min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="400"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
         <source>0.5km|mi -  5min</source>
         <translation>0.5km|mi - 5min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="401"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="376"/>
         <source>1.0km|mi - 10min</source>
         <translation>1.0km|mi - 10min</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1528"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="377"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="1503"/>
         <source>Alt/Slope</source>
         <translation>海拔/坡度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="382"/>
         <source>Anaerobic TISS</source>
         <translation>无氧(anaerobic)TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="384"/>
         <source>Metrics</source>
         <translation>指标</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="411"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="386"/>
         <source>Aerobic TISS</source>
         <translation>有氧(Aerobic)TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="390"/>
         <source>Iso Power</source>
         <translation>标准化功率</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="394"/>
         <source>Skiba xPower</source>
         <translation>Skiba xPower</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="423"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
         <source>Altitude Power</source>
         <translation>海拔功率(Altitude Power)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="427"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
         <source>W&apos; balance</source>
         <translation>W&apos;平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="441"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="416"/>
         <source>Time of day</source>
         <translation>时间</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="742"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="717"/>
         <source>Intervals</source>
         <translation>间歇</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="2253"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="2228"/>
         <source>Selection #%1 </source>
         <translation>选择#%1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="432"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
         <source>Power + shade</source>
         <translation>功率(阴影)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="433"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="408"/>
         <source>Power - shade</source>
         <translation>功率(无阴影)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="434"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
         <source>No Power</source>
         <translation>无功率</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="435"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="410"/>
         <source>Shading</source>
         <translation>阴影</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="439"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="414"/>
         <source>Time</source>
         <translation>时间</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="440"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
         <source>Distance</source>
         <translation>距离</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="442"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="417"/>
         <source>X Axis</source>
         <translation>X轴</translation>
     </message>
@@ -3473,51 +3470,45 @@ Press Next to Continue
 <context>
     <name>AutoImportPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4028"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4029"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
         <source>Browse</source>
         <translation type="vanished">浏览</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4040"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4041"/>
         <source>Delete</source>
-        <translation>删除</translation>
+        <translation type="vanished">删除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4042"/>
         <source>Up</source>
-        <translation>上</translation>
+        <translation type="vanished">上</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4043"/>
         <source>Down</source>
-        <translation>下</translation>
+        <translation type="vanished">下</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4054"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3779"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4059"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3784"/>
         <source>Directory</source>
         <translation>文件夹</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4060"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3785"/>
         <source>Import Rule</source>
         <translation>导入规则</translation>
     </message>
@@ -4335,37 +4326,37 @@ Press Next to Continue
 <context>
     <name>BackupPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="608"/>
+        <location filename="../../Gui/AthletePages.cpp" line="593"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="601"/>
         <source>every</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="617"/>
+        <location filename="../../Gui/AthletePages.cpp" line="602"/>
         <source>times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="603"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="605"/>
         <source>Backup now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="623"/>
+        <location filename="../../Gui/AthletePages.cpp" line="608"/>
         <source>Auto Backup Folder</source>
         <translation>自动备份文件夹</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="624"/>
+        <location filename="../../Gui/AthletePages.cpp" line="609"/>
         <source>Auto Backup after closing the athlete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5187,41 +5178,33 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">更新</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1202"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1203"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1204"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1150"/>
         <source>Review...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1206"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1152"/>
         <source>Changed power estimates are available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1213"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1225"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1214"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1226"/>
         <source>Delete</source>
-        <translation>删除</translation>
+        <translation type="vanished">删除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1216"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1158"/>
         <source>Def</source>
         <translation>确定</translation>
     </message>
@@ -5230,27 +5213,27 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">开始日期</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1218"/>
         <source>Critical Power</source>
         <translation>临界功率</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1305"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>AeTP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1306"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>FTP</source>
         <translation>FTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1307"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1221"/>
         <source>W&apos;</source>
         <translation>W&apos;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1308"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1222"/>
         <source>Pmax</source>
         <translation>P-max</translation>
     </message>
@@ -5263,207 +5246,207 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">临界功率必须大于0</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1347"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1261"/>
         <source>Short</source>
         <translation>序号</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1247"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1169"/>
         <source>Use CP for all metrics</source>
         <translation>所有指标使用CP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1240"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1162"/>
         <source>Manual</source>
         <translation type="unfinished">手动</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1241"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1163"/>
         <source>Semi-Automatic (CP2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1164"/>
         <source>Semi-Automatic (CP3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1243"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1165"/>
         <source>Semi-Automatic (Extended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1170"/>
         <source>Use FTP for Coggan metrics</source>
         <translation>Coggan指标使用FTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1273"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1279"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1285"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1342"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1618"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1631"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2283"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2289"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2310"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1187"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1193"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1199"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1211"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1537"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1545"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2180"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2186"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2194"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2207"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1205"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1547"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2201"/>
         <source>J</source>
         <translation type="unfinished">J</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1303"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1217"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2145"/>
         <source>Start Date</source>
         <translation type="unfinished">开始日期</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1309"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1223"/>
         <source>Model Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1262"/>
         <source>Long</source>
         <translation>区间</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1349"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1263"/>
         <source>From Watts</source>
         <translation>最低功率</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1598"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1512"/>
         <source>Review range starting on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1614"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1528"/>
         <source>Current</source>
         <translation type="unfinished">目前</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1615"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1529"/>
         <source>Estimate</source>
         <translation type="unfinished">估计</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1530"/>
         <source>Accept</source>
         <translation type="unfinished">接受</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1788"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1691"/>
         <source>🗹</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1692"/>
         <source>Estimate and settings &lt;b&gt;match&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1695"/>
         <source>☐</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1696"/>
         <source>Estimate and settings &lt;b&gt;differ&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1797"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1700"/>
         <source>⏲</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1800"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1703"/>
         <source>Range is %1 days older than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1802"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1705"/>
         <source>Range is %1 days younger than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1808"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1711"/>
         <source>∅</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1712"/>
         <source>No estimate available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1902"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1805"/>
         <source>New range from estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2237"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2134"/>
         <source>The proposed value for AeTP is a very rough estimate, assuming %1 % of CP. Usually it is determined by a&lt;ul&gt;&lt;li&gt;Metabolic test&lt;/li&gt;&lt;li&gt;Lactate ramp test&lt;/li&gt;&lt;li&gt;Run / Cycling ‘conversational’ test&lt;/li&gt;&lt;li&gt;Run Decoupling test&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2239"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2136"/>
         <source>Updating FTP internally to match CP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2139"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2244"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2141"/>
         <source>Your selected model does not deliver values for PMax, using default value of %1 W instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2246"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2143"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;li&gt;PMax, assuming a default of %1 W&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2250"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2147"/>
         <source>Critical Power (CP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2252"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2149"/>
         <source>Aerobic Threshold Power (AeTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2254"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2151"/>
         <source>Functional Threshold Power (FTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2153"/>
         <source>Anaerobic Work Capacity (W&apos;)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2258"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2155"/>
         <source>Maximum Power (PMax)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2270"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2167"/>
         <source>Manual range</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5472,14 +5455,14 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">最多10个区间</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2018"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2025"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1917"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1924"/>
         <source>New</source>
         <translation>新的</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2020"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1919"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1926"/>
         <source>New (%1)</source>
         <translation>新的(%1)</translation>
     </message>
@@ -5928,52 +5911,44 @@ yyyy年M月d日,ddd</translation>
         <translation type="vanished">更新</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3307"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3319"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3308"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3320"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3313"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3325"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3314"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3326"/>
         <source>Delete</source>
-        <translation>删除</translation>
+        <translation type="vanished">删除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3316"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3109"/>
         <source>Def</source>
         <translation>确定</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3359"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3506"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3272"/>
         <source>Start Date</source>
         <translation type="unfinished">开始日期</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3249"/>
         <source>New range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3507"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3273"/>
         <source>Critical Velocity (CV)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3508"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3274"/>
         <source>Aerobic Threshold (AeT)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,12 +5957,12 @@ yyyy年M月d日,ddd</translation>
         <translation type="vanished">开始日期</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3360"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3128"/>
         <source>Critical Velocity</source>
         <translation>临界速度</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3361"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3129"/>
         <source>Aerobic Threshold</source>
         <translation>有氧阈值</translation>
     </message>
@@ -6000,17 +5975,17 @@ yyyy年M月d日,ddd</translation>
         <translation type="vanished">yyyy年M月d日</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3403"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
         <source>Short</source>
         <translation>序号</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3404"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3172"/>
         <source>Long</source>
         <translation>区间</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3405"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3173"/>
         <source>From</source>
         <translation>最低速度</translation>
     </message>
@@ -6019,14 +5994,14 @@ yyyy年M月d日,ddd</translation>
         <translation type="vanished">最多10个区间</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3679"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3686"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3441"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3448"/>
         <source>New</source>
         <translation>新的</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3681"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3688"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3443"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3450"/>
         <source>New (%1)</source>
         <translation>新的(%1)</translation>
     </message>
@@ -7556,37 +7531,32 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>CredentialsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="67"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
+    </message>
+    <message>
+        <source>-</source>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="vanished">编辑</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">新增</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">删除</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="68"/>
-        <source>-</source>
-        <translation>-</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="69"/>
-        <source>Edit</source>
-        <translation>编辑</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="74"/>
-        <source>Add</source>
-        <translation>新增</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="75"/>
-        <source>Delete</source>
-        <translation>删除</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="86"/>
         <source>Service</source>
         <translation>服务</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="87"/>
+        <location filename="../../Gui/AthletePages.cpp" line="69"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
@@ -8273,7 +8243,7 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>DataFilterEdit</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2743"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2712"/>
         <source>Warning: sample() is slow -- update code to use samples()</source>
         <translation>警告: sample()过慢 - 请更新代码</translation>
     </message>
@@ -8632,7 +8602,7 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>DirectoryPathWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="277"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="308"/>
         <source>Browse</source>
         <translation type="unfinished">浏览</translation>
     </message>
@@ -8869,28 +8839,28 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>Dropbox</name>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="68"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="77"/>
         <source>Problem accessing Dropbox data</source>
         <translation>访问Dropbox数据错误</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="130"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="139"/>
         <source>You must authorise with Dropbox first</source>
         <translation>必须首先授权Dropbox</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="205"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="214"/>
         <source>Parsing Error: %1</source>
         <translation>解析错误: %1</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="293"/>
-        <location filename="../../Cloud/Dropbox.cpp" line="312"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="302"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="321"/>
         <source>Completed.</source>
         <translation>完成.</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="297"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="306"/>
         <source>Network Error - Upload failed.</source>
         <translation>网络错误 - 上传失败.</translation>
     </message>
@@ -9035,136 +9005,136 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2064"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2033"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2034"/>
         <source>Axis Label / Units</source>
         <translation>轴标签/单位</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1597"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1566"/>
         <source>Curve Settings</source>
         <translation>曲线设置</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1558"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1527"/>
         <source>Estimate %1 %2 Power</source>
         <translation>估计%1 %2 功率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1562"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1531"/>
         <source>Endurance Index</source>
         <translation>耐力指数</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1532"/>
         <source>Vo2Max Estimate</source>
         <translation>VO2max估计</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1605"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1574"/>
         <source>Metric</source>
         <translation>指标</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1606"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1575"/>
         <source>Best</source>
         <translation>最佳</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1607"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1576"/>
         <source>Estimate</source>
         <translation>估计</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1577"/>
         <source>PMC</source>
         <translation>PMC</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1609"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1578"/>
         <source>Formula</source>
         <translation>规则(Formula)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1610"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1579"/>
         <source>Measure</source>
         <translation>参数</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1611"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1580"/>
         <source>Performance</source>
         <translation>表现</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1612"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1581"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1684"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1767"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1653"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1736"/>
         <source>seconds</source>
         <translation>秒</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1685"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1768"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1737"/>
         <source>minutes</source>
         <translation>分</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1769"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1655"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1738"/>
         <source>hours</source>
         <translation>时</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1723"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1816"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1692"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1785"/>
         <source>Peak</source>
         <translation>峰值</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1781"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1750"/>
         <source>Absolute</source>
         <translation>绝对值</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1751"/>
         <source>Per Kilogram</source>
         <translation>每千克</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1813"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
         <source>Total</source>
         <translation>全部</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1814"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1783"/>
         <source>Running Total</source>
         <translation>跑步全部</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1815"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1784"/>
         <source>Average</source>
         <translation>平均</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1817"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1786"/>
         <source>Low</source>
         <translation>最小值</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1820"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1789"/>
         <source>Aggregate:</source>
         <translation>合计:</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1828"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1797"/>
         <source># type in a formula to use
 # for e.g. BikeStress / Duration
 # as you type the available metrics
@@ -9175,292 +9145,292 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 # 输入已知指标时会自动完成</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1839"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1808"/>
         <source>Weekly Best Performances</source>
         <translation>每周最佳表现</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1840"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1809"/>
         <source>Submaximal Weekly Best</source>
         <translation>每周次佳</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1841"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1810"/>
         <source>Performance Tests</source>
         <translation>表现测试</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1933"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1902"/>
         <source>Short Term Stress (STS/ATL)</source>
         <translation>短期压力(STS/ATL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1934"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1903"/>
         <source>Long Term Stress  (LTS/CTL)</source>
         <translation>长期压力(LTS/CTL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1935"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1904"/>
         <source>Stress Balance    (SB/TSB)</source>
         <translation>压力平衡(Stress Balance, SB/TSB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1936"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1905"/>
         <source>Stress Ramp Rate  (RR)</source>
         <translation>压力变化率(RR)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1944"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1913"/>
         <source>Stress Type</source>
         <translation>压力类型</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1949"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1918"/>
         <source>Negative Training Effect (NTE)</source>
         <translation>消极训练效应 (NTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1950"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1919"/>
         <source>Positive Training Effect (PTE)</source>
         <translation>积极训练效应 (PTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1951"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1920"/>
         <source>Performance (Power Index)</source>
         <translation>表现(功率指数)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1952"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1921"/>
         <source>Predicted CP (Watts)</source>
         <translation>预计临界功率(W)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1969"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1938"/>
         <source>Curve Type</source>
         <translation>曲线类型</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1945"/>
         <source>Perf. Metric</source>
         <translation>表现指标</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2006"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1975"/>
         <source>Metadata Field</source>
         <translation>元数据字段</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2007"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
         <source>PMC metric</source>
         <translation>PMC指标</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2032"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2001"/>
         <source>Measure Group</source>
         <translation>参数组</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2009"/>
         <source>Measure Field</source>
         <translation>参数字段</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2029"/>
         <source>Filter</source>
         <translation>过滤器</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2071"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
         <source>Style</source>
         <translation>风格</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2042"/>
         <source>Bar</source>
         <translation>柱状图</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2074"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2043"/>
         <source>Line</source>
         <translation>线条</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2075"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2044"/>
         <source>Sticks</source>
         <translation>棍状图</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2076"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2045"/>
         <source>Dots</source>
         <translation>点</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2048"/>
         <source>Stack</source>
         <translation>堆叠</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2053"/>
         <source>Symbol</source>
         <translation>符号</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2086"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2055"/>
         <source>None</source>
         <translation>无</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2087"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2056"/>
         <source>Circle</source>
         <translation>圆圈</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2057"/>
         <source>Square</source>
         <translation>方块</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2089"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2058"/>
         <source>Diamond</source>
         <translation>菱形</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2090"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2059"/>
         <source>Triangle</source>
         <translation>三角形</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2091"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
         <source>Cross</source>
         <translation>叉</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2092"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2061"/>
         <source>Hexagon</source>
         <translation>六边形</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2062"/>
         <source>Star</source>
         <translation>星形</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
         <source>Color</source>
         <translation>颜色</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2100"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2069"/>
         <source>Fill curve</source>
         <translation>填充曲线</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
         <source>Data labels</source>
         <translation>数据标签</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2080"/>
         <source>Highlight Highest</source>
         <translation>高亮最高值</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
         <source>Highlight Lowest</source>
         <translation>高亮最小值</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2127"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
         <source>Highlight Outliers</source>
         <translation>高亮逸出值</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2135"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
         <source>Baseline</source>
         <translation>基线</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2143"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2112"/>
         <source>Smooth Curve</source>
         <translation>平滑曲线</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2147"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2116"/>
         <source>No trend Line</source>
         <translation>无趋势线</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2148"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2117"/>
         <source>Linear Trend</source>
         <translation>线性趋势</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2149"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2118"/>
         <source>Quadratic Trend</source>
         <translation>二次趋势</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2150"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
         <source>Moving Average</source>
         <translation>移动平均</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2151"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2120"/>
         <source>Simple Average</source>
         <translation>简单平均</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2123"/>
         <source>Ignore Zeros</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2168"/>
         <source>&amp;OK</source>
         <translation>确定(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2201"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2170"/>
         <source>&amp;Cancel</source>
         <translation>取消(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2431"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2400"/>
         <source>Peak %1</source>
         <translation>峰值 %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2402"/>
         <source> second </source>
         <translation>秒</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2434"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2403"/>
         <source> minute </source>
         <translation>分</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2436"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2405"/>
         <source> hour </source>
         <translation>时</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2456"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2425"/>
         <source>%1 - %2</source>
         <translation>%1 - %2</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2470"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2439"/>
         <source>Performances</source>
         <translation>表现</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2471"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2440"/>
         <source>Power Index</source>
         <translation>功率指数</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2588"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2557"/>
         <source>Performances_%1_%2_%3</source>
         <translation>表现_%1_%2_%3</translation>
     </message>
@@ -9790,93 +9760,93 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditUserAxisDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1731"/>
+        <location filename="../../Charts/UserChart.cpp" line="1689"/>
         <source>Edit Axis</source>
         <translation>编辑轴</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1741"/>
+        <location filename="../../Charts/UserChart.cpp" line="1699"/>
         <source>&amp;OK</source>
         <translation>确定(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1742"/>
+        <location filename="../../Charts/UserChart.cpp" line="1700"/>
         <source>&amp;Cancel</source>
         <translation>取消(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1750"/>
+        <location filename="../../Charts/UserChart.cpp" line="1708"/>
         <source>Units</source>
         <translation>单位</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1760"/>
+        <location filename="../../Charts/UserChart.cpp" line="1718"/>
         <source>Logarithmic Scale</source>
         <translation>对数标尺</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1757"/>
+        <location filename="../../Charts/UserChart.cpp" line="1715"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1761"/>
-        <location filename="../../Charts/UserChart.cpp" line="1780"/>
+        <location filename="../../Charts/UserChart.cpp" line="1719"/>
+        <location filename="../../Charts/UserChart.cpp" line="1738"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1763"/>
+        <location filename="../../Charts/UserChart.cpp" line="1721"/>
         <source>Fixed</source>
         <translation>已修正</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1774"/>
+        <location filename="../../Charts/UserChart.cpp" line="1732"/>
         <source> from </source>
         <translation> 从 </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1776"/>
+        <location filename="../../Charts/UserChart.cpp" line="1734"/>
         <source> to </source>
         <translation> 到 </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1779"/>
+        <location filename="../../Charts/UserChart.cpp" line="1737"/>
         <source>Range</source>
         <translation>范围</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1787"/>
+        <location filename="../../Charts/UserChart.cpp" line="1745"/>
         <source>Smoothing</source>
         <translation>平滑处理</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1792"/>
+        <location filename="../../Charts/UserChart.cpp" line="1750"/>
         <source>None</source>
         <translation>无</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1793"/>
+        <location filename="../../Charts/UserChart.cpp" line="1751"/>
         <source>Day</source>
         <translation>天</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1794"/>
+        <location filename="../../Charts/UserChart.cpp" line="1752"/>
         <source>Week</source>
         <translation>周</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1795"/>
+        <location filename="../../Charts/UserChart.cpp" line="1753"/>
         <source>Month</source>
         <translation>月</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1796"/>
+        <location filename="../../Charts/UserChart.cpp" line="1754"/>
         <source>Year</source>
         <translation>年</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1798"/>
+        <location filename="../../Charts/UserChart.cpp" line="1756"/>
         <source>Group By</source>
         <translation>  分组类型:</translation>
     </message>
@@ -10071,158 +10041,158 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditUserSeriesDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1398"/>
+        <location filename="../../Charts/UserChart.cpp" line="1356"/>
         <source>Edit Data Series</source>
         <translation>编辑数据系列</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1414"/>
+        <location filename="../../Charts/UserChart.cpp" line="1372"/>
         <source>&amp;OK</source>
         <translation>确定(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1415"/>
+        <location filename="../../Charts/UserChart.cpp" line="1373"/>
         <source>&amp;Cancel</source>
         <translation>取消(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1422"/>
+        <location filename="../../Charts/UserChart.cpp" line="1380"/>
         <source>Group</source>
         <translation>分组</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1430"/>
+        <location filename="../../Charts/UserChart.cpp" line="1388"/>
         <source>Series Name</source>
         <translation>系列名称</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1519"/>
+        <location filename="../../Charts/UserChart.cpp" line="1477"/>
         <source>Y units</source>
         <translation>Y轴单位</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1524"/>
+        <location filename="../../Charts/UserChart.cpp" line="1482"/>
         <source>X units</source>
         <translation>X轴单位</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1528"/>
+        <location filename="../../Charts/UserChart.cpp" line="1486"/>
         <source>Sum</source>
         <translation>合计</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1529"/>
+        <location filename="../../Charts/UserChart.cpp" line="1487"/>
         <source>Average</source>
         <translation>平均</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1530"/>
+        <location filename="../../Charts/UserChart.cpp" line="1488"/>
         <source>Peak</source>
         <translation>峰值</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1531"/>
+        <location filename="../../Charts/UserChart.cpp" line="1489"/>
         <source>Low</source>
         <translation>最小值</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1532"/>
+        <location filename="../../Charts/UserChart.cpp" line="1490"/>
         <source>Running Total</source>
         <translation>跑步合计</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1533"/>
+        <location filename="../../Charts/UserChart.cpp" line="1491"/>
         <source>Mean Square Root</source>
         <translation>均方根</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1534"/>
+        <location filename="../../Charts/UserChart.cpp" line="1492"/>
         <source>Std Deviation</source>
         <translation>标准差</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1537"/>
+        <location filename="../../Charts/UserChart.cpp" line="1495"/>
         <source>Aggregate</source>
         <translation>集合</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1541"/>
-        <location filename="../../Charts/UserChart.cpp" line="1557"/>
+        <location filename="../../Charts/UserChart.cpp" line="1499"/>
+        <location filename="../../Charts/UserChart.cpp" line="1515"/>
         <source>None</source>
         <translation>无</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1542"/>
+        <location filename="../../Charts/UserChart.cpp" line="1500"/>
         <source>Solid</source>
         <translation>实线</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1543"/>
+        <location filename="../../Charts/UserChart.cpp" line="1501"/>
         <source>Dashed</source>
         <translation>短划线</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1544"/>
+        <location filename="../../Charts/UserChart.cpp" line="1502"/>
         <source>Dot</source>
         <translation>点线</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1545"/>
+        <location filename="../../Charts/UserChart.cpp" line="1503"/>
         <source>Dash Dot</source>
         <translation>短划点线</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1546"/>
+        <location filename="../../Charts/UserChart.cpp" line="1504"/>
         <source>Fast Graphics</source>
         <translation>快速图表</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1547"/>
+        <location filename="../../Charts/UserChart.cpp" line="1505"/>
         <source>Show on Legend</source>
         <translation>在图例上显示</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1548"/>
+        <location filename="../../Charts/UserChart.cpp" line="1506"/>
         <source>Show Data Labels</source>
         <translation>显示数据标签</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1554"/>
+        <location filename="../../Charts/UserChart.cpp" line="1512"/>
         <source>Line Style</source>
         <translation>线型</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1558"/>
+        <location filename="../../Charts/UserChart.cpp" line="1516"/>
         <source>Circle</source>
         <translation>圆圈</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1559"/>
+        <location filename="../../Charts/UserChart.cpp" line="1517"/>
         <source>Rectangle</source>
         <translation>矩形</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1564"/>
+        <location filename="../../Charts/UserChart.cpp" line="1522"/>
         <source>Symbol</source>
         <translation>符号</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1572"/>
+        <location filename="../../Charts/UserChart.cpp" line="1530"/>
         <source>Color</source>
         <translation>颜色</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1575"/>
+        <location filename="../../Charts/UserChart.cpp" line="1533"/>
         <source>Fill curve</source>
         <translation>填充曲线</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1583"/>
+        <location filename="../../Charts/UserChart.cpp" line="1541"/>
         <source>Opacity (%)</source>
         <translation>不透明度 (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1589"/>
+        <location filename="../../Charts/UserChart.cpp" line="1547"/>
         <source>Size/Width</source>
         <translation>尺寸/宽度</translation>
     </message>
@@ -10269,6 +10239,24 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
         <location filename="../../Metrics/BasicRideMetrics.cpp" line="144"/>
         <source>Only useful for intervals, time the interval started</source>
         <translation>仅对间歇有用, 间歇开始的时间</translation>
+    </message>
+</context>
+<context>
+    <name>ElevationChartWindow</name>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="221"/>
+        <source>Profile Distance (m)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="229"/>
+        <source>Seconds for delta slope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="237"/>
+        <source>Elevation window size (%) relative to current altitude</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10707,7 +10695,7 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ExhaustionDialog.cpp" line="160"/>
+        <location filename="../../Charts/ExhaustionDialog.cpp" line="162"/>
         <source>Time</source>
         <translation>时间</translation>
     </message>
@@ -13219,42 +13207,42 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GcCrashDialog</name>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="78"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="74"/>
         <source>%1 Crash Recovery</source>
         <translation>%1 崩溃恢复</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="116"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="112"/>
         <source>&lt;b&gt;GoldenCheetah appears to have PREVIOUSLY crashed for this athlete. &lt;/b&gt;&lt;br&gt;&lt;br&gt;The report below gives some diagnostic information that will be useful to the developers. Feel free to post this with a short description of what was occurring when the crash happened to the &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah forums&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;We respect privacy - this log does NOT contain ids, passwords or personal information.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;When this dialog is closed the athlete will be opened.&lt;/b&gt;</source>
         <translation>&lt;b&gt;此前发生了崩溃 &lt;/b&gt;&lt;br&gt;&lt;br&gt;下面的报告给出了一些诊断信息,将会对开发者有帮助.您可以将其连同奔溃时的情形描述发送至&lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah论坛&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;我们尊重隐私,本日志不含id,密码或个人信息.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;本窗口关闭时,将打开程序.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="141"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="137"/>
         <source>Save Crash Report...</source>
         <translation>保存崩溃报告...</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="143"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="139"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="225"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="221"/>
         <source>&lt;p&gt;Build date: %1 %2&lt;br&gt;Build id: %3&lt;br&gt;Version: %4&lt;br&gt;DB Schema: %5&lt;br&gt;Metrics: %7&lt;br&gt;OS: %6&lt;br&gt;OpenGL: %10&lt;br&gt;UI: dpi scale (%8) font size (%9)&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="255"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="251"/>
         <source>&lt;table&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QT&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QWT&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;%3&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SRMIO&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;D2XX&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;ICAL&lt;/td&gt;&lt;td&gt;%9&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;USBXPRESS&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LIBUSB&lt;/td&gt;&lt;td&gt;%11&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VLC&lt;/td&gt;&lt;td&gt;%12&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VIDEO&lt;/td&gt;&lt;td&gt;%13&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SAMPLERATE&lt;/td&gt;&lt;td&gt;%14&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SSL&lt;/td&gt;&lt;td&gt;%15&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;R&lt;/td&gt;&lt;td&gt;%16&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;Python&lt;/td&gt;&lt;td&gt;%18&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LMFIT&lt;/td&gt;&lt;td&gt;7.0&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;GSL&lt;/td&gt;&lt;td&gt;%19&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Save Diagnostics</source>
         <translation>保存诊断信息</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Text File (*.txt)</source>
         <translation>文本文件 (*.txt)</translation>
     </message>
@@ -13589,167 +13577,172 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GcWindowRegistry</name>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
         <source>Performance</source>
         <translation>表现</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="89"/>
         <source>Histogram</source>
         <translation>柱状图</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
         <source>Distribution</source>
         <translation>分布</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
         <source>Pedal Force vs Velocity</source>
         <translation>踩踏力/速度</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
         <source>Heartrate vs Power</source>
         <translation>心率/功率</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
         <source>R Chart</source>
         <translation>R图表</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="98"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
         <source>R Chart </source>
         <translation>R图表 </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
         <source>Python Chart</source>
         <translation>Python图表</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
         <source>Python Chart </source>
         <translation>Python图表 </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="101"/>
         <source>Calendar</source>
         <translation>日历</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
         <source>Navigator</source>
         <translation>导航</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="71"/>
         <source>Season Overview</source>
         <translation>赛季概览</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="72"/>
         <source>Blank Overview </source>
         <translation>空白概览</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="76"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="73"/>
         <source>User Chart</source>
         <translation>用户图表</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
         <source>Trends</source>
         <translation>趋势</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="78"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
         <source>TreeMap</source>
         <translation>树图</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
         <source>Power Duration </source>
         <translation>功率时间</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="83"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
         <source>Activity Overview</source>
         <translation>活动概览</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="81"/>
         <source>Blank Overview</source>
         <translation>空白概览</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="85"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="82"/>
         <source>User Chart </source>
         <translation>用户图表</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
         <source>Data</source>
         <translation>数据</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="88"/>
         <source>Power Duration</source>
         <translation>功率时间</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
         <source>Scatter</source>
         <translation>散布图</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="103"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
         <source>Aerolab</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
         <source>Telemetry</source>
         <translation>参数</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
         <source>Workout</source>
         <translation>训练课程</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="106"/>
         <source>Realtime</source>
         <translation>实时曲线</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
         <source>Pedal Stroke</source>
         <translation>踩踏</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="113"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
         <source>Live Map</source>
         <translation>Live地图</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="114"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <source>Elevation Chart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
         <source>Web page</source>
         <translation>网页</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
         <source>Map</source>
         <translation>地图</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
         <source>Video Player</source>
         <translation>视频播放器</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
         <source>Workout Editor</source>
         <translation>训练课程编辑器</translation>
     </message>
@@ -14751,137 +14744,142 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation>在Open Street Map中实时显示模拟训练课程路线</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="296"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="294"/>
+        <source>Show elevation profile of instant position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
         <source>Predefined and configurable set of data ranges for selection of activities to be analysed</source>
         <translation>预设和可设置的数据分析范围</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
         <source>Powerful filter and search engine to determine the activities which are considered in diagram</source>
         <translation>强大的过滤器和搜索引擎,以确定图表中考虑的活动范围</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
         <source>Configurable list of activities</source>
         <translation>可设置的活动列表</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="317"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
         <source>Configurable list of training devices</source>
         <translation>可设置的训练设备</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
         <source>Configurable list of workout files</source>
         <translation>可设置的训练课程文件列表</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
         <source>Configurable list of video files</source>
         <translation>可设置的视频文件列表</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="325"/>
         <source>Configurable list of video sync files</source>
         <translation>可设置的视频同步文件列表</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="327"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
         <source>Entry field for sophisticated Searching and Filtering of activities</source>
         <translation>活动复杂搜索和过滤的输入框</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
         <source>Adding intervals to an activity using simple query methods</source>
         <translation>使用简单查询方式向活添加间歇动</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
         <source>To compare Activities/Intervals in Activity View and Date Ranges in Trends View</source>
         <translation>在活动视图内比较活动/间歇,在趋势视图内比较日期范围</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="335"/>
         <source>Workout Control, Intensity Adjustments and Notifications Display</source>
         <translation>训练课程控制、强度调节和通知显示</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
         <source>Athlete Model</source>
         <translation>运动员模型</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
         <source>Athlete Measures</source>
         <translation>运动员参数</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
         <source>Auto Import</source>
         <translation>自动导入</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
         <source>Backup</source>
         <translation>备份</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="355"/>
         <source>Cloud Accounts</source>
         <translation>云账户</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
         <source>Definition of coloring rules for activities</source>
         <translation>定义活动着色规则</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
         <source>Metrics shown in &apos;Intervals&apos; and &apos;Summary&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
         <source>User/Custom Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
         <source>Create or Edit a User Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
         <source>Measures</source>
         <translation>参数</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
         <source>Train View devices configuration and preferences</source>
         <translation>训练视图设备配置和设置</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
         <source>Train View Preferences</source>
         <translation>训练视图设置</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
         <source>Remote Controls Configuration</source>
         <translation>遥控设置</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
         <source>Add/Remove Train Devices</source>
         <translation>新增/移除训练设备</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
         <source>Add Train Devices</source>
         <translation>新增训练设备</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="394"/>
         <source>Virtual Bicycle configuration for simulation rides</source>
         <translation>模拟骑行的自行车设置</translation>
     </message>
@@ -15015,8 +15013,8 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
     </message>
     <message>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="219"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
         <source>Calendar</source>
         <translation>日历</translation>
     </message>
@@ -15051,79 +15049,79 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation>图表特有的过滤器/搜索和数据范围设置</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
         <source>Definition of points in time &apos;Events&apos; which are marked explicitely on time related diagrams</source>
         <translation>设置显示在与时间相关的图表上的&quot;赛事&quot;</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="316"/>
         <source>Simple summary view</source>
         <translation>简单的总结视图</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
         <source>Alternative access to the charts created for the main view</source>
         <translation>主视图图表的另一种打开途径</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
         <source>Display the available and add new intervals using simple query methods</source>
         <translation>显示已有间歇和使用简单查询方式添加新间歇</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="356"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
         <source>General</source>
         <translation>一般</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="337"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
         <source>Athlete</source>
         <translation>运动员</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
         <source>Training Zone definition for power</source>
         <translation>功率训练区间定义</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
         <source>Training Zone definition for heartrate</source>
         <translation>心率训练区间定义</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
         <source>Training Zone definition for Swim and Run</source>
         <translation>游泳和跑步训练区间定义</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
         <source>Appearance</source>
         <translation>外观</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <source>Automatic Interval Detection</source>
         <translation>间歇自动检测</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="364"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
         <source>Data Fields</source>
         <translation>数据字段</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
         <source>Definition of default value(s) for data fields</source>
         <translation>数据字段默认值设置</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
         <source>Definition of processing default parameters for the fix, adjust,... tools</source>
         <translation>修正,调整工具进行处理的默认参数设置</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
         <source>Metrics</source>
         <translation>指标</translation>
     </message>
@@ -15323,48 +15321,44 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2437"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2438"/>
         <source>Delete</source>
-        <translation>删除</translation>
+        <translation type="vanished">删除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2431"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2432"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2447"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2332"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2458"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2343"/>
         <source>Short</source>
         <translation>简称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2459"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2344"/>
         <source>Long</source>
         <translation>全称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2460"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2345"/>
         <source>Percent of LT</source>
         <translatorcomment>いまいち</translatorcomment>
         <translation>LT百分比</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2461"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2346"/>
         <source>Trimp k</source>
         <translation>TRIMP K系数</translation>
     </message>
@@ -15373,14 +15367,14 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">最多10个区间</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2506"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2513"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2390"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2397"/>
         <source>New</source>
         <translation>新的</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2508"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2515"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2392"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2399"/>
         <source>New (%1)</source>
         <translation>新的(%1)</translation>
     </message>
@@ -15570,17 +15564,17 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2245"/>
         <source>Sport</source>
         <translation>运动</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2395"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2292"/>
         <source>Lactate Threshold</source>
         <translation>乳酸阈值</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2396"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2293"/>
         <source>Default</source>
         <translation>默认</translation>
     </message>
@@ -17733,545 +17727,542 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTMTool</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1303"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1272"/>
         <source>Metric</source>
         <translation>指标</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="74"/>
+        <location filename="../../Charts/LTMTool.cpp" line="75"/>
         <source>Filter</source>
         <translation>过滤器</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="80"/>
+        <location filename="../../Charts/LTMTool.cpp" line="81"/>
         <source>Date range</source>
         <translation>日期范围</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="84"/>
+        <location filename="../../Charts/LTMTool.cpp" line="85"/>
         <source>Days</source>
         <translation>天</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="85"/>
+        <location filename="../../Charts/LTMTool.cpp" line="86"/>
         <source>Weeks</source>
         <translation>周</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="86"/>
+        <location filename="../../Charts/LTMTool.cpp" line="87"/>
         <source>Months</source>
         <translation>月</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="87"/>
+        <location filename="../../Charts/LTMTool.cpp" line="88"/>
         <source>Years</source>
         <translation>年</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="88"/>
+        <location filename="../../Charts/LTMTool.cpp" line="89"/>
         <source>Time Of Day</source>
         <translation>时间</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="89"/>
+        <location filename="../../Charts/LTMTool.cpp" line="90"/>
         <source>All</source>
         <translation>全部</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="91"/>
+        <location filename="../../Charts/LTMTool.cpp" line="92"/>
         <source>Group by</source>
         <translation>  分组类型:</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="102"/>
+        <location filename="../../Charts/LTMTool.cpp" line="103"/>
         <source>Shade Zones</source>
         <translation>区间阴影</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="105"/>
+        <location filename="../../Charts/LTMTool.cpp" line="106"/>
         <source>Show Legend</source>
         <translation>显示图例</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="109"/>
         <source>Show Events</source>
         <translation>显示赛事</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="112"/>
         <source>Show Banister Helper</source>
         <translation>显示Banister助手</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="351"/>
+        <location filename="../../Charts/LTMTool.cpp" line="325"/>
         <source>Skiba Long Term Stress</source>
         <translation>Skiba长期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="353"/>
-        <location filename="../../Charts/LTMTool.cpp" line="368"/>
-        <location filename="../../Charts/LTMTool.cpp" line="429"/>
-        <location filename="../../Charts/LTMTool.cpp" line="444"/>
-        <location filename="../../Charts/LTMTool.cpp" line="505"/>
-        <location filename="../../Charts/LTMTool.cpp" line="520"/>
-        <location filename="../../Charts/LTMTool.cpp" line="580"/>
-        <location filename="../../Charts/LTMTool.cpp" line="595"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1080"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1095"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1156"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1171"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1309"/>
+        <location filename="../../Charts/LTMTool.cpp" line="327"/>
+        <location filename="../../Charts/LTMTool.cpp" line="342"/>
+        <location filename="../../Charts/LTMTool.cpp" line="403"/>
+        <location filename="../../Charts/LTMTool.cpp" line="418"/>
+        <location filename="../../Charts/LTMTool.cpp" line="479"/>
+        <location filename="../../Charts/LTMTool.cpp" line="494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="554"/>
+        <location filename="../../Charts/LTMTool.cpp" line="569"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1054"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1069"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1130"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1145"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1278"/>
         <source>Stress</source>
         <translation>压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="366"/>
+        <location filename="../../Charts/LTMTool.cpp" line="340"/>
         <source>Skiba Short Term Stress</source>
         <translation>Skiba短期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="381"/>
+        <location filename="../../Charts/LTMTool.cpp" line="355"/>
         <source>Skiba Stress Balance</source>
         <translation>Skiba压力平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="383"/>
-        <location filename="../../Charts/LTMTool.cpp" line="459"/>
-        <location filename="../../Charts/LTMTool.cpp" line="535"/>
-        <location filename="../../Charts/LTMTool.cpp" line="610"/>
-        <location filename="../../Charts/LTMTool.cpp" line="686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="762"/>
-        <location filename="../../Charts/LTMTool.cpp" line="838"/>
-        <location filename="../../Charts/LTMTool.cpp" line="914"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1110"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1186"/>
+        <location filename="../../Charts/LTMTool.cpp" line="357"/>
+        <location filename="../../Charts/LTMTool.cpp" line="433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="509"/>
+        <location filename="../../Charts/LTMTool.cpp" line="584"/>
+        <location filename="../../Charts/LTMTool.cpp" line="660"/>
+        <location filename="../../Charts/LTMTool.cpp" line="736"/>
+        <location filename="../../Charts/LTMTool.cpp" line="812"/>
+        <location filename="../../Charts/LTMTool.cpp" line="888"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1160"/>
         <source>Stress Balance</source>
         <translation>压力平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="396"/>
+        <location filename="../../Charts/LTMTool.cpp" line="370"/>
         <source>Skiba STS Ramp</source>
         <translation>Skiba短期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="398"/>
-        <location filename="../../Charts/LTMTool.cpp" line="413"/>
-        <location filename="../../Charts/LTMTool.cpp" line="474"/>
-        <location filename="../../Charts/LTMTool.cpp" line="489"/>
-        <location filename="../../Charts/LTMTool.cpp" line="550"/>
-        <location filename="../../Charts/LTMTool.cpp" line="565"/>
-        <location filename="../../Charts/LTMTool.cpp" line="625"/>
-        <location filename="../../Charts/LTMTool.cpp" line="640"/>
-        <location filename="../../Charts/LTMTool.cpp" line="701"/>
-        <location filename="../../Charts/LTMTool.cpp" line="716"/>
-        <location filename="../../Charts/LTMTool.cpp" line="777"/>
-        <location filename="../../Charts/LTMTool.cpp" line="792"/>
-        <location filename="../../Charts/LTMTool.cpp" line="853"/>
-        <location filename="../../Charts/LTMTool.cpp" line="868"/>
-        <location filename="../../Charts/LTMTool.cpp" line="929"/>
-        <location filename="../../Charts/LTMTool.cpp" line="944"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1005"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1020"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1125"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1140"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1201"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1216"/>
+        <location filename="../../Charts/LTMTool.cpp" line="372"/>
+        <location filename="../../Charts/LTMTool.cpp" line="387"/>
+        <location filename="../../Charts/LTMTool.cpp" line="448"/>
+        <location filename="../../Charts/LTMTool.cpp" line="463"/>
+        <location filename="../../Charts/LTMTool.cpp" line="524"/>
+        <location filename="../../Charts/LTMTool.cpp" line="539"/>
+        <location filename="../../Charts/LTMTool.cpp" line="599"/>
+        <location filename="../../Charts/LTMTool.cpp" line="614"/>
+        <location filename="../../Charts/LTMTool.cpp" line="675"/>
+        <location filename="../../Charts/LTMTool.cpp" line="690"/>
+        <location filename="../../Charts/LTMTool.cpp" line="751"/>
+        <location filename="../../Charts/LTMTool.cpp" line="766"/>
+        <location filename="../../Charts/LTMTool.cpp" line="827"/>
+        <location filename="../../Charts/LTMTool.cpp" line="842"/>
+        <location filename="../../Charts/LTMTool.cpp" line="903"/>
+        <location filename="../../Charts/LTMTool.cpp" line="918"/>
+        <location filename="../../Charts/LTMTool.cpp" line="979"/>
+        <location filename="../../Charts/LTMTool.cpp" line="994"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1099"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1114"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1175"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1190"/>
         <source>Ramp</source>
         <translation>变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="411"/>
+        <location filename="../../Charts/LTMTool.cpp" line="385"/>
         <source>Skiba LTS Ramp</source>
         <translation>Skiba长期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="427"/>
+        <location filename="../../Charts/LTMTool.cpp" line="401"/>
         <source>Aerobic TISS Long Term Stress</source>
         <translation>有氧TISS长期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="442"/>
+        <location filename="../../Charts/LTMTool.cpp" line="416"/>
         <source>Aerobic TISS Short Term Stress</source>
         <translation>有氧TISS短期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="457"/>
+        <location filename="../../Charts/LTMTool.cpp" line="431"/>
         <source>Aerobic TISS Stress Balance</source>
         <translation>有氧TISS压力平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="472"/>
+        <location filename="../../Charts/LTMTool.cpp" line="446"/>
         <source>Aerobic TISS STS Ramp</source>
         <translation>有氧TISS短期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="487"/>
+        <location filename="../../Charts/LTMTool.cpp" line="461"/>
         <source>Aerobic TISS LTS Ramp</source>
         <translation>有氧TISS长期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="503"/>
+        <location filename="../../Charts/LTMTool.cpp" line="477"/>
         <source>Anaerobic TISS Long Term Stress</source>
         <translation>无氧TISS长期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="518"/>
+        <location filename="../../Charts/LTMTool.cpp" line="492"/>
         <source>Anaerobic TISS Short Term Stress</source>
         <translation>无氧TISS短期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="533"/>
+        <location filename="../../Charts/LTMTool.cpp" line="507"/>
         <source>Anaerobic TISS Stress Balance</source>
         <translation>无氧TISS压力平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="548"/>
+        <location filename="../../Charts/LTMTool.cpp" line="522"/>
         <source>Anaerobic TISS STS Ramp</source>
         <translation>无氧TISS短期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="537"/>
         <source>Anaerobic TISS LTS Ramp</source>
         <translation>无氧TISS长期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="578"/>
+        <location filename="../../Charts/LTMTool.cpp" line="552"/>
         <source>Daniels Long Term Stress</source>
         <translation>Daniels长期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="593"/>
+        <location filename="../../Charts/LTMTool.cpp" line="567"/>
         <source>Daniels Short Term Stress</source>
         <translation>Daniels短期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="582"/>
         <source>Daniels Stress Balance</source>
         <translation>Daniels压力平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="623"/>
+        <location filename="../../Charts/LTMTool.cpp" line="597"/>
         <source>Daniels STS Ramp</source>
         <translation>Daniels短期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="638"/>
+        <location filename="../../Charts/LTMTool.cpp" line="612"/>
         <source>Daniels LTS Ramp</source>
         <translation>Daniels长期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="882"/>
+        <location filename="../../Charts/LTMTool.cpp" line="856"/>
         <source>Distance (km|mi) Long Term Stress</source>
         <translation>距离(km|mi)长期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="884"/>
-        <location filename="../../Charts/LTMTool.cpp" line="899"/>
+        <location filename="../../Charts/LTMTool.cpp" line="858"/>
+        <location filename="../../Charts/LTMTool.cpp" line="873"/>
         <source>Stress (km|mi)</source>
         <translation>压力(km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="897"/>
+        <location filename="../../Charts/LTMTool.cpp" line="871"/>
         <source>Distance (km|mi) Short Term Stress</source>
         <translation>距离(km|mi)短期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="912"/>
+        <location filename="../../Charts/LTMTool.cpp" line="886"/>
         <source>Distance (km|mi) Stress Balance</source>
         <translation>距离(km|mi)压力平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="927"/>
+        <location filename="../../Charts/LTMTool.cpp" line="901"/>
         <source>Distance (km|mi) STS Ramp</source>
         <translation>距离(km|mi)短期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="942"/>
+        <location filename="../../Charts/LTMTool.cpp" line="916"/>
         <source>Distance (km|mi) LTS Ramp</source>
         <translation>距离(km|mi)长期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="958"/>
+        <location filename="../../Charts/LTMTool.cpp" line="932"/>
         <source>Coggan Chronic Training Load</source>
         <translation>Coggan长期训练负荷</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="973"/>
+        <location filename="../../Charts/LTMTool.cpp" line="947"/>
         <source>Coggan Acute Training Load</source>
         <translation>Coggan短期训练负荷</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="988"/>
+        <location filename="../../Charts/LTMTool.cpp" line="962"/>
         <source>Coggan Training Stress Balance</source>
         <translation>Coggan训练压力平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1003"/>
+        <location filename="../../Charts/LTMTool.cpp" line="977"/>
         <source>Coggan STS Ramp</source>
         <translation>Coggan短期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1018"/>
+        <location filename="../../Charts/LTMTool.cpp" line="992"/>
         <source>Coggan LTS Ramp</source>
         <translation>Coggan长期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1053"/>
         <source>TRIMP Long Term Stress</source>
         <translation>TRIMP长期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1067"/>
         <source>TRIMP Short Term Stress</source>
         <translation>TRIMP短期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1082"/>
         <source>TRIMP Stress Balance</source>
         <translation>TRIMP压力平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1123"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1097"/>
         <source>TRIMP STS Ramp</source>
         <translation>TRIMP短期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1138"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1112"/>
         <source>TRIMP LTS Ramp</source>
         <translation>TRIMP长期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="268"/>
         <source>Edit</source>
-        <translation>编辑</translation>
+        <translation type="vanished">编辑</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="124"/>
+        <location filename="../../Charts/LTMTool.cpp" line="125"/>
         <source>Use sidebar chart settings</source>
         <translation>使用侧边栏图表设置</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Basic</source>
         <translation>基本</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="314"/>
+        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Preset</source>
         <translation>预置</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1307"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1276"/>
         <source>Estimate</source>
         <translation>估计</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1311"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1280"/>
         <source>Formula</source>
         <translation>规则(Formula)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1282"/>
         <source>Measure</source>
         <translation>参数</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1284"/>
         <source>Performance</source>
         <translation>表现</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1317"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1286"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1463"/>
         <source>Chart %1</source>
         <translation>图表 %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="94"/>
+        <location filename="../../Charts/LTMTool.cpp" line="95"/>
         <source>Data Table</source>
         <translation>数据表</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="98"/>
+        <location filename="../../Charts/LTMTool.cpp" line="99"/>
         <source>Show Stack</source>
         <translation>堆叠显示</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="121"/>
+        <location filename="../../Charts/LTMTool.cpp" line="122"/>
         <source>Stack Zoom</source>
         <translation>堆叠缩放</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="155"/>
+        <location filename="../../Charts/LTMTool.cpp" line="156"/>
         <source>Add Current</source>
         <translation>新增目前</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="146"/>
+        <location filename="../../Charts/LTMTool.cpp" line="147"/>
         <source>Charts</source>
         <translation>图表</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="155"/>
         <source>Apply</source>
         <translation>应用</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Up</source>
-        <translation>上</translation>
+        <translation type="vanished">上</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Down</source>
-        <translation>下</translation>
+        <translation type="vanished">下</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="289"/>
         <source>Curves</source>
         <translation>曲线</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="628"/>
         <source>Work (Kj) Long Term Stress</source>
         <translation>做功(kJ)长期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="656"/>
-        <location filename="../../Charts/LTMTool.cpp" line="671"/>
-        <location filename="../../Charts/LTMTool.cpp" line="732"/>
-        <location filename="../../Charts/LTMTool.cpp" line="747"/>
-        <location filename="../../Charts/LTMTool.cpp" line="808"/>
-        <location filename="../../Charts/LTMTool.cpp" line="823"/>
+        <location filename="../../Charts/LTMTool.cpp" line="630"/>
+        <location filename="../../Charts/LTMTool.cpp" line="645"/>
+        <location filename="../../Charts/LTMTool.cpp" line="706"/>
+        <location filename="../../Charts/LTMTool.cpp" line="721"/>
+        <location filename="../../Charts/LTMTool.cpp" line="782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="797"/>
         <source>Stress (Kj)</source>
         <translation>压力(kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="669"/>
+        <location filename="../../Charts/LTMTool.cpp" line="643"/>
         <source>Work (Kj) Short Term Stress</source>
         <translation>做功(kJ)短期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="684"/>
+        <location filename="../../Charts/LTMTool.cpp" line="658"/>
         <source>Work (Kj) Stress Balance</source>
         <translation>做功(kJ)压力平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="699"/>
+        <location filename="../../Charts/LTMTool.cpp" line="673"/>
         <source>Work (Kj) STS Ramp</source>
         <translation>做功(kJ)短期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="714"/>
+        <location filename="../../Charts/LTMTool.cpp" line="688"/>
         <source>Work (Kj) LTS Ramp</source>
         <translation>做功(kJ)长期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="730"/>
+        <location filename="../../Charts/LTMTool.cpp" line="704"/>
         <source>W&apos; Work (Kj) Long Term Stress</source>
         <translation>W&apos;做功(kJ)长期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="745"/>
+        <location filename="../../Charts/LTMTool.cpp" line="719"/>
         <source>W&apos; Work (Kj) Short Term Stress</source>
         <translation>W&apos;做功(kJ)短期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="760"/>
+        <location filename="../../Charts/LTMTool.cpp" line="734"/>
         <source>W&apos; Work (Kj) Stress Balance</source>
         <translation>W&apos;做功(kJ)压力平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="775"/>
+        <location filename="../../Charts/LTMTool.cpp" line="749"/>
         <source>W&apos; Work (Kj) STS Ramp</source>
         <translation>W&apos;做功(kJ)短期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="790"/>
+        <location filename="../../Charts/LTMTool.cpp" line="764"/>
         <source>W&apos; Work (Kj) LTS Ramp</source>
         <translation>W&apos;做功(kJ)长期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="806"/>
+        <location filename="../../Charts/LTMTool.cpp" line="780"/>
         <source>Below CP Work (Kj) Long Term Stress</source>
         <translation>阈值以下做功(kJ)长期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="821"/>
+        <location filename="../../Charts/LTMTool.cpp" line="795"/>
         <source>Below CP Work (Kj) Short Term Stress</source>
         <translation>阈值以下做功(kJ)短期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="836"/>
+        <location filename="../../Charts/LTMTool.cpp" line="810"/>
         <source>Below CP Work (Kj) Stress Balance</source>
         <translation>阈值以下做功(kJ)压力平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="851"/>
+        <location filename="../../Charts/LTMTool.cpp" line="825"/>
         <source>Below CP Work (Kj) STS Ramp</source>
         <translation>阈值以下做功(kJ)短期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="866"/>
+        <location filename="../../Charts/LTMTool.cpp" line="840"/>
         <source>Below CP Work (Kj) LTS Ramp</source>
         <translation>阈值以下做功(kJ)长期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1033"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1007"/>
         <source>Coggan Expected Chronic Training Load</source>
         <translation>Coggan预期长期训练负荷</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1048"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1022"/>
         <source>Coggan Expected Acute Training Load</source>
         <translation>Coggan预期短期训练负荷</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1063"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1037"/>
         <source>Coggan Expected Training Stress Balance</source>
         <translation>Coggan预期训练压力平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1128"/>
         <source>TriScore Long Term Stress</source>
         <translation>TriScore长期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1169"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1143"/>
         <source>TriScore Short Term Stress</source>
         <translation>TriScore短期压力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1184"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1158"/>
         <source>TriScore Stress Balance</source>
         <translation>TriScore压力平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1173"/>
         <source>TriScore STS Ramp</source>
         <translation>TriScore短期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1214"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1188"/>
         <source>TriScore LTS Ramp</source>
         <translation>TriScore长期压力变化率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Details</source>
         <translation>详细信息</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1305"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1274"/>
         <source>Peak</source>
         <translation>峰值</translation>
     </message>
@@ -18474,31 +18465,23 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">更新</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2590"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2602"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2591"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2603"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2596"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2608"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2597"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2609"/>
         <source>Delete</source>
-        <translation>删除</translation>
+        <translation type="vanished">删除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2599"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2467"/>
         <source>Def</source>
         <translation>确定</translation>
     </message>
@@ -18507,14 +18490,14 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">开始日期</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2651"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2790"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2494"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2631"/>
         <source>Lactate Threshold</source>
         <translation>乳酸阈值</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2652"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2791"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2495"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2632"/>
         <source>Aerobic Threshold</source>
         <translation>有氧阈值</translation>
     </message>
@@ -18527,45 +18510,45 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">最多10个区间</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2967"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2974"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2804"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2811"/>
         <source>New</source>
         <translation>新的</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2969"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2976"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2806"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2813"/>
         <source>New (%1)</source>
         <translation>新的(%1)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2653"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2496"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
         <source>Rest HR</source>
         <translation>静止時心率</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2628"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2690"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2770"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2775"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2780"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2785"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2473"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2478"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2488"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2611"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2621"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2626"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2650"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2493"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2630"/>
         <source>Start Date</source>
         <translation type="unfinished">开始日期</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2654"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2497"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2634"/>
         <source>Max HR</source>
         <translation>最大心率</translation>
     </message>
@@ -18574,22 +18557,22 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">yyyy年M月d日</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2701"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2544"/>
         <source>Short</source>
         <translation>简称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2702"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2545"/>
         <source>Long</source>
         <translation>全称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2703"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2546"/>
         <source>From BPM</source>
         <translation>最低心率</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2704"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2547"/>
         <source>Trimp k</source>
         <translation>TRIMP K系数</translation>
     </message>
@@ -19330,62 +19313,62 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>Library</name>
     <message>
+        <location filename="../../Train/Library.cpp" line="126"/>
         <location filename="../../Train/Library.cpp" line="130"/>
-        <location filename="../../Train/Library.cpp" line="134"/>
         <source>Import Videos, VideoSyncs and Workouts</source>
         <translation>导入视频,视频同步和训练课程</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="127"/>
         <location filename="../../Train/Library.cpp" line="131"/>
-        <location filename="../../Train/Library.cpp" line="135"/>
         <source>No supported videos, videoSyncs or workouts were found to import</source>
         <translation>未找到支持的视频,视频同步或训练课程</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="189"/>
         <location filename="../../Train/Library.cpp" line="193"/>
-        <location filename="../../Train/Library.cpp" line="197"/>
+        <location filename="../../Train/Library.cpp" line="198"/>
         <location filename="../../Train/Library.cpp" line="202"/>
-        <location filename="../../Train/Library.cpp" line="206"/>
         <source>Copy VideoSync Failed</source>
         <translation>复制视频同步失败</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="190"/>
         <location filename="../../Train/Library.cpp" line="194"/>
-        <location filename="../../Train/Library.cpp" line="198"/>
         <source>%1 already exists in videoSync library: %2</source>
         <translation>%1已在视频同步库中:%2</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="203"/>
+        <location filename="../../Train/Library.cpp" line="199"/>
         <source>%1 cannot be written to videoSync library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="207"/>
+        <location filename="../../Train/Library.cpp" line="203"/>
         <source>%1 cannot be written to videoSync library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="253"/>
+        <location filename="../../Train/Library.cpp" line="249"/>
         <source>%1 cannot be written to workout library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="257"/>
+        <location filename="../../Train/Library.cpp" line="253"/>
         <source>%1 cannot be written to workout library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="239"/>
         <location filename="../../Train/Library.cpp" line="243"/>
-        <location filename="../../Train/Library.cpp" line="247"/>
+        <location filename="../../Train/Library.cpp" line="248"/>
         <location filename="../../Train/Library.cpp" line="252"/>
-        <location filename="../../Train/Library.cpp" line="256"/>
         <source>Copy Workout Failed</source>
         <translation>复制训练课程失败</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="240"/>
         <location filename="../../Train/Library.cpp" line="244"/>
-        <location filename="../../Train/Library.cpp" line="248"/>
         <source>%1 already exists in workout library: %2</source>
         <translation>%1已在训练课程库中:%2</translation>
     </message>
@@ -19393,89 +19376,89 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LibrarySearchDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="330"/>
+        <location filename="../../Train/Library.cpp" line="326"/>
         <source>Search for Workouts, Syncs and Media</source>
         <translation>搜索训练课程,视频同步和媒体</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="337"/>
+        <location filename="../../Train/Library.cpp" line="333"/>
         <source>Workout files (.erg, .mrc, .zwo etc)</source>
         <translation>训练课程文件 (.erg, .mrc, .zwo等)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="339"/>
+        <location filename="../../Train/Library.cpp" line="335"/>
         <source>Video files (.mp4, .avi etc)</source>
         <translation>视频文件(.mp4, .avi等)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="341"/>
+        <location filename="../../Train/Library.cpp" line="337"/>
         <source>VideoSync files (.rlv, .tts etc)</source>
         <translation>视频同步文件 (.rlv, .tts等)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="359"/>
+        <location filename="../../Train/Library.cpp" line="353"/>
         <source>Search Path</source>
         <translation>搜索路径</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="379"/>
+        <location filename="../../Train/Library.cpp" line="373"/>
         <source>Video references</source>
         <translation>视频引用</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="391"/>
+        <location filename="../../Train/Library.cpp" line="385"/>
         <source>Searching...</source>
         <translation>搜索中...</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="394"/>
+        <location filename="../../Train/Library.cpp" line="388"/>
         <source>Videos</source>
         <translation>视频</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="396"/>
+        <location filename="../../Train/Library.cpp" line="390"/>
         <source>Workouts</source>
         <translation>训练课程</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="398"/>
+        <location filename="../../Train/Library.cpp" line="392"/>
         <source>VideoSyncs</source>
         <translation>视频同步</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="407"/>
-        <location filename="../../Train/Library.cpp" line="494"/>
+        <location filename="../../Train/Library.cpp" line="401"/>
+        <location filename="../../Train/Library.cpp" line="484"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="409"/>
+        <location filename="../../Train/Library.cpp" line="403"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="412"/>
+        <location filename="../../Train/Library.cpp" line="406"/>
         <source>Files to search for:</source>
         <translation>搜索的文件:</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="475"/>
+        <location filename="../../Train/Library.cpp" line="466"/>
         <source>Abort Search</source>
         <translation>放弃搜索</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="515"/>
-        <location filename="../../Train/Library.cpp" line="559"/>
+        <location filename="../../Train/Library.cpp" line="504"/>
+        <location filename="../../Train/Library.cpp" line="548"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="557"/>
+        <location filename="../../Train/Library.cpp" line="546"/>
         <source>Search completed.</source>
         <translation>搜索完成.</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="645"/>
+        <location filename="../../Train/Library.cpp" line="634"/>
         <source>Select Directory</source>
         <translation>选择文件夹</translation>
     </message>
@@ -19483,12 +19466,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>ListEditWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="623"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="654"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="625"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="656"/>
         <source>New (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19501,7 +19484,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="90"/>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="85"/>
+        <source>Initial Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="98"/>
         <source>Apply changes</source>
         <translation>应用更改</translation>
     </message>
@@ -19720,7 +19708,7 @@ on and that its display says, &quot;PC Link&quot;</source>
         <translation>切换侧边栏</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>Delete Activity</source>
         <translation>删除活动</translation>
     </message>
@@ -19786,70 +19774,70 @@ on and that its display says, &quot;PC Link&quot;</source>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Activity Import</source>
         <translation>活动导入</translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Closing of athlete window not possible while background activity import is in progress...</source>
         <translation>后台活动导入中,无法关闭运动员窗口...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Chart Import</source>
         <translation>图表导入</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1778"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1788"/>
         <source>Failed to export activity, please check permissions</source>
         <translation>导出活动失败,请检查权限</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1814"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1824"/>
         <source>No Activity To Save</source>
         <translation>无活动可保存</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1815"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1825"/>
         <source>There is no currently selected activity to save.</source>
         <translation>目前无选中活动以保存</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
         <location filename="../../Gui/MainWindow.cpp" line="1886"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Split Activity</source>
         <translation>分割活动</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
         <source>No activity selected</source>
         <translation>未选择活动</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
         <source>Current activity contains no data to split</source>
         <translation>目前活动无可分割的数据</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Current activity contains no data to merge</source>
         <translation>目前活动无可合并的数据</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1904"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1914"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation>确认删除活动:</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2400"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2421"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2410"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2431"/>
         <source>The workout directory is not configured, or the directory selected no longer exists.
 
 Please check your preference settings.</source>
@@ -19858,7 +19846,7 @@ Please check your preference settings.</source>
 请检查设置.</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2611"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2621"/>
         <source>Loading activities: %1%</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19871,14 +19859,14 @@ Please check your preference settings.</source>
         <translation type="vanished">管理Python修正...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>CloudDB</source>
         <translation>云数据库</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>Current athlete is not registered as curator - please contact the GoldenCheetah team</source>
         <translation>目前运动员未注册为管理员 - 请联系GC团队</translation>
     </message>
@@ -19973,7 +19961,7 @@ Please check your preference settings.</source>
         <translation>确认继续?</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2165"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2175"/>
         <source>&amp;New Athlete...</source>
         <translation>新建运动员(&amp;N)...</translation>
     </message>
@@ -19998,23 +19986,23 @@ Please check your preference settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
         <source>Select Activity</source>
         <translation>选择活动</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>No activity selected!</source>
         <translation>未选择活动！</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1724"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1734"/>
         <source>Export Activity</source>
         <translation>导出活动</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1777"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1787"/>
         <source>Export Failed</source>
         <translation>导出失败</translation>
     </message>
@@ -20356,59 +20344,59 @@ Please check your preference settings.</source>
         <translation>导入透视</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Imported %1 metric charts</source>
         <translation>已导入%1个指标图表</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>Import Images Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>You can only import images on the activities view with an activity selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>Import Images to Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>%1 images imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1799"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2369"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1809"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2379"/>
         <source>Import from File</source>
         <translation>从文件导入</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2342"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2352"/>
         <source>Refresh in Progress</source>
         <translation>刷新中</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Export Metrics</source>
         <translation>导出指标</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation>逗号分隔值 (*.csv)</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2399"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2420"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2409"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2430"/>
         <source>Workout Directory Invalid</source>
         <translation>训练课程文件夹无效</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1906"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1916"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
@@ -21364,23 +21352,23 @@ Please check your preference settings.</source>
         <translation type="vanished">时域1%参数</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="656"/>
+        <location filename="../../Gui/AthletePages.cpp" line="641"/>
         <source>From Date - Time</source>
         <translation>从日期 - 时间</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="780"/>
+        <location filename="../../Gui/AthletePages.cpp" line="751"/>
         <source>Start Date</source>
         <translation type="unfinished">开始日期</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="893"/>
+        <location filename="../../Gui/AthletePages.cpp" line="864"/>
         <source>MMM d, yyyy - hh:mm:ss</source>
         <translation>yyyy年M月d日, hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="659"/>
-        <location filename="../../Gui/AthletePages.cpp" line="807"/>
+        <location filename="../../Gui/AthletePages.cpp" line="644"/>
+        <location filename="../../Gui/AthletePages.cpp" line="778"/>
         <source>Comment</source>
         <translation>注释</translation>
     </message>
@@ -21389,32 +21377,28 @@ Please check your preference settings.</source>
         <translation type="vanished">更新</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="662"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="663"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">新增</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">删除</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="668"/>
-        <source>Add</source>
-        <translation>新增</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="669"/>
-        <source>Delete</source>
-        <translation>删除</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="698"/>
         <source>Source</source>
         <translation>来源</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="699"/>
+        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Original Source</source>
         <translation>原始来源</translation>
     </message>
@@ -22109,17 +22093,17 @@ No rides found to import.
 <context>
     <name>MultiDeviceDialog</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3048"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3060"/>
         <source>Multiple Device Configuration</source>
         <translation>多设备设置</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3103"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3115"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3106"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3118"/>
         <source>Apply</source>
         <translation>应用</translation>
     </message>
@@ -23136,42 +23120,38 @@ No rides found to import.
 <context>
     <name>PaceSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3154"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3155"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3160"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3161"/>
         <source>Delete</source>
-        <translation>删除</translation>
+        <translation type="vanished">删除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3176"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2987"/>
         <source>Short</source>
         <translation>简称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3177"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2988"/>
         <source>Long</source>
         <translation>全称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3178"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2989"/>
         <source>Percent of CV</source>
         <translation>CV百分比</translation>
     </message>
@@ -23180,14 +23160,14 @@ No rides found to import.
         <translation type="vanished">最多10个区间</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3220"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3227"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3037"/>
         <source>New</source>
         <translation>新的</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3222"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3229"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3032"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3039"/>
         <source>New (%1)</source>
         <translation>新的(%1)</translation>
     </message>
@@ -23387,27 +23367,27 @@ No rides found to import.
 <context>
     <name>PaceZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3082"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2905"/>
         <source>Sport</source>
         <translation>运动</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3084"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2907"/>
         <source>Run</source>
         <translation>跑步</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3085"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2908"/>
         <source>Swim</source>
         <translation>游泳</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3126"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2949"/>
         <source>Critical Velocity</source>
         <translation>临界速度</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2950"/>
         <source>Default</source>
         <translation>默认</translation>
     </message>
@@ -25555,78 +25535,79 @@ Do you want to continue?</source>
 <context>
     <name>PerspectiveDialog</name>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="34"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="35"/>
         <source>Manage Perspectives</source>
         <translation>管理透视</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="43"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="44"/>
         <source>Perspectives</source>
         <translation>透视</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="60"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="61"/>
         <source>Charts</source>
         <translation>图表</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Edit</source>
-        <translation>编辑</translation>
+        <translation type="vanished">编辑</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="83"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="78"/>
         <source>Import</source>
         <translation>导入</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="84"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="77"/>
         <source>Export</source>
         <translation>导出</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="90"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="91"/>
         <source>Delete</source>
-        <translation>删除</translation>
+        <translation type="vanished">删除</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="98"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Drag charts to move to a perspective</source>
         <translation>拖动图表移动到透视</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="287"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="256"/>
         <source>Export Persepctive</source>
         <translation>导出透视</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
         <source>Export Perspective</source>
         <translation>导出透视</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>No perspective file selected!</source>
         <translation>未选择透视文件!</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
         <source>Select Perspective file to export</source>
-        <translation>选择要导入的透视文件</translation>
+        <translation type="vanished">选择要导入的透视文件</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
         <source>GoldenCheetah Perspective Files (*.gchartset)</source>
         <translation>GoldenCheetah透视文件 (*.gchartset)</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
+        <source>Select Perspective file to import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>Import Perspective</source>
         <translation>导入透视</translation>
     </message>
@@ -26784,307 +26765,307 @@ Python disabled in preferences.</source>
 <context>
     <name>RealtimeData</name>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="621"/>
+        <location filename="../../Train/RealtimeData.cpp" line="623"/>
         <source>None</source>
         <translation>无</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="624"/>
+        <location filename="../../Train/RealtimeData.cpp" line="626"/>
         <source>Time</source>
         <translation>时间</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="627"/>
+        <location filename="../../Train/RealtimeData.cpp" line="629"/>
         <source>Lap</source>
         <translation>圈</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="630"/>
+        <location filename="../../Train/RealtimeData.cpp" line="632"/>
         <source>Lap Time</source>
         <translation>单圈时间</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="633"/>
+        <location filename="../../Train/RealtimeData.cpp" line="635"/>
         <source>Lap Time Remaining</source>
         <translation>单圈剩余时间</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="636"/>
+        <location filename="../../Train/RealtimeData.cpp" line="638"/>
         <source>Section Time Remaining</source>
         <translation>分段剩余时间</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="639"/>
+        <location filename="../../Train/RealtimeData.cpp" line="641"/>
         <source>BikeStress</source>
         <translation>BikeStress</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="645"/>
+        <location filename="../../Train/RealtimeData.cpp" line="647"/>
         <source>kJoules</source>
         <translation>kJ</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="648"/>
+        <location filename="../../Train/RealtimeData.cpp" line="650"/>
         <source>W&apos; bal</source>
         <translation>W&apos;平衡</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="651"/>
+        <location filename="../../Train/RealtimeData.cpp" line="653"/>
         <source>XPower</source>
         <translation>xPower</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="654"/>
+        <location filename="../../Train/RealtimeData.cpp" line="656"/>
         <source>Iso Power</source>
         <translation>标准化功率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="657"/>
+        <location filename="../../Train/RealtimeData.cpp" line="659"/>
         <source>Intensity Factor</source>
         <translation>强度系数</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="660"/>
+        <location filename="../../Train/RealtimeData.cpp" line="662"/>
         <source>Relative Intensity</source>
         <translation>相对强度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="663"/>
+        <location filename="../../Train/RealtimeData.cpp" line="665"/>
         <source>Skiba Variability Index</source>
         <translation>Skiba变化指数</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="666"/>
+        <location filename="../../Train/RealtimeData.cpp" line="668"/>
         <source>Variability Index</source>
         <translation>变化指数</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="669"/>
+        <location filename="../../Train/RealtimeData.cpp" line="671"/>
         <source>Distance</source>
         <translation>距离</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="672"/>
+        <location filename="../../Train/RealtimeData.cpp" line="674"/>
         <source>Route Distance</source>
         <translation>路线距离</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="675"/>
+        <location filename="../../Train/RealtimeData.cpp" line="677"/>
         <source>Distance Remaining</source>
         <translation>剩余距离</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="678"/>
+        <location filename="../../Train/RealtimeData.cpp" line="680"/>
         <source>Alternate Power</source>
         <translation>功率 (备用)</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="681"/>
+        <location filename="../../Train/RealtimeData.cpp" line="683"/>
         <source>Power</source>
         <translation>功率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="684"/>
+        <location filename="../../Train/RealtimeData.cpp" line="686"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="687"/>
+        <location filename="../../Train/RealtimeData.cpp" line="689"/>
         <source>Virtual Speed</source>
         <translation>虚拟速度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="690"/>
+        <location filename="../../Train/RealtimeData.cpp" line="692"/>
         <source>Cadence</source>
         <translation>踏频</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="693"/>
+        <location filename="../../Train/RealtimeData.cpp" line="695"/>
         <source>Heart Rate</source>
         <translation>心率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="696"/>
+        <location filename="../../Train/RealtimeData.cpp" line="698"/>
         <source>Target Power</source>
         <translation>目标功率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="699"/>
+        <location filename="../../Train/RealtimeData.cpp" line="701"/>
         <source>Average Power</source>
         <translation>平均功率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="702"/>
+        <location filename="../../Train/RealtimeData.cpp" line="704"/>
         <source>Average Speed</source>
         <translation>平均速度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="705"/>
+        <location filename="../../Train/RealtimeData.cpp" line="707"/>
         <source>Average Heartrate</source>
         <translation>平均心率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="708"/>
+        <location filename="../../Train/RealtimeData.cpp" line="710"/>
         <source>Average Cadence</source>
         <translation>平均踏频</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="711"/>
+        <location filename="../../Train/RealtimeData.cpp" line="713"/>
         <source>Lap Power</source>
         <translation>单圈功率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="714"/>
+        <location filename="../../Train/RealtimeData.cpp" line="716"/>
         <source>Lap Speed</source>
         <translation>单圈速度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="717"/>
+        <location filename="../../Train/RealtimeData.cpp" line="719"/>
         <source>Lap Heartrate</source>
         <translation>单圈心率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="720"/>
+        <location filename="../../Train/RealtimeData.cpp" line="722"/>
         <source>Lap Cadence</source>
         <translation>单圈踏频</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="723"/>
+        <location filename="../../Train/RealtimeData.cpp" line="725"/>
         <source>Left/Right Balance</source>
         <translation>左/右平衡</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="726"/>
+        <location filename="../../Train/RealtimeData.cpp" line="728"/>
         <source>Total Hb Mass</source>
         <translation>总血红蛋白质量</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="729"/>
+        <location filename="../../Train/RealtimeData.cpp" line="731"/>
         <source>Hb O2 Saturation</source>
         <translation>血红蛋白氧饱和度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="732"/>
+        <location filename="../../Train/RealtimeData.cpp" line="734"/>
         <source>Deoxy Hb</source>
         <translation>脱氧血红蛋白</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="735"/>
+        <location filename="../../Train/RealtimeData.cpp" line="737"/>
         <source>Oxy Hb</source>
         <translation>氧合血红蛋白</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="738"/>
+        <location filename="../../Train/RealtimeData.cpp" line="740"/>
         <source>Left Torque Effectiveness</source>
         <translation>左扭矩效率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="741"/>
+        <location filename="../../Train/RealtimeData.cpp" line="743"/>
         <source>Right Torque Effectiveness</source>
         <translation>右扭矩效率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="744"/>
+        <location filename="../../Train/RealtimeData.cpp" line="746"/>
         <source>Left Pedal Smoothness</source>
         <translation>左踏板平滑度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="747"/>
+        <location filename="../../Train/RealtimeData.cpp" line="749"/>
         <source>Right Pedal Smoothness</source>
         <translation>右踏板平滑度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="750"/>
+        <location filename="../../Train/RealtimeData.cpp" line="752"/>
         <source>Right Power Phase Start</source>
         <translation type="unfinished">右功率相起始角度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="753"/>
+        <location filename="../../Train/RealtimeData.cpp" line="755"/>
         <source>Right Power Phase End</source>
         <translation type="unfinished">右功率相结束角度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="756"/>
+        <location filename="../../Train/RealtimeData.cpp" line="758"/>
         <source>Right Power Phase Peak Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="759"/>
+        <location filename="../../Train/RealtimeData.cpp" line="761"/>
         <source>Right Power Phase Peak End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="762"/>
+        <location filename="../../Train/RealtimeData.cpp" line="764"/>
         <source>Slope</source>
         <translation>坡度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="765"/>
+        <location filename="../../Train/RealtimeData.cpp" line="767"/>
         <source>Lap Distance</source>
         <translation>单圈距离</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="768"/>
+        <location filename="../../Train/RealtimeData.cpp" line="770"/>
         <source>Lap Distance Remaining</source>
         <translation>单圈剩余距离</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="771"/>
+        <location filename="../../Train/RealtimeData.cpp" line="773"/>
         <source>Latitude</source>
         <translation>纬度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="774"/>
+        <location filename="../../Train/RealtimeData.cpp" line="776"/>
         <source>Longitude</source>
         <translation>经度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="777"/>
+        <location filename="../../Train/RealtimeData.cpp" line="779"/>
         <source>Altitude</source>
         <translation>海拔</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="780"/>
+        <location filename="../../Train/RealtimeData.cpp" line="782"/>
         <source>Respiratory Frequency</source>
         <translation>呼吸频率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="783"/>
+        <location filename="../../Train/RealtimeData.cpp" line="785"/>
         <source>Ventilation</source>
         <translation>换气</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="786"/>
+        <location filename="../../Train/RealtimeData.cpp" line="788"/>
         <source>VO2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="789"/>
+        <location filename="../../Train/RealtimeData.cpp" line="791"/>
         <source>VCO2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="792"/>
+        <location filename="../../Train/RealtimeData.cpp" line="794"/>
         <source>Respiratory Exchange Ratio</source>
         <translation>呼吸交换率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="795"/>
+        <location filename="../../Train/RealtimeData.cpp" line="797"/>
         <source>Tidal Volume</source>
         <translation>潮气量</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="798"/>
+        <location filename="../../Train/RealtimeData.cpp" line="800"/>
         <source>Fraction O2 Expired</source>
         <translation>呼出氧气</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="801"/>
+        <location filename="../../Train/RealtimeData.cpp" line="803"/>
         <source>Temperature</source>
         <translation type="unfinished">温度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="804"/>
+        <location filename="../../Train/RealtimeData.cpp" line="806"/>
         <source>CoreTemp</source>
         <translation type="unfinished"></translation>
     </message>
@@ -27180,22 +27161,22 @@ Python disabled in preferences.</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Series</source>
         <translation>系列</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Value</source>
         <translation>数值</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="172"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
         <source>Power</source>
         <translation>功率</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="176"/>
         <source>Heart Rate</source>
         <translation>心率</translation>
     </message>
@@ -29492,317 +29473,317 @@ native format. Should we do so?
 <context>
     <name>ScatterPlot</name>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="113"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
         <source>Power (watts)</source>
         <translation>功率(W)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
         <source>Cadence (rpm)</source>
         <translation>踏频 (rpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="116"/>
         <source>Heartrate (bpm)</source>
         <translation>心率 (bpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="118"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="119"/>
         <source>Speed (kph)</source>
         <translation>速度 (km/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="120"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="121"/>
         <source>Speed (mph)</source>
         <translation>速度 (mi/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="124"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="125"/>
         <source>Altitude (meters)</source>
         <translation>海拔 (m)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="126"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="127"/>
         <source>Altitude (feet)</source>
         <translation>海拔 (ft)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="128"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
         <source>Torque (N)</source>
         <translation>扭距 (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="130"/>
         <source>Elapsed Time (secs)</source>
         <translation>历时 (s)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="132"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="133"/>
         <source>Elapsed Distance (km)</source>
         <translation>距离 (km)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="134"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="135"/>
         <source>Elapsed Distance (mi)</source>
         <translation>距离 (mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="136"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
         <source>Interval Number</source>
         <translation>间歇数</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
         <source>Latitude (degree offset)</source>
         <translation>纬度 (偏移度)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
         <source>Longitude (degree offset)</source>
         <translation>经度 (偏移度)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
         <source>Circumferential Pedal Velocity (m/s)</source>
         <translation>圆周踏板速度 (m/s)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="141"/>
         <source>Average Effective Pedal Force (N)</source>
         <translation>平均有效踩踏力 (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="144"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
         <source>Time at X/Y (%)</source>
         <translation>X/Y处时间 (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
         <source>Power Zone</source>
         <translation>功率区间</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
         <source>Headwind (kph)</source>
         <translation>逆风 (km/h)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
         <source>Slope (gradient)</source>
         <translation>坡度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
         <source>Temperature (C)</source>
         <translation>温度 (ºC)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
         <source>L/R Balance</source>
         <translation>左/右平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
         <source>Torque Efficiency</source>
         <translation>扭矩效率</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
         <source>Pedal Smoothness</source>
         <translation>踏板平滑度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
         <source>Running Vertical Oscillation</source>
         <translation>跑步垂直振幅</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
         <source>Running Ground Contact Time</source>
         <translation>触地时间</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
         <source>Running Cadence</source>
         <translation>步频</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
         <source>Gear Ratio</source>
         <translation>齿比</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
         <source>Muscle Oxygen</source>
         <translation>肌肉含氧量</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
         <source>Haemoglobin Mass</source>
         <translation>总血红蛋白量</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
         <source>Deoxygenated Haemoglobin</source>
         <translation>缺氧血红蛋白</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="160"/>
         <source>Oxygenated Haemoglobin</source>
         <translation>氧合血红蛋白</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="161"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="162"/>
         <source>Unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="165"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
         <source>Power</source>
         <translation>功率</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
         <source>Cadence</source>
         <translation>踏频</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
         <source>Heartrate</source>
         <translation>心率</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
         <source>Altitude</source>
         <translation>海拔</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
         <source>Pedal Force</source>
         <translation>踩踏力</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
         <source>Time</source>
         <translation>时间</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
         <source>Distance</source>
         <translation>距离</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
         <source>Interval</source>
         <translation>间歇</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
         <source>Latitude</source>
         <translation>纬度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
         <source>Longitude</source>
         <translation>经度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
         <source>Time at X/Y</source>
         <translation>X/Y处时间</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
         <source>Zone</source>
         <translation>区间</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
         <source>CPV</source>
         <translation>CPV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
         <source>AEPF</source>
         <translation>AEPF</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
         <source>Headwind</source>
         <translation>逆风</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
         <source>Slope</source>
         <translation>坡度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
         <source>Temp</source>
         <translation>温度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
         <source>Balance</source>
         <translation>平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
         <source>TE</source>
         <translation>TE</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
         <source>PS</source>
         <translation>PS</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
         <source>RV</source>
         <translation>RV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
         <source>GCT</source>
         <translation>触地时间</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
         <source>Run Cad</source>
         <translation>步频</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
         <source>Gear</source>
         <translation>齿比</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="194"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="195"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="196"/>
         <source>None</source>
         <translation>无</translation>
     </message>
@@ -30040,42 +30021,38 @@ native format. Should we do so?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1012"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1013"/>
         <source>Delete</source>
-        <translation>删除</translation>
+        <translation type="vanished">删除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1006"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1007"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1023"/>
+        <location filename="../../Gui/AthletePages.cpp" line="982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="988"/>
         <source>Short</source>
         <translation>简称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="989"/>
         <source>Long</source>
         <translation>全称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1031"/>
+        <location filename="../../Gui/AthletePages.cpp" line="990"/>
         <source>Percent of CP</source>
         <translation>CP百分比</translation>
     </message>
@@ -30084,14 +30061,14 @@ native format. Should we do so?
         <translation type="vanished">最多10个区间</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1069"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1076"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1034"/>
         <source>New</source>
         <translation>新的</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1071"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1078"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1036"/>
         <source>New (%1)</source>
         <translation>新的(%1)</translation>
     </message>
@@ -30264,64 +30241,64 @@ native format. Should we do so?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3821"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3569"/>
         <source>Add</source>
         <translation>新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3822"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3570"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3823"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3571"/>
         <source>Up</source>
         <translation>上</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3824"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3572"/>
         <source>Down</source>
         <translation>下</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3870"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3872"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3963"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3965"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3711"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3713"/>
         <source>ddd MMM d, yyyy</source>
         <translation>yyyy年M月d日 ddd</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3557"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3810"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3558"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3804"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3835"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3583"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3805"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3836"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3553"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3584"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3806"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3837"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3554"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3585"/>
         <source>From</source>
         <translation>从</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3807"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3838"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3555"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3586"/>
         <source>To</source>
         <translation>到</translation>
     </message>
@@ -32764,25 +32741,25 @@ tab.</source>
 <context>
     <name>TrainSidebar</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="253"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="257"/>
         <source>Save workout data</source>
         <translation>保存训练课程数据</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="259"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="263"/>
         <source>Devices</source>
         <translation>设备</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="262"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="267"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="311"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="321"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="271"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="315"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="325"/>
         <source>Menu</source>
         <translation>菜单</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="270"/>
         <source>Workouts</source>
         <translation>训练课程</translation>
     </message>
@@ -32791,143 +32768,143 @@ tab.</source>
         <translation type="obsolete">过滤...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="303"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="307"/>
         <source>Workout Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="310"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="314"/>
         <source>Media</source>
         <translation>媒体</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="320"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="324"/>
         <source>VideoSync</source>
         <translation>视频同步</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="506"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
         <source>Import Workout from File</source>
         <translation>从文件导入训练课程</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="507"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="511"/>
         <source>Get Workouts from TrainerDay</source>
         <translation>从TrainerDay获取训练课程</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="509"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="513"/>
         <source>Create Workout via Wizard</source>
         <translation>通过向导创建训练课程</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="514"/>
         <source>Scan for Workouts</source>
         <translation>扫描训练课程</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="534"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="538"/>
         <source>Delete selected Workout</source>
         <translation>删除选中的训练课程</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="541"/>
         <source>Delete %1 selected Workouts</source>
         <translation>删除选中的%1个训练课程</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Train mode active</source>
         <translation>训练模式已激活</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Please stop the train mode before closing the window or application.</source>
         <translation>关闭窗口或应用请停止训练模式.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="635"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="639"/>
         <source>Remove reference to selected video</source>
         <translation>移除选中视频的引用</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="650"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="654"/>
         <source>Import VideoSync from File</source>
         <translation>从文件导入视频同步</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="651"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="655"/>
         <source>Scan for VideoSyncs</source>
         <translation>扫描视频同步</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="668"/>
         <source>Delete selected VideoSync</source>
         <translation>删除选中的视频同步</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1064"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1068"/>
         <source>Are you sure you want to remove the reference to this video?</source>
         <translation>确认删除此视频的引用?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1066"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1128"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1204"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1070"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1132"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1208"/>
         <source>Remove</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1099"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1103"/>
         <source>Are you sure you want to delete this VideoSync?</source>
         <translation>确认删除此视频同步?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1126"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1130"/>
         <source>The VideoSync file is either not valid or not existing and will be removed from the library.</source>
         <translation>此视频同步文件无效或不存在,将被从库中删除.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1160"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1164"/>
         <source>Are you sure you want to delete this Workout?</source>
         <translation>确认删除此训练课程?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1163"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1167"/>
         <source>Are you sure you want to delete this %1 workouts?</source>
         <translation>确认删除这%1个训练课程?</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1202"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1206"/>
         <source>The Workout file is either not valid or not existing and will be removed from the library.</source>
         <translation>此训练课程文件无效或不存在,将被从库中删除.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1347"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1351"/>
         <source>Starting in %1</source>
         <translation>%1秒后开始</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2225"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2237"/>
         <source>Recalibrating steering..</source>
         <translation>正在校准转向..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2521"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2525"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2594"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2645"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2649"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2533"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2606"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2657"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2661"/>
         <source>Requesting calibration..</source>
         <translation>正在请求校准..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2532"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2544"/>
         <source>Calibrating...</source>
         <translation>校准中...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2536"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2548"/>
         <source>Calibrating...
 Current speed %1 kph
 Increase speed to %2 kph</source>
@@ -32936,14 +32913,14 @@ Increase speed to %2 kph</source>
 加快速度到 %2 km/h</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2540"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2552"/>
         <source>Calibrating...
 Stop pedalling until speed drops to 0</source>
         <translation>校准中...
 停止踩踏,直到速度为0</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2545"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2557"/>
         <source>Calibration completed successfully!
 Spindown %1 ms
 Zero Offset %2</source>
@@ -32952,30 +32929,30 @@ Zero Offset %2</source>
 零值偏移 %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2553"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2620"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2672"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2565"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2632"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2684"/>
         <source>Calibration failed!</source>
         <translation>校准失败!</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2573"/>
         <source>Calibration Failed: Loosen Roller</source>
         <translation>校准失败: 滚筒过松</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2569"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2581"/>
         <source>Calibration Failed: Tighten Roller</source>
         <translation>校准失败: 滚筒过紧</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2588"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2639"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2600"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2651"/>
         <source>Unclip or stop pedalling to begin calibration..</source>
         <translation>解锁或停止踩踏来开始校准...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2607"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2619"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Torque %1</source>
@@ -32984,7 +32961,7 @@ Torque %1</source>
 扭矩 %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2612"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2624"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Torque %2</source>
@@ -32993,7 +32970,7 @@ Torque %2</source>
 扭矩 %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2659"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2671"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Zero Offset %1</source>
@@ -33002,7 +32979,7 @@ Zero Offset %1</source>
 零值偏移 %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2676"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Slope %2</source>
@@ -33011,175 +32988,175 @@ Slope %2</source>
 斜率 %2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2693"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2705"/>
         <source>Give the pedal a kick to start calibration...
 The motor will run until calibration is complete.</source>
         <translation>踩踏以开始校准...
 电机将一直运行,直到校准完成.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2695"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
         <source>Allow wheel speed to settle, DO NOT PEDAL...
 The motor will run until calibration is complete.</source>
         <translation>让车轮速度保持平稳, 不要踩踏...
 电机将一直运行,直到校准完成.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2700"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2712"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Gathering enough samples to calculate average: %1</source>
         <translation>校准中...不要踩踏或离开坐垫...
 收集足够样本中: %1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2719"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Waiting for value to stabilize (max %1s): %2 (%3W @ %4kph)</source>
         <translation>校准中...不要踩踏或离开坐垫...
 等待数值稳定 (最大 %1s): %2 (%3W @ %4kph)</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2722"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
         <source>Calibration completed successfully!
 Final calibration value %1 (%2W @ %3kph)</source>
         <translation>校准成功!
 最终校准值: %1 (%2W @ %3kph)</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2746"/>
         <source>Calibration failed! Do not pedal while calibration is taking place.
 Allow wheel to run freely.</source>
         <translation>校准失败!校准中不要踩踏.
 让车轮自由转动.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2780"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2792"/>
         <source>Fast forward..</source>
         <translation>快进..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2813"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2825"/>
         <source>Rewind..</source>
         <translation>快退..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2843"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2855"/>
         <source>Next Lap..</source>
         <translation>下一圈..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2876"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2888"/>
         <source>Back Lap..</source>
         <translation>上一圈..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2902"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2914"/>
         <source>Increasing intensity..</source>
         <translation>增大阻力..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2928"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2940"/>
         <source>Decreasing intensity..</source>
         <translation>减小阻力..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="621"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="625"/>
         <source>Import Video from File</source>
         <translation>从文件导入视频</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="508"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="512"/>
         <source>Get Workouts from Strava Routes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="622"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="626"/>
         <source>Scan for Videos</source>
         <translation>扫描视频</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1101"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1173"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3183"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1105"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1177"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3195"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1309"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1313"/>
         <source>Resuming..</source>
         <translation>恢复中..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1336"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1340"/>
         <source>Paused..</source>
         <translation>已暂停..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1465"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1469"/>
         <source>Starting..</source>
         <translation>开始中..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1673"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1677"/>
         <source>Stopped..</source>
         <translation>已停止..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1763"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1769"/>
         <source>Connected..</source>
         <translation>已连接..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1787"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1793"/>
         <source>Disconnected..</source>
         <translation>已断开..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2198"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2210"/>
         <source>New lap..</source>
         <translation>新计圈..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>No Devices Configured</source>
         <translation>未设定设备</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>Please configure a device in Preferences.</source>
         <translation>请在选项中设置一个设备.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2483"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2495"/>
         <source>Exiting calibration..</source>
         <translation>退出校准..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2498"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2510"/>
         <source>Calibration not supported for this device.</source>
         <translation>不支持此设备的校准.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2505"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2517"/>
         <source>Calibrating...
 Press F3 on Controller when done.</source>
         <translation>校准中...
 完成后按控制器上的E3.</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3135"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3153"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3147"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3165"/>
         <source>Add Device</source>
         <translation>新增设备</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3140"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3158"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3152"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3170"/>
         <source>Delete Device</source>
         <translation>删除设备</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3181"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3193"/>
         <source>Are you sure you want to delete this device?</source>
         <translation>确认删除此设备?</translation>
     </message>
@@ -33496,7 +33473,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>UniqueLabelEditDelegate</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="77"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="108"/>
         <source>The given value &quot;%1&quot; is not unique</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33512,171 +33489,167 @@ Press F3 on Controller when done.</source>
 <context>
     <name>UserChartSettings</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="772"/>
+        <location filename="../../Charts/UserChart.cpp" line="773"/>
         <source>Chart</source>
         <translation>图表</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="782"/>
+        <location filename="../../Charts/UserChart.cpp" line="783"/>
         <source>Sub-title</source>
         <translation>小标题</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="785"/>
+        <location filename="../../Charts/UserChart.cpp" line="786"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="791"/>
+        <location filename="../../Charts/UserChart.cpp" line="792"/>
         <source>Line Chart</source>
         <translation>线图</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="792"/>
+        <location filename="../../Charts/UserChart.cpp" line="793"/>
         <source>Scatter Chart</source>
         <translation>散点图</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="793"/>
+        <location filename="../../Charts/UserChart.cpp" line="794"/>
         <source>Bar Chart</source>
         <translation>条形图</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="794"/>
+        <location filename="../../Charts/UserChart.cpp" line="795"/>
         <source>Stacked Bar Chart</source>
         <translation>堆叠条形图</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="795"/>
+        <location filename="../../Charts/UserChart.cpp" line="796"/>
         <source>Stacked Percent Chart</source>
         <translation>堆叠百分比图</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="796"/>
+        <location filename="../../Charts/UserChart.cpp" line="797"/>
         <source>Pie Chart</source>
         <translation>饼图</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="800"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="801"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="804"/>
+        <location filename="../../Charts/UserChart.cpp" line="805"/>
         <source>Vertical</source>
         <translation>垂直</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="805"/>
+        <location filename="../../Charts/UserChart.cpp" line="806"/>
         <source>Horizontal</source>
         <translation>水平</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="808"/>
+        <location filename="../../Charts/UserChart.cpp" line="809"/>
         <source>Layout</source>
         <translation>布局</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="812"/>
+        <location filename="../../Charts/UserChart.cpp" line="813"/>
         <source>None</source>
         <translation>无</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="813"/>
+        <location filename="../../Charts/UserChart.cpp" line="814"/>
         <source>Top</source>
         <translation>上</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="814"/>
+        <location filename="../../Charts/UserChart.cpp" line="815"/>
         <source>Left</source>
         <translation>左</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="815"/>
+        <location filename="../../Charts/UserChart.cpp" line="816"/>
         <source>Right</source>
         <translation>右</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="816"/>
+        <location filename="../../Charts/UserChart.cpp" line="817"/>
         <source>Bottom</source>
         <translation>下</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="820"/>
+        <location filename="../../Charts/UserChart.cpp" line="821"/>
         <source>Legend</source>
         <translation>图例</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="829"/>
+        <location filename="../../Charts/UserChart.cpp" line="830"/>
         <source>Font scaling</source>
         <translation>字体缩放</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="831"/>
-        <location filename="../../Charts/UserChart.cpp" line="833"/>
+        <location filename="../../Charts/UserChart.cpp" line="832"/>
+        <location filename="../../Charts/UserChart.cpp" line="834"/>
         <source>Background</source>
         <translation>背景</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="836"/>
+        <location filename="../../Charts/UserChart.cpp" line="837"/>
         <source>Animate</source>
         <translation>动画</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="838"/>
+        <location filename="../../Charts/UserChart.cpp" line="839"/>
         <source>Single series per plot</source>
         <translation>图表系列</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="841"/>
+        <location filename="../../Charts/UserChart.cpp" line="842"/>
         <source>Refresh for intervals</source>
         <translation>刷新间歇</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="848"/>
+        <location filename="../../Charts/UserChart.cpp" line="849"/>
         <source>Series</source>
         <translation>系列</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Group</source>
         <translation>分组</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Y Formula</source>
         <translation>Y规则</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="870"/>
-        <location filename="../../Charts/UserChart.cpp" line="932"/>
         <source>Edit</source>
-        <translation>编辑</translation>
+        <translation type="vanished">编辑</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="889"/>
         <source>Up</source>
-        <translation>上</translation>
+        <translation type="vanished">上</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="890"/>
         <source>Down</source>
-        <translation>下</translation>
+        <translation type="vanished">下</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="911"/>
+        <location filename="../../Charts/UserChart.cpp" line="885"/>
         <source>Axes</source>
         <translation>轴</translation>
     </message>
@@ -34342,72 +34315,72 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VideoWindow</name>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> kph</source>
         <translation> km/h</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="119"/>
+        <location filename="../../Train/VideoWindow.cpp" line="144"/>
         <source>Meters layout</source>
         <translation>仪表布局</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="127"/>
+        <location filename="../../Train/VideoWindow.cpp" line="152"/>
         <source>Reset Meters layout to default</source>
         <translation>重置仪表布局为默认值</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> mph</source>
         <translation>mi/h</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> m</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> feet</source>
         <translation>英尺</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="625"/>
+        <location filename="../../Train/VideoWindow.cpp" line="681"/>
         <source>w</source>
         <translation>W</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="629"/>
+        <location filename="../../Train/VideoWindow.cpp" line="685"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> km</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> mi</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="673"/>
+        <location filename="../../Train/VideoWindow.cpp" line="729"/>
         <source>Calibration required</source>
         <translation>需要校准</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="678"/>
+        <location filename="../../Train/VideoWindow.cpp" line="734"/>
         <source>Configuration required</source>
         <translation>需要设置</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="683"/>
+        <location filename="../../Train/VideoWindow.cpp" line="739"/>
         <source>brake fault</source>
         <translation>制动器故障</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="688"/>
+        <location filename="../../Train/VideoWindow.cpp" line="744"/>
         <source>Ready</source>
         <translation>就绪</translation>
     </message>
@@ -34842,27 +34815,27 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WheelSizeCalculator</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="202"/>
+        <location filename="../../Gui/AthletePages.cpp" line="187"/>
         <source>Wheel Size Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="221"/>
+        <location filename="../../Gui/AthletePages.cpp" line="206"/>
         <source>Rim Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="222"/>
+        <location filename="../../Gui/AthletePages.cpp" line="207"/>
         <source>Tire Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="223"/>
+        <location filename="../../Gui/AthletePages.cpp" line="208"/>
         <source>Wheel Size</source>
         <translation type="unfinished">车轮尺寸</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="227"/>
         <source>mm</source>
         <translation type="unfinished">mm</translation>
     </message>
@@ -34974,12 +34947,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutFilterBox</name>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="34"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="44"/>
         <source>Filter...</source>
         <translation type="unfinished">过滤...</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="64"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="95"/>
         <source>ERROR: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34987,12 +34960,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutImportDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="820"/>
+        <location filename="../../Train/Library.cpp" line="809"/>
         <source>Import to Library</source>
         <translation>导入至库</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="854"/>
+        <location filename="../../Train/Library.cpp" line="843"/>
         <source>Please note, that when importing or drag and dropping videos into the library we DO NOT copy the file into the GoldenCheetah library, instead we add a REFERENCE to it. We DO copy workout and videoSync files, since they are smaller.
 
 You can remove references when managing the library via the context menu options</source>
@@ -35001,24 +34974,107 @@ You can remove references when managing the library via the context menu options
 可通过上下文菜单选项移除引用</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="868"/>
+        <location filename="../../Train/Library.cpp" line="857"/>
         <source>Files</source>
         <translation>文件</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="878"/>
+        <location filename="../../Train/Library.cpp" line="867"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="880"/>
+        <location filename="../../Train/Library.cpp" line="869"/>
         <source>OK</source>
         <translation>确定</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="884"/>
+        <location filename="../../Train/Library.cpp" line="873"/>
         <source>Overwite existing files</source>
         <translation>覆盖已有文件</translation>
+    </message>
+</context>
+<context>
+    <name>WorkoutMenuProvider</name>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="271"/>
+        <source>Select Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="274"/>
+        <source>Manage Filters</source>
+        <translation type="unfinished">管理过滤器</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="275"/>
+        <source>Add Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="289"/>
+        <source>Add Tag to Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="292"/>
+        <source>Filter Tags...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="310"/>
+        <source>Match all selected tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="353"/>
+        <source>Manage Workout Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="360"/>
+        <source>Name</source>
+        <translation type="unfinished">名称</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="361"/>
+        <source>Filter</source>
+        <translation type="unfinished">过滤器</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="362"/>
+        <source>_index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="370"/>
+        <source>Execute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="371"/>
+        <source>Update</source>
+        <translation type="unfinished">更新</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="423"/>
+        <source>Add Workout Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="426"/>
+        <source>Name of the Filter...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="467"/>
+        <source>New</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="469"/>
+        <source>New (%1)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -35033,41 +35089,41 @@ You can remove references when managing the library via the context menu options
     <name>WorkoutPlotWindow</name>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="40"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="104"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
         <source>Ergmode specific settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="46"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
         <source>Color power zones</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="48"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="56"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="49"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="50"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="57"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="109"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="113"/>
         <source>When stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="54"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="110"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
         <source>Show tooltip</source>
         <translation type="unfinished"></translation>
     </message>
@@ -35161,12 +35217,12 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>WorkoutWidget</name>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="1531"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="1532"/>
         <source>File save failed.</source>
         <translation>文件保存失败.</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="2367"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="2368"/>
         <source>Intensity</source>
         <translation>强度</translation>
     </message>
@@ -35320,26 +35376,22 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="44"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="45"/>
         <source>xData</source>
         <translation>X数据</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="58"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="59"/>
         <source>Data Series</source>
         <translation>数据系列</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="78"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="80"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="79"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="81"/>
         <source>Delete</source>
-        <translation>删除</translation>
+        <translation type="vanished">删除</translation>
     </message>
 </context>
 <context>
@@ -35416,32 +35468,32 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataSeriesSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="333"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="315"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="338"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="320"/>
         <source>Units</source>
         <translation>单位</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="346"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="328"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="347"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="329"/>
         <source>OK</source>
         <translation>确定</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Name is blank</source>
         <translation>名称为空</translation>
     </message>
@@ -35449,48 +35501,48 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="262"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="244"/>
         <source>xData</source>
         <translation>X数据</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="269"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="251"/>
         <source>Data Series</source>
         <translation>数据系列</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="270"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="252"/>
         <source>Units</source>
         <translation>单位</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="274"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="256"/>
         <source>Series %1</source>
         <translation>系列 %1</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="281"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="263"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="282"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="264"/>
         <source>OK</source>
         <translation>确定</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
         <source>XData name is blank</source>
         <translation>X数据名称为空</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Must have at least one data series.</source>
         <translation>至少应有一个数据系列.</translation>
     </message>
@@ -35811,17 +35863,17 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="915"/>
+        <location filename="../../Gui/AthletePages.cpp" line="886"/>
         <source>Sport</source>
         <translation>运动</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="962"/>
+        <location filename="../../Gui/AthletePages.cpp" line="933"/>
         <source>Critical Power</source>
         <translation>临界功率</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="963"/>
+        <location filename="../../Gui/AthletePages.cpp" line="934"/>
         <source>Default</source>
         <translation>默认</translation>
     </message>

--- a/src/Resources/translations/gc_zh-tw.ts
+++ b/src/Resources/translations/gc_zh-tw.ts
@@ -107,38 +107,38 @@ It might be necessary to manually disable it.</source>
         <translation type="vanished">平均長期Long Term Stress (d)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="504"/>
+        <location filename="../../Gui/AthletePages.cpp" line="489"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="517"/>
-        <location filename="../../Gui/AthletePages.cpp" line="522"/>
+        <location filename="../../Gui/AthletePages.cpp" line="502"/>
+        <location filename="../../Gui/AthletePages.cpp" line="507"/>
         <source>days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="525"/>
+        <location filename="../../Gui/AthletePages.cpp" line="510"/>
         <source>PMC Stress Balance Today</source>
         <translation>本日PMC壓力平衡</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="528"/>
+        <location filename="../../Gui/AthletePages.cpp" line="513"/>
         <source>Restore Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="517"/>
         <source>W&apos;bal tau</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="518"/>
         <source>Short Term Stress (STS) average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="534"/>
+        <location filename="../../Gui/AthletePages.cpp" line="519"/>
         <source>Long Term Stress (LTS) average</source>
         <translation type="unfinished"></translation>
     </message>
@@ -154,96 +154,96 @@ It might be necessary to manually disable it.</source>
 <context>
     <name>AboutRiderPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="372"/>
+        <location filename="../../Gui/AthletePages.cpp" line="357"/>
         <source>Nickname</source>
         <translation>暱稱</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="373"/>
+        <location filename="../../Gui/AthletePages.cpp" line="358"/>
         <source>Date of Birth</source>
         <translation>生日</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="374"/>
+        <location filename="../../Gui/AthletePages.cpp" line="359"/>
         <source>Sex</source>
         <translation>性別</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="376"/>
+        <location filename="../../Gui/AthletePages.cpp" line="361"/>
         <source>Weight</source>
         <translation type="unfinished">體重</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="375"/>
+        <location filename="../../Gui/AthletePages.cpp" line="360"/>
         <source>Height</source>
         <translation type="unfinished">高</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="279"/>
+        <location filename="../../Gui/AthletePages.cpp" line="264"/>
         <source>Male</source>
         <translation>男性</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="280"/>
+        <location filename="../../Gui/AthletePages.cpp" line="265"/>
         <source>Female</source>
         <translation>女性</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> kg</source>
         <translation type="unfinished"> kg</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="430"/>
+        <location filename="../../Gui/AthletePages.cpp" line="276"/>
+        <location filename="../../Gui/AthletePages.cpp" line="415"/>
         <source> lb</source>
         <translation type="unfinished"> lb</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> cm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="298"/>
-        <location filename="../../Gui/AthletePages.cpp" line="431"/>
+        <location filename="../../Gui/AthletePages.cpp" line="283"/>
+        <location filename="../../Gui/AthletePages.cpp" line="416"/>
         <source> in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="359"/>
+        <location filename="../../Gui/AthletePages.cpp" line="344"/>
         <source>Calculate...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="378"/>
+        <location filename="../../Gui/AthletePages.cpp" line="363"/>
         <source>Bike</source>
         <translation type="unfinished">騎車</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="379"/>
+        <location filename="../../Gui/AthletePages.cpp" line="364"/>
         <source>Crank Length</source>
         <translation>曲柄長度</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="380"/>
+        <location filename="../../Gui/AthletePages.cpp" line="365"/>
         <source>Wheelsize</source>
         <translation>輪徑</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="438"/>
+        <location filename="../../Gui/AthletePages.cpp" line="423"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="356"/>
+        <location filename="../../Gui/AthletePages.cpp" line="341"/>
         <source>mm</source>
         <translation>mm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="437"/>
+        <location filename="../../Gui/AthletePages.cpp" line="422"/>
         <source>Choose Picture</source>
         <translation>選擇照片</translation>
     </message>
@@ -2270,397 +2270,394 @@ Press Next to Continue
 <context>
     <name>AllPlotWindow</name>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="190"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="444"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="165"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
         <source>Smooth</source>
         <translation>平滑化</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="198"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="173"/>
         <source>Stacked</source>
         <translation>堆疊</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="199"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="174"/>
         <source>by series</source>
         <translation>依序列</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="200"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="175"/>
         <source>Fullplot</source>
         <translation>全圖</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="201"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="176"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="239"/>
         <source>Overlay</source>
         <translation>浮動視窗</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="229"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="204"/>
         <source>View</source>
         <translation>檢視</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="206"/>
         <source>Stack</source>
         <translation>堆疊</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="210"/>
         <source>By Series</source>
         <translation>依序列</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="246"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="221"/>
         <source>Stack Zoom</source>
         <translation>堆疊放大</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="248"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="223"/>
         <source>Full plot</source>
         <translation>全圖</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="227"/>
         <source>Show Interval Markers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="256"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="231"/>
         <source>Interval Navigator</source>
         <translation>區段搜尋器</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="260"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="235"/>
         <source>Hover intervals</source>
         <translation>暫選區段</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="268"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="243"/>
         <source>Fill Curves</source>
         <translation>填滿曲線</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="247"/>
         <source>Grid</source>
         <translation>格點</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="277"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="252"/>
         <source>Acceleration</source>
         <translation>加速率</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="279"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="254"/>
         <source>Delta Series</source>
         <translation>差值序列</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="280"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="255"/>
         <source>Power %1</source>
         <translation>功率 %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="283"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="258"/>
         <source>Cadence %1</source>
         <translation>迴轉數 %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="261"/>
         <source>Torque %1</source>
         <translation>扭矩 %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="289"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="264"/>
         <source>Heartrate %1</source>
         <translation>心率 %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="295"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="270"/>
         <source>Balance</source>
         <translation>平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="272"/>
         <source>Left/Right</source>
         <translation>左/右</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="274"/>
         <source>Torque Effectiveness</source>
         <translation>扭矩效率</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="303"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="278"/>
         <source>Smoothness</source>
         <translation>平滑度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="282"/>
         <source>Pedal Center Offset</source>
         <translation>踏板施力偏移PCO</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="311"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="286"/>
         <source>Power Phase</source>
         <translation>功率分佈PP</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="290"/>
         <source>Peak Power Phase</source>
         <translation>峰值功率分佈PP</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="322"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="297"/>
         <source>Vertical Oscillation</source>
         <translation>重直振幅</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="324"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="299"/>
         <source>Running</source>
         <translation>跑步</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="326"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="301"/>
         <source>Ground Contact Time</source>
         <translation>觸地時間</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="307"/>
         <source>Cadence </source>
         <translation>迴轉數 </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="313"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="340"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="315"/>
         <source>Moxy</source>
         <translation>Moxy</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="317"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="321"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="325"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="355"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="330"/>
         <source>Heart Rate</source>
         <translation>心率</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="357"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="332"/>
         <source>Data series</source>
         <translation>資料序列</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="359"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="334"/>
         <source>Core Temperature</source>
         <translation>核心溫度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="363"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="338"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="367"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="342"/>
         <source>Cadence</source>
         <translation>迴轉數</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="94"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="95"/>
         <source>Basic</source>
         <translation>基本</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="109"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="110"/>
         <source>Curves</source>
         <translation>曲線</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="116"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="117"/>
         <source>User Data</source>
         <translation>使用者資料</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="132"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="133"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1016"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="134"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="991"/>
         <source>Formula</source>
         <translation>計算公式</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="144"/>
         <source>Edit</source>
-        <translation>編輯</translation>
+        <translation type="vanished">編輯</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="163"/>
         <source>Up</source>
-        <translation>上</translation>
+        <translation type="vanished">上</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="164"/>
         <source>Down</source>
-        <translation>下</translation>
+        <translation type="vanished">下</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="371"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="346"/>
         <source>Altitude</source>
         <translation>標高</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="350"/>
         <source>Temperature</source>
         <translation>溫度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="379"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="354"/>
         <source>Headwind</source>
         <translation>逆風</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="383"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="358"/>
         <source>Torque</source>
         <translation>扭矩</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="387"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="362"/>
         <source>Gear Ratio</source>
         <translation>齒輪比</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="391"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="366"/>
         <source>Slope</source>
         <translation>坡度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="373"/>
         <source>No Alt/Slope</source>
         <translation>無高度/坡度資訊</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="399"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="374"/>
         <source>0.1km|mi -  1min</source>
         <translation>0.1公里|英哩 -  1分</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="400"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="375"/>
         <source>0.5km|mi -  5min</source>
         <translation>0.5公里|英哩 -  5分</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="401"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="376"/>
         <source>1.0km|mi - 10min</source>
         <translation>1.0公里|英哩 - 10分</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="1528"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="377"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="1503"/>
         <source>Alt/Slope</source>
         <translation>高度/坡度</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="382"/>
         <source>Anaerobic TISS</source>
         <translation>無氧TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="384"/>
         <source>Metrics</source>
         <translation>計測量</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="411"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="386"/>
         <source>Aerobic TISS</source>
         <translation>有氧TISS</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="390"/>
         <source>Iso Power</source>
         <translation>IsoPower</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="419"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="394"/>
         <source>Skiba xPower</source>
         <translation>Skiba xPower</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="423"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="398"/>
         <source>Altitude Power</source>
         <translation>等高功率</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="427"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="402"/>
         <source>W&apos; balance</source>
         <translation>W&apos;Bal</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="441"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="416"/>
         <source>Time of day</source>
         <translation>時間</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="742"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="717"/>
         <source>Intervals</source>
         <translation>區段</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="2253"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="2228"/>
         <source>Selection #%1 </source>
         <translation>選項 #%1 </translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="432"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="407"/>
         <source>Power + shade</source>
         <translation>輸出功率 (上色)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="433"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="408"/>
         <source>Power - shade</source>
         <translation>輸出功率 (不上色)</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="434"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="409"/>
         <source>No Power</source>
         <translation>沒有輸出功率</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="435"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="410"/>
         <source>Shading</source>
         <translation>顯示色</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="439"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="414"/>
         <source>Time</source>
         <translation>時間</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="440"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="415"/>
         <source>Distance</source>
         <translation>距離</translation>
     </message>
     <message>
-        <location filename="../../Charts/AllPlotWindow.cpp" line="442"/>
+        <location filename="../../Charts/AllPlotWindow.cpp" line="417"/>
         <source>X Axis</source>
         <translation>X軸</translation>
     </message>
@@ -3467,51 +3464,45 @@ Press Next to Continue
 <context>
     <name>AutoImportPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4028"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4029"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
         <source>Browse</source>
         <translation type="vanished">瀏覽</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4040"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4041"/>
         <source>Delete</source>
-        <translation>刪除</translation>
+        <translation type="vanished">刪除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4042"/>
         <source>Up</source>
-        <translation>上</translation>
+        <translation type="vanished">上</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4043"/>
         <source>Down</source>
-        <translation>下</translation>
+        <translation type="vanished">下</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4054"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3779"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4059"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3784"/>
         <source>Directory</source>
         <translation>檔案夾</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="4060"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3785"/>
         <source>Import Rule</source>
         <translation>匯入規則</translation>
     </message>
@@ -4329,37 +4320,37 @@ Press Next to Continue
 <context>
     <name>BackupPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="608"/>
+        <location filename="../../Gui/AthletePages.cpp" line="593"/>
         <source>Enter a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="601"/>
         <source>every</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="617"/>
+        <location filename="../../Gui/AthletePages.cpp" line="602"/>
         <source>times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="603"/>
         <source>never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="605"/>
         <source>Backup now</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="623"/>
+        <location filename="../../Gui/AthletePages.cpp" line="608"/>
         <source>Auto Backup Folder</source>
         <translation>自動備份檔案夾</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="624"/>
+        <location filename="../../Gui/AthletePages.cpp" line="609"/>
         <source>Auto Backup after closing the athlete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5185,41 +5176,33 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">更新</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1202"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1203"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1204"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1150"/>
         <source>Review...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1206"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1152"/>
         <source>Changed power estimates are available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1213"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1225"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1214"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1226"/>
         <source>Delete</source>
-        <translation>刪除</translation>
+        <translation type="vanished">刪除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1216"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1158"/>
         <source>Def</source>
         <translation>定義</translation>
     </message>
@@ -5228,27 +5211,27 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">起始日期</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1218"/>
         <source>Critical Power</source>
         <translation>臨界功率</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1305"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1219"/>
         <source>AeTP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1306"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1220"/>
         <source>FTP</source>
         <translation>FTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1307"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1221"/>
         <source>W&apos;</source>
         <translation>W&apos;</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1308"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1222"/>
         <source>Pmax</source>
         <translation>Pmax</translation>
     </message>
@@ -5257,207 +5240,207 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">yyyy年M月d日</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1347"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1261"/>
         <source>Short</source>
         <translation>簡稱</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1247"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1169"/>
         <source>Use CP for all metrics</source>
         <translation>在所有計測中使用CP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1240"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1162"/>
         <source>Manual</source>
         <translation type="unfinished">手動</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1241"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1163"/>
         <source>Semi-Automatic (CP2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1164"/>
         <source>Semi-Automatic (CP3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1243"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1165"/>
         <source>Semi-Automatic (Extended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1170"/>
         <source>Use FTP for Coggan metrics</source>
         <translation>在Coggan計測中使用FTP</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1273"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1279"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1285"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1342"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1618"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1631"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2283"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2289"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2297"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2310"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1187"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1193"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1199"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1211"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1532"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1537"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1545"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2180"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2186"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2194"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2207"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1291"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2304"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1205"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1547"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2201"/>
         <source>J</source>
         <translation type="unfinished">J</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1303"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2248"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1217"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2145"/>
         <source>Start Date</source>
         <translation type="unfinished">起始日期</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1309"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1223"/>
         <source>Model Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1262"/>
         <source>Long</source>
         <translation>全名</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1349"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1263"/>
         <source>From Watts</source>
         <translation>最低瓦</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1598"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1512"/>
         <source>Review range starting on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1614"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1528"/>
         <source>Current</source>
         <translation type="unfinished">目前值</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1615"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1529"/>
         <source>Estimate</source>
         <translation type="unfinished">預估</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1530"/>
         <source>Accept</source>
         <translation type="unfinished">接受</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1788"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1691"/>
         <source>🗹</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1692"/>
         <source>Estimate and settings &lt;b&gt;match&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1695"/>
         <source>☐</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1696"/>
         <source>Estimate and settings &lt;b&gt;differ&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1797"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1700"/>
         <source>⏲</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1800"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1703"/>
         <source>Range is %1 days older than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1802"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1705"/>
         <source>Range is %1 days younger than closest estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1808"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1711"/>
         <source>∅</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1712"/>
         <source>No estimate available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1902"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1805"/>
         <source>New range from estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2237"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2134"/>
         <source>The proposed value for AeTP is a very rough estimate, assuming %1 % of CP. Usually it is determined by a&lt;ul&gt;&lt;li&gt;Metabolic test&lt;/li&gt;&lt;li&gt;Lactate ramp test&lt;/li&gt;&lt;li&gt;Run / Cycling ‘conversational’ test&lt;/li&gt;&lt;li&gt;Run Decoupling test&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2239"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2136"/>
         <source>Updating FTP internally to match CP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2139"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2244"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2141"/>
         <source>Your selected model does not deliver values for PMax, using default value of %1 W instead</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2246"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2143"/>
         <source>Your selected model does not deliver values for&lt;ul&gt;&lt;li&gt;FTP, using CP instead&lt;/li&gt;&lt;li&gt;PMax, assuming a default of %1 W&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2250"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2147"/>
         <source>Critical Power (CP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2252"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2149"/>
         <source>Aerobic Threshold Power (AeTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2254"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2151"/>
         <source>Functional Threshold Power (FTP)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2256"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2153"/>
         <source>Anaerobic Work Capacity (W&apos;)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2258"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2155"/>
         <source>Maximum Power (PMax)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2270"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2167"/>
         <source>Manual range</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5466,14 +5449,14 @@ Let&apos;s get you setup.</source>
         <translation type="vanished">僅允許設定10個區間。</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2018"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2025"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1917"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1924"/>
         <source>New</source>
         <translation>新建</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2020"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1919"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1926"/>
         <source>New (%1)</source>
         <translation>新建 (%1)</translation>
     </message>
@@ -5925,52 +5908,44 @@ ddd, dd MMM yyyy</source>
         <translation type="vanished">更新</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3307"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3319"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3308"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3320"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3313"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3325"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3314"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3326"/>
         <source>Delete</source>
-        <translation>刪除</translation>
+        <translation type="vanished">刪除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3316"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3109"/>
         <source>Def</source>
         <translation>定義</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3359"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3506"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3272"/>
         <source>Start Date</source>
         <translation type="unfinished">起始日期</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3249"/>
         <source>New range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3507"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3273"/>
         <source>Critical Velocity (CV)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3508"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3274"/>
         <source>Aerobic Threshold (AeT)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5979,12 +5954,12 @@ ddd, dd MMM yyyy</source>
         <translation type="vanished">起始日期</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3360"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3128"/>
         <source>Critical Velocity</source>
         <translation>臨界速度</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3361"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3129"/>
         <source>Aerobic Threshold</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5993,17 +5968,17 @@ ddd, dd MMM yyyy</source>
         <translation type="vanished">yyyy年M月d日</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3403"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
         <source>Short</source>
         <translation>簡稱</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3404"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3172"/>
         <source>Long</source>
         <translation>全名</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3405"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3173"/>
         <source>From</source>
         <translation>從</translation>
     </message>
@@ -6012,14 +5987,14 @@ ddd, dd MMM yyyy</source>
         <translation type="vanished">僅允許設定10個區間。</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3679"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3686"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3441"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3448"/>
         <source>New</source>
         <translation>新建</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3681"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3688"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3443"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3450"/>
         <source>New (%1)</source>
         <translation>新建 (%1)</translation>
     </message>
@@ -7549,37 +7524,32 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>CredentialsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="67"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
+    </message>
+    <message>
+        <source>-</source>
+        <translation type="vanished">-</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="vanished">編輯</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation type="vanished">新增</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="vanished">刪除</translation>
     </message>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="68"/>
-        <source>-</source>
-        <translation>-</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="69"/>
-        <source>Edit</source>
-        <translation>編輯</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="74"/>
-        <source>Add</source>
-        <translation>新增</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="75"/>
-        <source>Delete</source>
-        <translation>刪除</translation>
-    </message>
-    <message>
-        <location filename="../../Gui/AthletePages.cpp" line="86"/>
         <source>Service</source>
         <translation>服務</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="87"/>
+        <location filename="../../Gui/AthletePages.cpp" line="69"/>
         <source>Description</source>
         <translation>説明</translation>
     </message>
@@ -8266,7 +8236,7 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>DataFilterEdit</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2743"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2712"/>
         <source>Warning: sample() is slow -- update code to use samples()</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8625,7 +8595,7 @@ Do you want to apply and restart GoldenCheetah?</source>
 <context>
     <name>DirectoryPathWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="277"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="308"/>
         <source>Browse</source>
         <translation type="unfinished">瀏覽</translation>
     </message>
@@ -8862,28 +8832,28 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>Dropbox</name>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="68"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="77"/>
         <source>Problem accessing Dropbox data</source>
         <translation>無法存取Dropbox資料</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="130"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="139"/>
         <source>You must authorise with Dropbox first</source>
         <translation>必須先授權Dropbox</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="205"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="214"/>
         <source>Parsing Error: %1</source>
         <translation>解譯失敗： %1</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="293"/>
-        <location filename="../../Cloud/Dropbox.cpp" line="312"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="302"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="321"/>
         <source>Completed.</source>
         <translation>完成。</translation>
     </message>
     <message>
-        <location filename="../../Cloud/Dropbox.cpp" line="297"/>
+        <location filename="../../Cloud/Dropbox.cpp" line="306"/>
         <source>Network Error - Upload failed.</source>
         <translation>網路異常 - 上傳失敗。</translation>
     </message>
@@ -9028,136 +8998,136 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2064"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2033"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2034"/>
         <source>Axis Label / Units</source>
         <translation>軸標籤／單位</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1597"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1566"/>
         <source>Curve Settings</source>
         <translation>曲線設定</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1558"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1527"/>
         <source>Estimate %1 %2 Power</source>
         <translation>估計%1 %2功率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1562"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1531"/>
         <source>Endurance Index</source>
         <translation>耐力指數</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1532"/>
         <source>Vo2Max Estimate</source>
         <translation>VO2max預估</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1605"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1574"/>
         <source>Metric</source>
         <translation>公制</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1606"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1575"/>
         <source>Best</source>
         <translation>最佳</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1607"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1576"/>
         <source>Estimate</source>
         <translation>預估</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1577"/>
         <source>PMC</source>
         <translation>PMC</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1609"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1578"/>
         <source>Formula</source>
         <translation>計算公式</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1610"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1579"/>
         <source>Measure</source>
         <translation>測量值</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1611"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1580"/>
         <source>Performance</source>
         <translation>個人表現</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1612"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1581"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1684"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1767"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1653"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1736"/>
         <source>seconds</source>
         <translation>s</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1685"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1768"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1737"/>
         <source>minutes</source>
         <translation>min</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1769"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1655"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1738"/>
         <source>hours</source>
         <translation>hr</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1723"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1816"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1692"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1785"/>
         <source>Peak</source>
         <translation>峰值</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1781"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1750"/>
         <source>Absolute</source>
         <translation>絕對值</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1751"/>
         <source>Per Kilogram</source>
         <translation>每公斤</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1813"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1782"/>
         <source>Total</source>
         <translation>總量</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1814"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1783"/>
         <source>Running Total</source>
         <translation>跑步總量</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1815"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1784"/>
         <source>Average</source>
         <translation>平均</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1817"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1786"/>
         <source>Low</source>
         <translation>低值</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1820"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1789"/>
         <source>Aggregate:</source>
         <translation>總量：</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1828"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1797"/>
         <source># type in a formula to use
 # for e.g. BikeStress / Duration
 # as you type the available metrics
@@ -9169,292 +9139,292 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 # 系統會提示可用選項</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1839"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1808"/>
         <source>Weekly Best Performances</source>
         <translation>每週最佳表現</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1840"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1809"/>
         <source>Submaximal Weekly Best</source>
         <translation>臨界每週最近表現</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1841"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1810"/>
         <source>Performance Tests</source>
         <translation>能力測驗</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1933"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1902"/>
         <source>Short Term Stress (STS/ATL)</source>
         <translation>短期壓力 (STS/ATL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1934"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1903"/>
         <source>Long Term Stress  (LTS/CTL)</source>
         <translation>長期壓力 (LTS/CTL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1935"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1904"/>
         <source>Stress Balance    (SB/TSB)</source>
         <translation>壓力平衡 (SB/TSB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1936"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1905"/>
         <source>Stress Ramp Rate  (RR)</source>
         <translation>壓力升率 (RR)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1944"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1913"/>
         <source>Stress Type</source>
         <translation>壓力類型</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1949"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1918"/>
         <source>Negative Training Effect (NTE)</source>
         <translation>負向訓練反應 (NTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1950"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1919"/>
         <source>Positive Training Effect (PTE)</source>
         <translation>正向訓練反應 (PTE)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1951"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1920"/>
         <source>Performance (Power Index)</source>
         <translation>個人表現 (功率指數)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1952"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1921"/>
         <source>Predicted CP (Watts)</source>
         <translation>預估CP (w)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1969"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1938"/>
         <source>Curve Type</source>
         <translation>曲線種類</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1945"/>
         <source>Perf. Metric</source>
         <translation>能力計測量</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2006"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1975"/>
         <source>Metadata Field</source>
         <translation>附加參數欄位</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2007"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1976"/>
         <source>PMC metric</source>
         <translation>PMC計測量</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2032"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2001"/>
         <source>Measure Group</source>
         <translation>量測組別</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2009"/>
         <source>Measure Field</source>
         <translation>量測欄位</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2029"/>
         <source>Filter</source>
         <translation>過濾器</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2071"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2040"/>
         <source>Style</source>
         <translation>風格</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2042"/>
         <source>Bar</source>
         <translation>長條</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2074"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2043"/>
         <source>Line</source>
         <translation>線</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2075"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2044"/>
         <source>Sticks</source>
         <translation>蠋</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2076"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2045"/>
         <source>Dots</source>
         <translation>點</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2048"/>
         <source>Stack</source>
         <translation>堆疊</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2053"/>
         <source>Symbol</source>
         <translation>符號</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2086"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2055"/>
         <source>None</source>
         <translation>無</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2087"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2056"/>
         <source>Circle</source>
         <translation>圓</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2057"/>
         <source>Square</source>
         <translation>方</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2089"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2058"/>
         <source>Diamond</source>
         <translation>鑽</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2090"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2059"/>
         <source>Triangle</source>
         <translation>三角</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2091"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2060"/>
         <source>Cross</source>
         <translation>交叉</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2092"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2061"/>
         <source>Hexagon</source>
         <translation>六角</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2062"/>
         <source>Star</source>
         <translation>星</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2065"/>
         <source>Color</source>
         <translation>色彩</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2100"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2069"/>
         <source>Fill curve</source>
         <translation>填滿曲線</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2073"/>
         <source>Data labels</source>
         <translation>資訊標籤</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2080"/>
         <source>Highlight Highest</source>
         <translation>標記最高值</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2088"/>
         <source>Highlight Lowest</source>
         <translation>標記最低值</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2127"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2096"/>
         <source>Highlight Outliers</source>
         <translation>標記異值</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2135"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2104"/>
         <source>Baseline</source>
         <translation>基準</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2143"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2112"/>
         <source>Smooth Curve</source>
         <translation>平滑化曲線</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2147"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2116"/>
         <source>No trend Line</source>
         <translation>無趨勢曲線</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2148"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2117"/>
         <source>Linear Trend</source>
         <translation>線性趨勢</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2149"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2118"/>
         <source>Quadratic Trend</source>
         <translation>二次趨勢</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2150"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2119"/>
         <source>Moving Average</source>
         <translation>移動平均</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2151"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2120"/>
         <source>Simple Average</source>
         <translation>簡單平均</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2123"/>
         <source>Ignore Zeros</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2168"/>
         <source>&amp;OK</source>
         <translation>OK(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2201"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2170"/>
         <source>&amp;Cancel</source>
         <translation>取消(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2431"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2400"/>
         <source>Peak %1</source>
         <translation>%1峰值</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2402"/>
         <source> second </source>
         <translation>s</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2434"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2403"/>
         <source> minute </source>
         <translation>min</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2436"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2405"/>
         <source> hour </source>
         <translation>hr</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2456"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2425"/>
         <source>%1 - %2</source>
         <translation>%1 - %2</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2470"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2439"/>
         <source>Performances</source>
         <translation>個人表現</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2471"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2440"/>
         <source>Power Index</source>
         <translation>功率指數</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="2588"/>
+        <location filename="../../Charts/LTMTool.cpp" line="2557"/>
         <source>Performances_%1_%2_%3</source>
         <translation>個人表現 %1 %2 %3</translation>
     </message>
@@ -9784,93 +9754,93 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditUserAxisDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1731"/>
+        <location filename="../../Charts/UserChart.cpp" line="1689"/>
         <source>Edit Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1741"/>
+        <location filename="../../Charts/UserChart.cpp" line="1699"/>
         <source>&amp;OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1742"/>
+        <location filename="../../Charts/UserChart.cpp" line="1700"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished">取消(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1750"/>
+        <location filename="../../Charts/UserChart.cpp" line="1708"/>
         <source>Units</source>
         <translation type="unfinished">單位</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1760"/>
+        <location filename="../../Charts/UserChart.cpp" line="1718"/>
         <source>Logarithmic Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1757"/>
+        <location filename="../../Charts/UserChart.cpp" line="1715"/>
         <source>Type</source>
         <translation type="unfinished">種類</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1761"/>
-        <location filename="../../Charts/UserChart.cpp" line="1780"/>
+        <location filename="../../Charts/UserChart.cpp" line="1719"/>
+        <location filename="../../Charts/UserChart.cpp" line="1738"/>
         <source> </source>
         <translation type="unfinished"> </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1763"/>
+        <location filename="../../Charts/UserChart.cpp" line="1721"/>
         <source>Fixed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1774"/>
+        <location filename="../../Charts/UserChart.cpp" line="1732"/>
         <source> from </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1776"/>
+        <location filename="../../Charts/UserChart.cpp" line="1734"/>
         <source> to </source>
         <translation type="unfinished"> 至 </translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1779"/>
+        <location filename="../../Charts/UserChart.cpp" line="1737"/>
         <source>Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1787"/>
+        <location filename="../../Charts/UserChart.cpp" line="1745"/>
         <source>Smoothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1792"/>
+        <location filename="../../Charts/UserChart.cpp" line="1750"/>
         <source>None</source>
         <translation type="unfinished">無</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1793"/>
+        <location filename="../../Charts/UserChart.cpp" line="1751"/>
         <source>Day</source>
         <translation type="unfinished">日</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1794"/>
+        <location filename="../../Charts/UserChart.cpp" line="1752"/>
         <source>Week</source>
         <translation type="unfinished">週</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1795"/>
+        <location filename="../../Charts/UserChart.cpp" line="1753"/>
         <source>Month</source>
         <translation type="unfinished">月</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1796"/>
+        <location filename="../../Charts/UserChart.cpp" line="1754"/>
         <source>Year</source>
         <translation type="unfinished">年</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1798"/>
+        <location filename="../../Charts/UserChart.cpp" line="1756"/>
         <source>Group By</source>
         <translation type="unfinished">依群組</translation>
     </message>
@@ -10066,158 +10036,158 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditUserSeriesDialog</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1398"/>
+        <location filename="../../Charts/UserChart.cpp" line="1356"/>
         <source>Edit Data Series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1414"/>
+        <location filename="../../Charts/UserChart.cpp" line="1372"/>
         <source>&amp;OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1415"/>
+        <location filename="../../Charts/UserChart.cpp" line="1373"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished">取消(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1422"/>
+        <location filename="../../Charts/UserChart.cpp" line="1380"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1430"/>
+        <location filename="../../Charts/UserChart.cpp" line="1388"/>
         <source>Series Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1519"/>
+        <location filename="../../Charts/UserChart.cpp" line="1477"/>
         <source>Y units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1524"/>
+        <location filename="../../Charts/UserChart.cpp" line="1482"/>
         <source>X units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1528"/>
+        <location filename="../../Charts/UserChart.cpp" line="1486"/>
         <source>Sum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1529"/>
+        <location filename="../../Charts/UserChart.cpp" line="1487"/>
         <source>Average</source>
         <translation type="unfinished">平均</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1530"/>
+        <location filename="../../Charts/UserChart.cpp" line="1488"/>
         <source>Peak</source>
         <translation type="unfinished">峰值</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1531"/>
+        <location filename="../../Charts/UserChart.cpp" line="1489"/>
         <source>Low</source>
         <translation type="unfinished">低值</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1532"/>
+        <location filename="../../Charts/UserChart.cpp" line="1490"/>
         <source>Running Total</source>
         <translation type="unfinished">跑步總量</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1533"/>
+        <location filename="../../Charts/UserChart.cpp" line="1491"/>
         <source>Mean Square Root</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1534"/>
+        <location filename="../../Charts/UserChart.cpp" line="1492"/>
         <source>Std Deviation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1537"/>
+        <location filename="../../Charts/UserChart.cpp" line="1495"/>
         <source>Aggregate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1541"/>
-        <location filename="../../Charts/UserChart.cpp" line="1557"/>
+        <location filename="../../Charts/UserChart.cpp" line="1499"/>
+        <location filename="../../Charts/UserChart.cpp" line="1515"/>
         <source>None</source>
         <translation type="unfinished">無</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1542"/>
+        <location filename="../../Charts/UserChart.cpp" line="1500"/>
         <source>Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1543"/>
+        <location filename="../../Charts/UserChart.cpp" line="1501"/>
         <source>Dashed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1544"/>
+        <location filename="../../Charts/UserChart.cpp" line="1502"/>
         <source>Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1545"/>
+        <location filename="../../Charts/UserChart.cpp" line="1503"/>
         <source>Dash Dot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1546"/>
+        <location filename="../../Charts/UserChart.cpp" line="1504"/>
         <source>Fast Graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1547"/>
+        <location filename="../../Charts/UserChart.cpp" line="1505"/>
         <source>Show on Legend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1548"/>
+        <location filename="../../Charts/UserChart.cpp" line="1506"/>
         <source>Show Data Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1554"/>
+        <location filename="../../Charts/UserChart.cpp" line="1512"/>
         <source>Line Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1558"/>
+        <location filename="../../Charts/UserChart.cpp" line="1516"/>
         <source>Circle</source>
         <translation type="unfinished">圓</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1559"/>
+        <location filename="../../Charts/UserChart.cpp" line="1517"/>
         <source>Rectangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1564"/>
+        <location filename="../../Charts/UserChart.cpp" line="1522"/>
         <source>Symbol</source>
         <translation type="unfinished">符號</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1572"/>
+        <location filename="../../Charts/UserChart.cpp" line="1530"/>
         <source>Color</source>
         <translation type="unfinished">色彩</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1575"/>
+        <location filename="../../Charts/UserChart.cpp" line="1533"/>
         <source>Fill curve</source>
         <translation type="unfinished">填滿曲線</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1583"/>
+        <location filename="../../Charts/UserChart.cpp" line="1541"/>
         <source>Opacity (%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="1589"/>
+        <location filename="../../Charts/UserChart.cpp" line="1547"/>
         <source>Size/Width</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10264,6 +10234,24 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
         <location filename="../../Metrics/BasicRideMetrics.cpp" line="144"/>
         <source>Only useful for intervals, time the interval started</source>
         <translation>區段之經過時間</translation>
+    </message>
+</context>
+<context>
+    <name>ElevationChartWindow</name>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="221"/>
+        <source>Profile Distance (m)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="229"/>
+        <source>Seconds for delta slope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/ElevationChartWindow.cpp" line="237"/>
+        <source>Elevation window size (%) relative to current altitude</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10702,7 +10690,7 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ExhaustionDialog.cpp" line="160"/>
+        <location filename="../../Charts/ExhaustionDialog.cpp" line="162"/>
         <source>Time</source>
         <translation>時間</translation>
     </message>
@@ -13100,42 +13088,42 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GcCrashDialog</name>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="78"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="74"/>
         <source>%1 Crash Recovery</source>
         <translation>%1 崩潰恢復</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="116"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="112"/>
         <source>&lt;b&gt;GoldenCheetah appears to have PREVIOUSLY crashed for this athlete. &lt;/b&gt;&lt;br&gt;&lt;br&gt;The report below gives some diagnostic information that will be useful to the developers. Feel free to post this with a short description of what was occurring when the crash happened to the &lt;href a=&quot;https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users&quot;&gt;GoldenCheetah forums&lt;/href&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;We respect privacy - this log does NOT contain ids, passwords or personal information.&lt;/b&gt;&lt;br&gt;&lt;b&gt;&lt;br&gt;When this dialog is closed the athlete will be opened.&lt;/b&gt;</source>
         <translation>&lt;b&gt; GoldenCheetah似乎曾經在存取此運動員檔案時當機。 &lt;/ b&gt; &lt;br&gt; &lt;br&gt;以下報告提供了一些對開發人員有用的診斷信息。 可於在&lt;href a =“https://groups.google.com/forum/?fromgroups=#!forum/golden-cheetah-users”&gt; GoldenCheetah論壇&lt;/ href&gt; 發表以下報告，並簡要說明當機發生情形&lt;br&gt; &lt;b&gt; &lt;br&gt;我們尊重隱私 - 此報告不包含ID，密碼或個人信息。&lt;/ b&gt; &lt;br&gt; &lt;b&gt; &lt;br&gt;此對話框關閉時將打開運動員檔案。&lt;/ b&gt;</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="141"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="137"/>
         <source>Save Crash Report...</source>
         <translation>儲存崩潰報告...</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="143"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="139"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="225"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="221"/>
         <source>&lt;p&gt;Build date: %1 %2&lt;br&gt;Build id: %3&lt;br&gt;Version: %4&lt;br&gt;DB Schema: %5&lt;br&gt;Metrics: %7&lt;br&gt;OS: %6&lt;br&gt;OpenGL: %10&lt;br&gt;UI: dpi scale (%8) font size (%9)&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="255"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="251"/>
         <source>&lt;table&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QT&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;QWT&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;%3&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SRMIO&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;D2XX&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;ICAL&lt;/td&gt;&lt;td&gt;%9&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;USBXPRESS&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LIBUSB&lt;/td&gt;&lt;td&gt;%11&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VLC&lt;/td&gt;&lt;td&gt;%12&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;VIDEO&lt;/td&gt;&lt;td&gt;%13&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SAMPLERATE&lt;/td&gt;&lt;td&gt;%14&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;SSL&lt;/td&gt;&lt;td&gt;%15&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;R&lt;/td&gt;&lt;td&gt;%16&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;Python&lt;/td&gt;&lt;td&gt;%18&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;LMFIT&lt;/td&gt;&lt;td&gt;7.0&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;GSL&lt;/td&gt;&lt;td&gt;%19&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Save Diagnostics</source>
         <translation>儲存診斷訊息</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcCrashDialog.cpp" line="462"/>
+        <location filename="../../Gui/GcCrashDialog.cpp" line="456"/>
         <source>Text File (*.txt)</source>
         <translation>文字檔 (*.txt)</translation>
     </message>
@@ -13470,167 +13458,172 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GcWindowRegistry</name>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
         <source>Performance</source>
         <translation>個人表現</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="89"/>
         <source>Histogram</source>
         <translation>柱狀圖</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="90"/>
         <source>Distribution</source>
         <translation>分佈</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
         <source>Pedal Force vs Velocity</source>
         <translation>踏板受力與速度</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="92"/>
         <source>Heartrate vs Power</source>
         <translation>心率與功率對照</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
         <source>Python Chart</source>
         <translation>Python圖表</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
         <source>Python Chart </source>
         <translation>Python圖表 </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="101"/>
         <source>Calendar</source>
         <translation>行事曆</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
         <source>Navigator</source>
         <translation>領航員</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="71"/>
         <source>Season Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="72"/>
         <source>Blank Overview </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="76"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="73"/>
         <source>User Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="74"/>
         <source>Trends</source>
         <translation type="unfinished">趨勢</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="78"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="75"/>
         <source>TreeMap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="77"/>
         <source>Power Duration </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="83"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="80"/>
         <source>Activity Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="81"/>
         <source>Blank Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="85"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="82"/>
         <source>User Chart </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="87"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="84"/>
         <source>Data</source>
         <translation type="unfinished">日期</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="91"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="88"/>
         <source>Power Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="102"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="99"/>
         <source>Scatter</source>
         <translation type="unfinished">分佈圖</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="103"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="100"/>
         <source>Aerolab</source>
         <translation type="unfinished">空力實驗室</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="104"/>
         <source>Telemetry</source>
         <translation>感測器資訊</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="105"/>
         <source>Workout</source>
         <translation>訓練課表</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="106"/>
         <source>Realtime</source>
         <translation>即時</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="107"/>
         <source>Pedal Stroke</source>
         <translation>踩踏動作</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="113"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="110"/>
         <source>Live Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="114"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <source>Elevation Chart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
         <source>Web page</source>
         <translation>網頁</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="96"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="93"/>
         <source>Map</source>
         <translation>地圖</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="97"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="94"/>
         <source>R Chart</source>
         <translation>R圖表</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="98"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="95"/>
         <source>R Chart </source>
         <translation>R圖表 </translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="111"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="108"/>
         <source>Video Player</source>
         <translation>影片播放器</translation>
     </message>
     <message>
-        <location filename="../../Gui/GcWindowRegistry.cpp" line="112"/>
+        <location filename="../../Gui/GcWindowRegistry.cpp" line="109"/>
         <source>Workout Editor</source>
         <translation>訓練課表編輯器</translation>
     </message>
@@ -14732,142 +14725,147 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="296"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="294"/>
+        <source>Show elevation profile of instant position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
         <source>Predefined and configurable set of data ranges for selection of activities to be analysed</source>
         <translation>針對活動紀錄之預設及可配置日期範圍以供進行分析</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
         <source>Powerful filter and search engine to determine the activities which are considered in diagram</source>
         <translation>功能強大之過濾及搜尋器，以選擇圖表顯示數值的活動紀錄</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
         <source>Configurable list of activities</source>
         <translation>可配置活動紀錄列表</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="317"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
         <source>Configurable list of training devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="319"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
         <source>Configurable list of workout files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="321"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
         <source>Configurable list of video files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="323"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="325"/>
         <source>Configurable list of video sync files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="327"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
         <source>Entry field for sophisticated Searching and Filtering of activities</source>
         <translation>活動紀錄過濾及搜尋器之輸入欄位</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="329"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
         <source>Adding intervals to an activity using simple query methods</source>
         <translation>利用簡單的設定，自動從活動紀錄找尋增加間歇區段</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="331"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
         <source>To compare Activities/Intervals in Activity View and Date Ranges in Trends View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="333"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="335"/>
         <source>Workout Control, Intensity Adjustments and Notifications Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
         <source>Athlete Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
         <source>Athlete Measures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="349"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
         <source>Auto Import</source>
         <translation type="unfinished">自動匯入</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="351"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
         <source>Backup</source>
         <translation type="unfinished">備份</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="353"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="355"/>
         <source>Cloud Accounts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <source>Automatic Interval Detection</source>
         <translation>自動偵測區段</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
         <source>Definition of coloring rules for activities</source>
         <translation>活動紀錄上色條件定義</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
         <source>Metrics shown in &apos;Intervals&apos; and &apos;Summary&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="376"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
         <source>User/Custom Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="378"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
         <source>Create or Edit a User Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="380"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
         <source>Measures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="382"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
         <source>Train View devices configuration and preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="384"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
         <source>Train View Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="386"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
         <source>Remote Controls Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="388"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
         <source>Add/Remove Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="390"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
         <source>Add Train Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="392"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="394"/>
         <source>Virtual Bicycle configuration for simulation rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14901,8 +14899,8 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
     </message>
     <message>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="219"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="308"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
         <source>Calendar</source>
         <translation>行事曆</translation>
     </message>
@@ -14937,74 +14935,74 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation>針對圖表之過濾/搜尋及日期範圍選項</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="298"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
         <source>Definition of points in time &apos;Events&apos; which are marked explicitely on time related diagrams</source>
         <translation>定義特定賽事日子，於日期相關圖表中標記顯示</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="300"/>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="314"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="302"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="316"/>
         <source>Simple summary view</source>
         <translation>簡易總結頁面</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="304"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="306"/>
         <source>Alternative access to the charts created for the main view</source>
         <translation>主畫面定義之圖表的另一種使用方式</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="310"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="312"/>
         <source>Display the available and add new intervals using simple query methods</source>
         <translation>顯示可用或使用簡易查詢方式新增之區段</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="356"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
         <source>General</source>
         <translation>一般</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="337"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="339"/>
         <source>Athlete</source>
         <translation>運動員</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="341"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
         <source>Training Zone definition for power</source>
         <translation>功率訓練區間之定義</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="343"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
         <source>Training Zone definition for heartrate</source>
         <translation>心率訓練區間之定義</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="345"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="347"/>
         <source>Training Zone definition for Swim and Run</source>
         <translation>游泳及跑步訓練區間之定義</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="358"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="360"/>
         <source>Appearance</source>
         <translation>外觀</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="362"/>
         <location filename="../../Gui/HelpWhatsThis.cpp" line="364"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="366"/>
         <source>Data Fields</source>
         <translation>資訊欄位</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="368"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
         <source>Definition of default value(s) for data fields</source>
         <translation>各數值欄位之預設值定義</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="370"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
         <source>Definition of processing default parameters for the fix, adjust,... tools</source>
         <translation>各修改或修正工具之預設參數定義</translation>
     </message>
     <message>
-        <location filename="../../Gui/HelpWhatsThis.cpp" line="372"/>
+        <location filename="../../Gui/HelpWhatsThis.cpp" line="374"/>
         <source>Metrics</source>
         <translation>計測量</translation>
     </message>
@@ -15204,47 +15202,43 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2437"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2438"/>
         <source>Delete</source>
-        <translation>刪除</translation>
+        <translation type="vanished">刪除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2431"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2432"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2447"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2332"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2458"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2343"/>
         <source>Short</source>
         <translation>簡稱</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2459"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2344"/>
         <source>Long</source>
         <translation>全名</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2460"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2345"/>
         <source>Percent of LT</source>
         <translation>LT百分比</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2461"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2346"/>
         <source>Trimp k</source>
         <translation>Trimp系数</translation>
     </message>
@@ -15253,14 +15247,14 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">僅允許設定10個區間。</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2506"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2513"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2390"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2397"/>
         <source>New</source>
         <translation>新建</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2508"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2515"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2392"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2399"/>
         <source>New (%1)</source>
         <translation>新建 (%1)</translation>
     </message>
@@ -15450,17 +15444,17 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2348"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2245"/>
         <source>Sport</source>
         <translation>運動種類</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2395"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2292"/>
         <source>Lactate Threshold</source>
         <translation>乳酸閾値</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2396"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2293"/>
         <source>Default</source>
         <translation>預設</translation>
     </message>
@@ -17608,545 +17602,542 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTMTool</name>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1303"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1272"/>
         <source>Metric</source>
         <translation>公制</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="74"/>
+        <location filename="../../Charts/LTMTool.cpp" line="75"/>
         <source>Filter</source>
         <translation>過濾器</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="80"/>
+        <location filename="../../Charts/LTMTool.cpp" line="81"/>
         <source>Date range</source>
         <translation>日期範圍</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="84"/>
+        <location filename="../../Charts/LTMTool.cpp" line="85"/>
         <source>Days</source>
         <translation>日</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="85"/>
+        <location filename="../../Charts/LTMTool.cpp" line="86"/>
         <source>Weeks</source>
         <translation>週</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="86"/>
+        <location filename="../../Charts/LTMTool.cpp" line="87"/>
         <source>Months</source>
         <translation>月</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="87"/>
+        <location filename="../../Charts/LTMTool.cpp" line="88"/>
         <source>Years</source>
         <translation>年</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="88"/>
+        <location filename="../../Charts/LTMTool.cpp" line="89"/>
         <source>Time Of Day</source>
         <translation>時間</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="89"/>
+        <location filename="../../Charts/LTMTool.cpp" line="90"/>
         <source>All</source>
         <translation>全部</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="91"/>
+        <location filename="../../Charts/LTMTool.cpp" line="92"/>
         <source>Group by</source>
         <translation>依群組</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="102"/>
+        <location filename="../../Charts/LTMTool.cpp" line="103"/>
         <source>Shade Zones</source>
         <translation>區間上色</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="105"/>
+        <location filename="../../Charts/LTMTool.cpp" line="106"/>
         <source>Show Legend</source>
         <translation>顯示圖例</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="109"/>
         <source>Show Events</source>
         <translation>顯示賽事</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="351"/>
+        <location filename="../../Charts/LTMTool.cpp" line="325"/>
         <source>Skiba Long Term Stress</source>
         <translation>Skiba長期壓力(LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="353"/>
-        <location filename="../../Charts/LTMTool.cpp" line="368"/>
-        <location filename="../../Charts/LTMTool.cpp" line="429"/>
-        <location filename="../../Charts/LTMTool.cpp" line="444"/>
-        <location filename="../../Charts/LTMTool.cpp" line="505"/>
-        <location filename="../../Charts/LTMTool.cpp" line="520"/>
-        <location filename="../../Charts/LTMTool.cpp" line="580"/>
-        <location filename="../../Charts/LTMTool.cpp" line="595"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1080"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1095"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1156"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1171"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1309"/>
+        <location filename="../../Charts/LTMTool.cpp" line="327"/>
+        <location filename="../../Charts/LTMTool.cpp" line="342"/>
+        <location filename="../../Charts/LTMTool.cpp" line="403"/>
+        <location filename="../../Charts/LTMTool.cpp" line="418"/>
+        <location filename="../../Charts/LTMTool.cpp" line="479"/>
+        <location filename="../../Charts/LTMTool.cpp" line="494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="554"/>
+        <location filename="../../Charts/LTMTool.cpp" line="569"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1054"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1069"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1130"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1145"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1278"/>
         <source>Stress</source>
         <translation>壓力</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="366"/>
+        <location filename="../../Charts/LTMTool.cpp" line="340"/>
         <source>Skiba Short Term Stress</source>
         <translation>Skiba短期壓力(STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="381"/>
+        <location filename="../../Charts/LTMTool.cpp" line="355"/>
         <source>Skiba Stress Balance</source>
         <translation>Skiba壓力平衡(SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="383"/>
-        <location filename="../../Charts/LTMTool.cpp" line="459"/>
-        <location filename="../../Charts/LTMTool.cpp" line="535"/>
-        <location filename="../../Charts/LTMTool.cpp" line="610"/>
-        <location filename="../../Charts/LTMTool.cpp" line="686"/>
-        <location filename="../../Charts/LTMTool.cpp" line="762"/>
-        <location filename="../../Charts/LTMTool.cpp" line="838"/>
-        <location filename="../../Charts/LTMTool.cpp" line="914"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1110"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1186"/>
+        <location filename="../../Charts/LTMTool.cpp" line="357"/>
+        <location filename="../../Charts/LTMTool.cpp" line="433"/>
+        <location filename="../../Charts/LTMTool.cpp" line="509"/>
+        <location filename="../../Charts/LTMTool.cpp" line="584"/>
+        <location filename="../../Charts/LTMTool.cpp" line="660"/>
+        <location filename="../../Charts/LTMTool.cpp" line="736"/>
+        <location filename="../../Charts/LTMTool.cpp" line="812"/>
+        <location filename="../../Charts/LTMTool.cpp" line="888"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1084"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1160"/>
         <source>Stress Balance</source>
         <translation>壓力平衡 (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="396"/>
+        <location filename="../../Charts/LTMTool.cpp" line="370"/>
         <source>Skiba STS Ramp</source>
         <translation>Skiba短期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="398"/>
-        <location filename="../../Charts/LTMTool.cpp" line="413"/>
-        <location filename="../../Charts/LTMTool.cpp" line="474"/>
-        <location filename="../../Charts/LTMTool.cpp" line="489"/>
-        <location filename="../../Charts/LTMTool.cpp" line="550"/>
-        <location filename="../../Charts/LTMTool.cpp" line="565"/>
-        <location filename="../../Charts/LTMTool.cpp" line="625"/>
-        <location filename="../../Charts/LTMTool.cpp" line="640"/>
-        <location filename="../../Charts/LTMTool.cpp" line="701"/>
-        <location filename="../../Charts/LTMTool.cpp" line="716"/>
-        <location filename="../../Charts/LTMTool.cpp" line="777"/>
-        <location filename="../../Charts/LTMTool.cpp" line="792"/>
-        <location filename="../../Charts/LTMTool.cpp" line="853"/>
-        <location filename="../../Charts/LTMTool.cpp" line="868"/>
-        <location filename="../../Charts/LTMTool.cpp" line="929"/>
-        <location filename="../../Charts/LTMTool.cpp" line="944"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1005"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1020"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1125"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1140"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1201"/>
-        <location filename="../../Charts/LTMTool.cpp" line="1216"/>
+        <location filename="../../Charts/LTMTool.cpp" line="372"/>
+        <location filename="../../Charts/LTMTool.cpp" line="387"/>
+        <location filename="../../Charts/LTMTool.cpp" line="448"/>
+        <location filename="../../Charts/LTMTool.cpp" line="463"/>
+        <location filename="../../Charts/LTMTool.cpp" line="524"/>
+        <location filename="../../Charts/LTMTool.cpp" line="539"/>
+        <location filename="../../Charts/LTMTool.cpp" line="599"/>
+        <location filename="../../Charts/LTMTool.cpp" line="614"/>
+        <location filename="../../Charts/LTMTool.cpp" line="675"/>
+        <location filename="../../Charts/LTMTool.cpp" line="690"/>
+        <location filename="../../Charts/LTMTool.cpp" line="751"/>
+        <location filename="../../Charts/LTMTool.cpp" line="766"/>
+        <location filename="../../Charts/LTMTool.cpp" line="827"/>
+        <location filename="../../Charts/LTMTool.cpp" line="842"/>
+        <location filename="../../Charts/LTMTool.cpp" line="903"/>
+        <location filename="../../Charts/LTMTool.cpp" line="918"/>
+        <location filename="../../Charts/LTMTool.cpp" line="979"/>
+        <location filename="../../Charts/LTMTool.cpp" line="994"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1099"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1114"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1175"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1190"/>
         <source>Ramp</source>
         <translation>升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="411"/>
+        <location filename="../../Charts/LTMTool.cpp" line="385"/>
         <source>Skiba LTS Ramp</source>
         <translation>Skiba長期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="427"/>
+        <location filename="../../Charts/LTMTool.cpp" line="401"/>
         <source>Aerobic TISS Long Term Stress</source>
         <translation>有氧TISS長期壓力(LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="442"/>
+        <location filename="../../Charts/LTMTool.cpp" line="416"/>
         <source>Aerobic TISS Short Term Stress</source>
         <translation>有氧TISS短期壓力(STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="457"/>
+        <location filename="../../Charts/LTMTool.cpp" line="431"/>
         <source>Aerobic TISS Stress Balance</source>
         <translation>有氧TISS壓力平衡(SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="472"/>
+        <location filename="../../Charts/LTMTool.cpp" line="446"/>
         <source>Aerobic TISS STS Ramp</source>
         <translation>有氧TISS短期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="487"/>
+        <location filename="../../Charts/LTMTool.cpp" line="461"/>
         <source>Aerobic TISS LTS Ramp</source>
         <translation>有氧TISS長期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="503"/>
+        <location filename="../../Charts/LTMTool.cpp" line="477"/>
         <source>Anaerobic TISS Long Term Stress</source>
         <translation>無氧TISS長期壓力(LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="518"/>
+        <location filename="../../Charts/LTMTool.cpp" line="492"/>
         <source>Anaerobic TISS Short Term Stress</source>
         <translation>無氧TISS短期壓力(STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="533"/>
+        <location filename="../../Charts/LTMTool.cpp" line="507"/>
         <source>Anaerobic TISS Stress Balance</source>
         <translation>無氧TISS壓力平衡(SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="548"/>
+        <location filename="../../Charts/LTMTool.cpp" line="522"/>
         <source>Anaerobic TISS STS Ramp</source>
         <translation>無氧TISS短期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="563"/>
+        <location filename="../../Charts/LTMTool.cpp" line="537"/>
         <source>Anaerobic TISS LTS Ramp</source>
         <translation>無氧TISS長期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="578"/>
+        <location filename="../../Charts/LTMTool.cpp" line="552"/>
         <source>Daniels Long Term Stress</source>
         <translation>Daniels長期壓力(LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="593"/>
+        <location filename="../../Charts/LTMTool.cpp" line="567"/>
         <source>Daniels Short Term Stress</source>
         <translation>Daniels短期壓力(STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="608"/>
+        <location filename="../../Charts/LTMTool.cpp" line="582"/>
         <source>Daniels Stress Balance</source>
         <translation>Daniels壓力平衡(SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="623"/>
+        <location filename="../../Charts/LTMTool.cpp" line="597"/>
         <source>Daniels STS Ramp</source>
         <translation>Daniels短期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="638"/>
+        <location filename="../../Charts/LTMTool.cpp" line="612"/>
         <source>Daniels LTS Ramp</source>
         <translation>Daniels長期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="654"/>
+        <location filename="../../Charts/LTMTool.cpp" line="628"/>
         <source>Work (Kj) Long Term Stress</source>
         <translation>作功(kJ)長期壓力(LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="656"/>
-        <location filename="../../Charts/LTMTool.cpp" line="671"/>
-        <location filename="../../Charts/LTMTool.cpp" line="732"/>
-        <location filename="../../Charts/LTMTool.cpp" line="747"/>
-        <location filename="../../Charts/LTMTool.cpp" line="808"/>
-        <location filename="../../Charts/LTMTool.cpp" line="823"/>
+        <location filename="../../Charts/LTMTool.cpp" line="630"/>
+        <location filename="../../Charts/LTMTool.cpp" line="645"/>
+        <location filename="../../Charts/LTMTool.cpp" line="706"/>
+        <location filename="../../Charts/LTMTool.cpp" line="721"/>
+        <location filename="../../Charts/LTMTool.cpp" line="782"/>
+        <location filename="../../Charts/LTMTool.cpp" line="797"/>
         <source>Stress (Kj)</source>
         <translation>壓力(kJ)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="669"/>
+        <location filename="../../Charts/LTMTool.cpp" line="643"/>
         <source>Work (Kj) Short Term Stress</source>
         <translation>作功(kJ)短期壓力(STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="684"/>
+        <location filename="../../Charts/LTMTool.cpp" line="658"/>
         <source>Work (Kj) Stress Balance</source>
         <translation>作功(kJ)壓力平衡(SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="699"/>
+        <location filename="../../Charts/LTMTool.cpp" line="673"/>
         <source>Work (Kj) STS Ramp</source>
         <translation>作功(kJ)短期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="714"/>
+        <location filename="../../Charts/LTMTool.cpp" line="688"/>
         <source>Work (Kj) LTS Ramp</source>
         <translation>作功(kJ)長期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="730"/>
+        <location filename="../../Charts/LTMTool.cpp" line="704"/>
         <source>W&apos; Work (Kj) Long Term Stress</source>
         <translation>W&apos;作功(kJ)長期壓力(LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="745"/>
+        <location filename="../../Charts/LTMTool.cpp" line="719"/>
         <source>W&apos; Work (Kj) Short Term Stress</source>
         <translation>W&apos;作功(kJ)短期壓力(STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="760"/>
+        <location filename="../../Charts/LTMTool.cpp" line="734"/>
         <source>W&apos; Work (Kj) Stress Balance</source>
         <translation>W&apos;作功(kJ)壓力平衡(SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="775"/>
+        <location filename="../../Charts/LTMTool.cpp" line="749"/>
         <source>W&apos; Work (Kj) STS Ramp</source>
         <translation>W&apos;作功(kJ)短期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="790"/>
+        <location filename="../../Charts/LTMTool.cpp" line="764"/>
         <source>W&apos; Work (Kj) LTS Ramp</source>
         <translation>W&apos;作功(kJ)長期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="806"/>
+        <location filename="../../Charts/LTMTool.cpp" line="780"/>
         <source>Below CP Work (Kj) Long Term Stress</source>
         <translation>CP以下作功(kJ)長期壓力(LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="821"/>
+        <location filename="../../Charts/LTMTool.cpp" line="795"/>
         <source>Below CP Work (Kj) Short Term Stress</source>
         <translation>CP以下作功(kJ)短期壓力(STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="836"/>
+        <location filename="../../Charts/LTMTool.cpp" line="810"/>
         <source>Below CP Work (Kj) Stress Balance</source>
         <translation>CP以下作功(kJ)壓力平衡(SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="851"/>
+        <location filename="../../Charts/LTMTool.cpp" line="825"/>
         <source>Below CP Work (Kj) STS Ramp</source>
         <translation>CP以下作功(kJ)短期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="866"/>
+        <location filename="../../Charts/LTMTool.cpp" line="840"/>
         <source>Below CP Work (Kj) LTS Ramp</source>
         <translation>CP以下作功(kJ)長期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="882"/>
+        <location filename="../../Charts/LTMTool.cpp" line="856"/>
         <source>Distance (km|mi) Long Term Stress</source>
         <translation>距離(km|mi)長期壓力(LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="884"/>
-        <location filename="../../Charts/LTMTool.cpp" line="899"/>
+        <location filename="../../Charts/LTMTool.cpp" line="858"/>
+        <location filename="../../Charts/LTMTool.cpp" line="873"/>
         <source>Stress (km|mi)</source>
         <translation>壓力(km|mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="897"/>
+        <location filename="../../Charts/LTMTool.cpp" line="871"/>
         <source>Distance (km|mi) Short Term Stress</source>
         <translation>距離(km|mi)短期壓力(STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="912"/>
+        <location filename="../../Charts/LTMTool.cpp" line="886"/>
         <source>Distance (km|mi) Stress Balance</source>
         <translation>距離(km|mi)壓力平衡(SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="927"/>
+        <location filename="../../Charts/LTMTool.cpp" line="901"/>
         <source>Distance (km|mi) STS Ramp</source>
         <translation>距離(km|mi)短期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="942"/>
+        <location filename="../../Charts/LTMTool.cpp" line="916"/>
         <source>Distance (km|mi) LTS Ramp</source>
         <translation>距離(km|mi)長期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="958"/>
+        <location filename="../../Charts/LTMTool.cpp" line="932"/>
         <source>Coggan Chronic Training Load</source>
         <translation>Coggan週期訓練量(CTL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="973"/>
+        <location filename="../../Charts/LTMTool.cpp" line="947"/>
         <source>Coggan Acute Training Load</source>
         <translation>Coggan短期訓練量(ATL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="988"/>
+        <location filename="../../Charts/LTMTool.cpp" line="962"/>
         <source>Coggan Training Stress Balance</source>
         <translation>Coggan訓練壓力平衡(TSB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1003"/>
+        <location filename="../../Charts/LTMTool.cpp" line="977"/>
         <source>Coggan STS Ramp</source>
         <translation>Coggan短期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1018"/>
+        <location filename="../../Charts/LTMTool.cpp" line="992"/>
         <source>Coggan LTS Ramp</source>
         <translation>Coggan長期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1033"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1007"/>
         <source>Coggan Expected Chronic Training Load</source>
         <translation>Coggan預計週期訓練量(CTL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1048"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1022"/>
         <source>Coggan Expected Acute Training Load</source>
         <translation>Coggan預計短期訓練量(ATL)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1063"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1037"/>
         <source>Coggan Expected Training Stress Balance</source>
         <translation>Coggan預計訓練壓力平衡(TSB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1079"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1053"/>
         <source>TRIMP Long Term Stress</source>
         <translation>TRIMP長期壓力(LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1093"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1067"/>
         <source>TRIMP Short Term Stress</source>
         <translation>TRIMP短期壓力(STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1108"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1082"/>
         <source>TRIMP Stress Balance</source>
         <translation>TRIMP壓力平衡(SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1123"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1097"/>
         <source>TRIMP STS Ramp</source>
         <translation>TRIMP短期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1138"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1112"/>
         <source>TRIMP LTS Ramp</source>
         <translation>TRIMP長期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="268"/>
         <source>Edit</source>
-        <translation>編輯</translation>
+        <translation type="vanished">編輯</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="124"/>
+        <location filename="../../Charts/LTMTool.cpp" line="125"/>
         <source>Use sidebar chart settings</source>
         <translation>使用側邊欄之圖表設定</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Basic</source>
         <translation>基本</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="314"/>
+        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Preset</source>
         <translation>預置</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1307"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1276"/>
         <source>Estimate</source>
         <translation>預估</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1311"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1280"/>
         <source>Formula</source>
         <translation>計算式</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1313"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1282"/>
         <source>Measure</source>
         <translation>量測</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1284"/>
         <source>Performance</source>
         <translation>個人表現</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1317"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1286"/>
         <source>Banister</source>
         <translation>Banister</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1494"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1463"/>
         <source>Chart %1</source>
         <translation>圖表 %1</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="94"/>
+        <location filename="../../Charts/LTMTool.cpp" line="95"/>
         <source>Data Table</source>
         <translation>資料表</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="98"/>
+        <location filename="../../Charts/LTMTool.cpp" line="99"/>
         <source>Show Stack</source>
         <translation>堆疊顯示</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="121"/>
+        <location filename="../../Charts/LTMTool.cpp" line="122"/>
         <source>Stack Zoom</source>
         <translation>堆疊縮放</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="155"/>
+        <location filename="../../Charts/LTMTool.cpp" line="156"/>
         <source>Add Current</source>
         <translation>新增目前項目</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="146"/>
+        <location filename="../../Charts/LTMTool.cpp" line="147"/>
         <source>Charts</source>
         <translation>圖表</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="111"/>
+        <location filename="../../Charts/LTMTool.cpp" line="112"/>
         <source>Show Banister Helper</source>
         <translation>顯示Banister幫手</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="155"/>
         <source>Apply</source>
         <translation>套用</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="287"/>
         <source>Up</source>
-        <translation>上</translation>
+        <translation type="vanished">上</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="288"/>
         <source>Down</source>
-        <translation>下</translation>
+        <translation type="vanished">下</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="315"/>
+        <location filename="../../Charts/LTMTool.cpp" line="289"/>
         <source>Curves</source>
         <translation>曲線</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1154"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1128"/>
         <source>TriScore Long Term Stress</source>
         <translation>TriScore長期壓力 (LTS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1169"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1143"/>
         <source>TriScore Short Term Stress</source>
         <translation>TriScore短期壓力 (STS)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1184"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1158"/>
         <source>TriScore Stress Balance</source>
         <translation>TriScore壓力平衡 (SB)</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1199"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1173"/>
         <source>TriScore STS Ramp</source>
         <translation>TriScore短期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1214"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1188"/>
         <source>TriScore LTS Ramp</source>
         <translation>TriScore長期壓力升率</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Type</source>
         <translation>種類</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1292"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1261"/>
         <source>Details</source>
         <translation>詳細資訊</translation>
     </message>
     <message>
-        <location filename="../../Charts/LTMTool.cpp" line="1305"/>
+        <location filename="../../Charts/LTMTool.cpp" line="1274"/>
         <source>Peak</source>
         <translation>峰值</translation>
     </message>
@@ -18349,31 +18340,23 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">更新</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2590"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2602"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2591"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2603"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2596"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2608"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2597"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2609"/>
         <source>Delete</source>
-        <translation>刪除</translation>
+        <translation type="vanished">刪除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2599"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2467"/>
         <source>Def</source>
         <translation>定義</translation>
     </message>
@@ -18382,14 +18365,14 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">起始日期</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2651"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2790"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2494"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2631"/>
         <source>Lactate Threshold</source>
         <translation>乳酸閾値</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2652"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2791"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2495"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2632"/>
         <source>Aerobic Threshold</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18398,45 +18381,45 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">僅允許設定10個區間。</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2967"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2974"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2804"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2811"/>
         <source>New</source>
         <translation>新建</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2969"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2976"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2806"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2813"/>
         <source>New (%1)</source>
         <translation>新建 (%1)</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2653"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2792"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2496"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
         <source>Rest HR</source>
         <translation>静止心率</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2623"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2628"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2633"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2638"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2690"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2770"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2775"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2780"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2785"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2473"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2478"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2483"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2488"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2533"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2611"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2616"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2621"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2626"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2650"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2789"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2493"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2630"/>
         <source>Start Date</source>
         <translation type="unfinished">起始日期</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2654"/>
-        <location filename="../../Gui/AthletePages.cpp" line="2793"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2497"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2634"/>
         <source>Max HR</source>
         <translation>最大心率</translation>
     </message>
@@ -18445,22 +18428,22 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="vanished">yyyy年M月 d日</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2701"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2544"/>
         <source>Short</source>
         <translation>簡稱</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2702"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2545"/>
         <source>Long</source>
         <translation>全名</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2703"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2546"/>
         <source>From BPM</source>
         <translation>最低心率</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="2704"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2547"/>
         <source>Trimp k</source>
         <translation>Trimp系數</translation>
     </message>
@@ -19201,62 +19184,62 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>Library</name>
     <message>
+        <location filename="../../Train/Library.cpp" line="126"/>
         <location filename="../../Train/Library.cpp" line="130"/>
-        <location filename="../../Train/Library.cpp" line="134"/>
         <source>Import Videos, VideoSyncs and Workouts</source>
         <translation>匯入訓練課表，影片及影片同步檔</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="127"/>
         <location filename="../../Train/Library.cpp" line="131"/>
-        <location filename="../../Train/Library.cpp" line="135"/>
         <source>No supported videos, videoSyncs or workouts were found to import</source>
         <translation>未找到支援之影片，影片同步檔或訓練課表</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="189"/>
         <location filename="../../Train/Library.cpp" line="193"/>
-        <location filename="../../Train/Library.cpp" line="197"/>
+        <location filename="../../Train/Library.cpp" line="198"/>
         <location filename="../../Train/Library.cpp" line="202"/>
-        <location filename="../../Train/Library.cpp" line="206"/>
         <source>Copy VideoSync Failed</source>
         <translation>複制影片同步檔失敗</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="190"/>
         <location filename="../../Train/Library.cpp" line="194"/>
-        <location filename="../../Train/Library.cpp" line="198"/>
         <source>%1 already exists in videoSync library: %2</source>
         <translation>%1已存在於影片同步檔檔案夾:%2</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="203"/>
+        <location filename="../../Train/Library.cpp" line="199"/>
         <source>%1 cannot be written to videoSync library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="207"/>
+        <location filename="../../Train/Library.cpp" line="203"/>
         <source>%1 cannot be written to videoSync library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="253"/>
+        <location filename="../../Train/Library.cpp" line="249"/>
         <source>%1 cannot be written to workout library %2. Check library path, permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="257"/>
+        <location filename="../../Train/Library.cpp" line="253"/>
         <source>%1 cannot be written to workout library %2, check permissions and free space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="239"/>
         <location filename="../../Train/Library.cpp" line="243"/>
-        <location filename="../../Train/Library.cpp" line="247"/>
+        <location filename="../../Train/Library.cpp" line="248"/>
         <location filename="../../Train/Library.cpp" line="252"/>
-        <location filename="../../Train/Library.cpp" line="256"/>
         <source>Copy Workout Failed</source>
         <translation>複制訓練課表失敗</translation>
     </message>
     <message>
+        <location filename="../../Train/Library.cpp" line="240"/>
         <location filename="../../Train/Library.cpp" line="244"/>
-        <location filename="../../Train/Library.cpp" line="248"/>
         <source>%1 already exists in workout library: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19264,89 +19247,89 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LibrarySearchDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="330"/>
+        <location filename="../../Train/Library.cpp" line="326"/>
         <source>Search for Workouts, Syncs and Media</source>
         <translation>搜尋訓練課表，影片及影片同步檔</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="337"/>
+        <location filename="../../Train/Library.cpp" line="333"/>
         <source>Workout files (.erg, .mrc, .zwo etc)</source>
         <translation>訓練課表檔案 (.erg, .mrc, .zwo 等)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="339"/>
+        <location filename="../../Train/Library.cpp" line="335"/>
         <source>Video files (.mp4, .avi etc)</source>
         <translation>影片檔案 (.mp4, .avi 等)</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="341"/>
+        <location filename="../../Train/Library.cpp" line="337"/>
         <source>VideoSync files (.rlv, .tts etc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="359"/>
+        <location filename="../../Train/Library.cpp" line="353"/>
         <source>Search Path</source>
         <translation>搜尋路徑</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="379"/>
+        <location filename="../../Train/Library.cpp" line="373"/>
         <source>Video references</source>
         <translation>影片喜好設定</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="391"/>
+        <location filename="../../Train/Library.cpp" line="385"/>
         <source>Searching...</source>
         <translation>搜尋中...</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="394"/>
+        <location filename="../../Train/Library.cpp" line="388"/>
         <source>Videos</source>
         <translation>影片</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="396"/>
+        <location filename="../../Train/Library.cpp" line="390"/>
         <source>Workouts</source>
         <translation>訓練課表</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="398"/>
+        <location filename="../../Train/Library.cpp" line="392"/>
         <source>VideoSyncs</source>
         <translation>影片同步檔</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="407"/>
-        <location filename="../../Train/Library.cpp" line="494"/>
+        <location filename="../../Train/Library.cpp" line="401"/>
+        <location filename="../../Train/Library.cpp" line="484"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="409"/>
+        <location filename="../../Train/Library.cpp" line="403"/>
         <source>Search</source>
         <translation>搜尋</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="412"/>
+        <location filename="../../Train/Library.cpp" line="406"/>
         <source>Files to search for:</source>
         <translation>欲搜尋之檔案：</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="475"/>
+        <location filename="../../Train/Library.cpp" line="466"/>
         <source>Abort Search</source>
         <translation>中止搜尋</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="515"/>
-        <location filename="../../Train/Library.cpp" line="559"/>
+        <location filename="../../Train/Library.cpp" line="504"/>
+        <location filename="../../Train/Library.cpp" line="548"/>
         <source>Save</source>
         <translation>儲存</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="557"/>
+        <location filename="../../Train/Library.cpp" line="546"/>
         <source>Search completed.</source>
         <translation>搜尋完成。</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="645"/>
+        <location filename="../../Train/Library.cpp" line="634"/>
         <source>Select Directory</source>
         <translation>選擇檔案夾</translation>
     </message>
@@ -19354,12 +19337,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>ListEditWidget</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="623"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="654"/>
         <source>New</source>
         <translation type="unfinished">新建</translation>
     </message>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="625"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="656"/>
         <source>New (%1)</source>
         <translation type="unfinished">新建 (%1)</translation>
     </message>
@@ -19372,7 +19355,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="90"/>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="85"/>
+        <source>Initial Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/LiveMapWebPageWindow.cpp" line="98"/>
         <source>Apply changes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19592,7 +19580,7 @@ on and that its display says, &quot;PC Link&quot;</source>
         <translation>切換左方資訊列</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>Delete Activity</source>
         <translation>刪除活動紀錄</translation>
     </message>
@@ -19724,90 +19712,90 @@ on and that its display says, &quot;PC Link&quot;</source>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Activity Import</source>
         <translation>匯入活動紀錄</translation>
     </message>
     <message>
         <location filename="../../Gui/MainWindow.cpp" line="1095"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2023"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2052"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2033"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2062"/>
         <source>Closing of athlete window not possible while background activity import is in progress...</source>
         <translation>活動紀錄背景匯入進行中，無法關閉運動員視窗...</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Chart Import</source>
         <translation>圖表匯入</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>Import Images Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1650"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1660"/>
         <source>You can only import images on the activities view with an activity selected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>Import Images to Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1656"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1666"/>
         <source>%1 images imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1778"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1788"/>
         <source>Failed to export activity, please check permissions</source>
         <translation>匯出活動紀錄失敗，請確認權限</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1814"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1824"/>
         <source>No Activity To Save</source>
         <translation>沒有活動紀錄可儲存</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1815"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1825"/>
         <source>There is no currently selected activity to save.</source>
         <translation>並無選中的活動紀錄可儲存。</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
         <location filename="../../Gui/MainWindow.cpp" line="1886"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Split Activity</source>
         <translation>分割活動紀錄</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1874"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1884"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1896"/>
         <source>No activity selected</source>
         <translation>未選擇活動紀錄</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1876"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1886"/>
         <source>Current activity contains no data to split</source>
         <translation>目前的活動紀錄不包合可分割的資料</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1888"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
         <source>Current activity contains no data to merge</source>
         <translation>目前的活動紀錄不包合可整併的資料</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1904"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1914"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation>你想要刪除活動紀錄：</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2400"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2421"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2410"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2431"/>
         <source>The workout directory is not configured, or the directory selected no longer exists.
 
 Please check your preference settings.</source>
@@ -19816,19 +19804,19 @@ Please check your preference settings.</source>
 請檢查您的設定。</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2611"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2621"/>
         <source>Loading activities: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>CloudDB</source>
         <translation>CloudDB</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2712"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2733"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2722"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2743"/>
         <source>Current athlete is not registered as curator - please contact the GoldenCheetah team</source>
         <translation>目前運動員非注冊編集者，請聯繫Golden Cheetah團隊</translation>
     </message>
@@ -19923,12 +19911,12 @@ Please check your preference settings.</source>
         <translation>要繼續嗎？</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1616"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1626"/>
         <source>Imported %1 metric charts</source>
         <translation>匯入%1計測方式圖表</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2165"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2175"/>
         <source>&amp;New Athlete...</source>
         <translation>新建運動員資料(&amp;N)</translation>
     </message>
@@ -19943,23 +19931,23 @@ Please check your preference settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
         <source>Select Activity</source>
         <translation>選擇活動紀錄</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1711"/>
-        <location filename="../../Gui/MainWindow.cpp" line="1898"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1721"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1908"/>
         <source>No activity selected!</source>
         <translation>未選擇活動紀錄!</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1724"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1734"/>
         <source>Export Activity</source>
         <translation>匯出活動紀錄</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1777"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1787"/>
         <source>Export Failed</source>
         <translation>匯出失敗</translation>
     </message>
@@ -20241,34 +20229,34 @@ Please check your preference settings.</source>
         <translation>關於Golden Cheetah(&amp;A)</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1799"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2369"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1809"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2379"/>
         <source>Import from File</source>
         <translation>從檔案匯入</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2342"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2352"/>
         <source>Refresh in Progress</source>
         <translation>刷新中</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Export Metrics</source>
         <translation>匯出計測量</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2348"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2358"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation>(*.csv)</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="2399"/>
-        <location filename="../../Gui/MainWindow.cpp" line="2420"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2409"/>
+        <location filename="../../Gui/MainWindow.cpp" line="2430"/>
         <source>Workout Directory Invalid</source>
         <translation>無效的訓練課表檔案夾</translation>
     </message>
     <message>
-        <location filename="../../Gui/MainWindow.cpp" line="1906"/>
+        <location filename="../../Gui/MainWindow.cpp" line="1916"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
@@ -21180,23 +21168,23 @@ Please check your preference settings.</source>
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="656"/>
+        <location filename="../../Gui/AthletePages.cpp" line="641"/>
         <source>From Date - Time</source>
         <translation type="unfinished">起始日期 - 時間</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="780"/>
+        <location filename="../../Gui/AthletePages.cpp" line="751"/>
         <source>Start Date</source>
         <translation type="unfinished">起始日期</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="893"/>
+        <location filename="../../Gui/AthletePages.cpp" line="864"/>
         <source>MMM d, yyyy - hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="659"/>
-        <location filename="../../Gui/AthletePages.cpp" line="807"/>
+        <location filename="../../Gui/AthletePages.cpp" line="644"/>
+        <location filename="../../Gui/AthletePages.cpp" line="778"/>
         <source>Comment</source>
         <translation type="unfinished">筆記</translation>
     </message>
@@ -21205,27 +21193,24 @@ Please check your preference settings.</source>
         <translation type="obsolete">更新</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="662"/>
         <source>+</source>
-        <translation type="unfinished">+</translation>
+        <translation type="obsolete">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="663"/>
         <source>-</source>
-        <translation type="unfinished">-</translation>
+        <translation type="obsolete">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Delete</source>
-        <translation type="unfinished">刪除</translation>
+        <translation type="obsolete">刪除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="698"/>
+        <location filename="../../Gui/AthletePages.cpp" line="668"/>
         <source>Source</source>
         <translation type="unfinished">來源</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="699"/>
+        <location filename="../../Gui/AthletePages.cpp" line="669"/>
         <source>Original Source</source>
         <translation type="unfinished">來源</translation>
     </message>
@@ -21234,9 +21219,8 @@ Please check your preference settings.</source>
         <translation type="obsolete">手動建立</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="668"/>
         <source>Add</source>
-        <translation type="unfinished">增加</translation>
+        <translation type="obsolete">增加</translation>
     </message>
 </context>
 <context>
@@ -21919,17 +21903,17 @@ No rides found to import.
 <context>
     <name>MultiDeviceDialog</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3048"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3060"/>
         <source>Multiple Device Configuration</source>
         <translation>多裝置配置</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3103"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3115"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3106"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3118"/>
         <source>Apply</source>
         <translation type="unfinished">套用</translation>
     </message>
@@ -22934,42 +22918,38 @@ No rides found to import.
 <context>
     <name>PaceSchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3154"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3155"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3160"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3161"/>
         <source>Delete</source>
-        <translation>刪除</translation>
+        <translation type="vanished">刪除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3171"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3176"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2987"/>
         <source>Short</source>
         <translation>簡稱</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3177"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2988"/>
         <source>Long</source>
         <translation>全名</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3178"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2989"/>
         <source>Percent of CV</source>
         <translation>CV百分比</translation>
     </message>
@@ -22978,14 +22958,14 @@ No rides found to import.
         <translation type="vanished">僅允許設定10個區間。</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3220"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3227"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3037"/>
         <source>New</source>
         <translation>新建</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3222"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3229"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3032"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3039"/>
         <source>New (%1)</source>
         <translation>新建 (%1)</translation>
     </message>
@@ -23185,27 +23165,27 @@ No rides found to import.
 <context>
     <name>PaceZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3082"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2905"/>
         <source>Sport</source>
         <translation>運動種類</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3084"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2907"/>
         <source>Run</source>
         <translation>跑步</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3085"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2908"/>
         <source>Swim</source>
         <translation> 游泳</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3126"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2949"/>
         <source>Critical Velocity</source>
         <translation>臨界速度</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3127"/>
+        <location filename="../../Gui/AthletePages.cpp" line="2950"/>
         <source>Default</source>
         <translation>預設</translation>
     </message>
@@ -25348,78 +25328,71 @@ Do you want to continue?</source>
 <context>
     <name>PerspectiveDialog</name>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="34"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="35"/>
         <source>Manage Perspectives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="43"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="44"/>
         <source>Perspectives</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="60"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="61"/>
         <source>Charts</source>
         <translation type="unfinished">圖表</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Edit</source>
-        <translation type="unfinished">編輯</translation>
+        <translation type="obsolete">編輯</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="83"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="78"/>
         <source>Import</source>
         <translation type="unfinished">匯入</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="84"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="77"/>
         <source>Export</source>
         <translation type="unfinished">匯出</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="90"/>
-        <source>Add</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="91"/>
         <source>Delete</source>
-        <translation type="unfinished">刪除</translation>
+        <translation type="obsolete">刪除</translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="98"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="82"/>
         <source>Drag charts to move to a perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="287"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="256"/>
         <source>Export Persepctive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
         <source>Export Perspective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="292"/>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="261"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>No perspective file selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
-        <source>Select Perspective file to export</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="302"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
         <source>GoldenCheetah Perspective Files (*.gchartset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/PerspectiveDialog.cpp" line="304"/>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="271"/>
+        <source>Select Perspective file to import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Gui/PerspectiveDialog.cpp" line="273"/>
         <source>Import Perspective</source>
         <translation type="unfinished"></translation>
     </message>
@@ -26575,307 +26548,307 @@ Python disabled in preferences.</source>
 <context>
     <name>RealtimeData</name>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="621"/>
+        <location filename="../../Train/RealtimeData.cpp" line="623"/>
         <source>None</source>
         <translation>無</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="624"/>
+        <location filename="../../Train/RealtimeData.cpp" line="626"/>
         <source>Time</source>
         <translation>時間</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="627"/>
+        <location filename="../../Train/RealtimeData.cpp" line="629"/>
         <source>Lap</source>
         <translation>圈數</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="630"/>
+        <location filename="../../Train/RealtimeData.cpp" line="632"/>
         <source>Lap Time</source>
         <translation>單圈時間</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="633"/>
+        <location filename="../../Train/RealtimeData.cpp" line="635"/>
         <source>Lap Time Remaining</source>
         <translation>單圈剩餘時間</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="636"/>
+        <location filename="../../Train/RealtimeData.cpp" line="638"/>
         <source>Section Time Remaining</source>
         <translation>階段剩餘時間</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="639"/>
+        <location filename="../../Train/RealtimeData.cpp" line="641"/>
         <source>BikeStress</source>
         <translation>BikeStress</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="645"/>
+        <location filename="../../Train/RealtimeData.cpp" line="647"/>
         <source>kJoules</source>
         <translation>kJ</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="648"/>
+        <location filename="../../Train/RealtimeData.cpp" line="650"/>
         <source>W&apos; bal</source>
         <translation>W&apos;Bal</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="651"/>
+        <location filename="../../Train/RealtimeData.cpp" line="653"/>
         <source>XPower</source>
         <translation>xPower</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="654"/>
+        <location filename="../../Train/RealtimeData.cpp" line="656"/>
         <source>Iso Power</source>
         <translation>IsoPower</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="657"/>
+        <location filename="../../Train/RealtimeData.cpp" line="659"/>
         <source>Intensity Factor</source>
         <translation>強度系數</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="660"/>
+        <location filename="../../Train/RealtimeData.cpp" line="662"/>
         <source>Relative Intensity</source>
         <translation>相對強度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="663"/>
+        <location filename="../../Train/RealtimeData.cpp" line="665"/>
         <source>Skiba Variability Index</source>
         <translation>Skiba變量指數</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="666"/>
+        <location filename="../../Train/RealtimeData.cpp" line="668"/>
         <source>Variability Index</source>
         <translation>變量指數</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="669"/>
+        <location filename="../../Train/RealtimeData.cpp" line="671"/>
         <source>Distance</source>
         <translation>距離</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="672"/>
+        <location filename="../../Train/RealtimeData.cpp" line="674"/>
         <source>Route Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="675"/>
+        <location filename="../../Train/RealtimeData.cpp" line="677"/>
         <source>Distance Remaining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="678"/>
+        <location filename="../../Train/RealtimeData.cpp" line="680"/>
         <source>Alternate Power</source>
         <translation>額外功率源</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="681"/>
+        <location filename="../../Train/RealtimeData.cpp" line="683"/>
         <source>Power</source>
         <translation>輸出功率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="684"/>
+        <location filename="../../Train/RealtimeData.cpp" line="686"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="687"/>
+        <location filename="../../Train/RealtimeData.cpp" line="689"/>
         <source>Virtual Speed</source>
         <translation>虛擬速度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="690"/>
+        <location filename="../../Train/RealtimeData.cpp" line="692"/>
         <source>Cadence</source>
         <translation>迴轉數</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="693"/>
+        <location filename="../../Train/RealtimeData.cpp" line="695"/>
         <source>Heart Rate</source>
         <translation>心率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="696"/>
+        <location filename="../../Train/RealtimeData.cpp" line="698"/>
         <source>Target Power</source>
         <translation>目標功率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="699"/>
+        <location filename="../../Train/RealtimeData.cpp" line="701"/>
         <source>Average Power</source>
         <translation>平均輸出功率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="702"/>
+        <location filename="../../Train/RealtimeData.cpp" line="704"/>
         <source>Average Speed</source>
         <translation>平均速度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="705"/>
+        <location filename="../../Train/RealtimeData.cpp" line="707"/>
         <source>Average Heartrate</source>
         <translation>平均心率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="708"/>
+        <location filename="../../Train/RealtimeData.cpp" line="710"/>
         <source>Average Cadence</source>
         <translation>平均迴轉數</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="711"/>
+        <location filename="../../Train/RealtimeData.cpp" line="713"/>
         <source>Lap Power</source>
         <translation>單圈功率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="714"/>
+        <location filename="../../Train/RealtimeData.cpp" line="716"/>
         <source>Lap Speed</source>
         <translation>單圈速度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="717"/>
+        <location filename="../../Train/RealtimeData.cpp" line="719"/>
         <source>Lap Heartrate</source>
         <translation>單圈心率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="720"/>
+        <location filename="../../Train/RealtimeData.cpp" line="722"/>
         <source>Lap Cadence</source>
         <translation>單圈迴轉數</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="723"/>
+        <location filename="../../Train/RealtimeData.cpp" line="725"/>
         <source>Left/Right Balance</source>
         <translation>左/右平衡</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="726"/>
+        <location filename="../../Train/RealtimeData.cpp" line="728"/>
         <source>Total Hb Mass</source>
         <translation>總Hb重量</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="729"/>
+        <location filename="../../Train/RealtimeData.cpp" line="731"/>
         <source>Hb O2 Saturation</source>
         <translation>HbO2 濃度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="732"/>
+        <location filename="../../Train/RealtimeData.cpp" line="734"/>
         <source>Deoxy Hb</source>
         <translation>缺氧Hb</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="735"/>
+        <location filename="../../Train/RealtimeData.cpp" line="737"/>
         <source>Oxy Hb</source>
         <translation>帶氧Hb</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="738"/>
+        <location filename="../../Train/RealtimeData.cpp" line="740"/>
         <source>Left Torque Effectiveness</source>
         <translation>左扭矩效率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="741"/>
+        <location filename="../../Train/RealtimeData.cpp" line="743"/>
         <source>Right Torque Effectiveness</source>
         <translation>右扭矩效率</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="744"/>
+        <location filename="../../Train/RealtimeData.cpp" line="746"/>
         <source>Left Pedal Smoothness</source>
         <translation>左踏板平滑度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="747"/>
+        <location filename="../../Train/RealtimeData.cpp" line="749"/>
         <source>Right Pedal Smoothness</source>
         <translation>右踏板平滑度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="750"/>
+        <location filename="../../Train/RealtimeData.cpp" line="752"/>
         <source>Right Power Phase Start</source>
         <translation type="unfinished">右側功率分佈PP起始角度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="753"/>
+        <location filename="../../Train/RealtimeData.cpp" line="755"/>
         <source>Right Power Phase End</source>
         <translation type="unfinished">右側功率分佈PP結束角度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="756"/>
+        <location filename="../../Train/RealtimeData.cpp" line="758"/>
         <source>Right Power Phase Peak Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="759"/>
+        <location filename="../../Train/RealtimeData.cpp" line="761"/>
         <source>Right Power Phase Peak End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="762"/>
+        <location filename="../../Train/RealtimeData.cpp" line="764"/>
         <source>Slope</source>
         <translation>坡度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="765"/>
+        <location filename="../../Train/RealtimeData.cpp" line="767"/>
         <source>Lap Distance</source>
         <translation>單圈距離</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="768"/>
+        <location filename="../../Train/RealtimeData.cpp" line="770"/>
         <source>Lap Distance Remaining</source>
         <translation>單圈剩餘距離</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="771"/>
+        <location filename="../../Train/RealtimeData.cpp" line="773"/>
         <source>Latitude</source>
         <translation>緯度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="774"/>
+        <location filename="../../Train/RealtimeData.cpp" line="776"/>
         <source>Longitude</source>
         <translation>經度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="777"/>
+        <location filename="../../Train/RealtimeData.cpp" line="779"/>
         <source>Altitude</source>
         <translation>標高</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="780"/>
+        <location filename="../../Train/RealtimeData.cpp" line="782"/>
         <source>Respiratory Frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="783"/>
+        <location filename="../../Train/RealtimeData.cpp" line="785"/>
         <source>Ventilation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="786"/>
+        <location filename="../../Train/RealtimeData.cpp" line="788"/>
         <source>VO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="789"/>
+        <location filename="../../Train/RealtimeData.cpp" line="791"/>
         <source>VCO2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="792"/>
+        <location filename="../../Train/RealtimeData.cpp" line="794"/>
         <source>Respiratory Exchange Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="795"/>
+        <location filename="../../Train/RealtimeData.cpp" line="797"/>
         <source>Tidal Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="798"/>
+        <location filename="../../Train/RealtimeData.cpp" line="800"/>
         <source>Fraction O2 Expired</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="801"/>
+        <location filename="../../Train/RealtimeData.cpp" line="803"/>
         <source>Temperature</source>
         <translation type="unfinished">溫度</translation>
     </message>
     <message>
-        <location filename="../../Train/RealtimeData.cpp" line="804"/>
+        <location filename="../../Train/RealtimeData.cpp" line="806"/>
         <source>CoreTemp</source>
         <translation type="unfinished"></translation>
     </message>
@@ -26971,22 +26944,22 @@ Python disabled in preferences.</source>
         <translation> + </translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Series</source>
         <translation>序列</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="162"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="164"/>
         <source>Value</source>
         <translation>値</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="172"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
         <source>Power</source>
         <translation>輸出功率</translation>
     </message>
     <message>
-        <location filename="../../Charts/ReferenceLineDialog.cpp" line="174"/>
+        <location filename="../../Charts/ReferenceLineDialog.cpp" line="176"/>
         <source>Heart Rate</source>
         <translation>心率</translation>
     </message>
@@ -29284,317 +29257,317 @@ native format. Should we do so?
 <context>
     <name>ScatterPlot</name>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="113"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
         <source>Power (watts)</source>
         <translation>輸出功率 (w)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="114"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
         <source>Cadence (rpm)</source>
         <translation>迴轉數 (rpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="115"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="116"/>
         <source>Heartrate (bpm)</source>
         <translation>心率 (bpm)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="118"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="119"/>
         <source>Speed (kph)</source>
         <translation>速度 (kph)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="120"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="121"/>
         <source>Speed (mph)</source>
         <translation>速度 (mph)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="124"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="125"/>
         <source>Altitude (meters)</source>
         <translation>標高 (m)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="126"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="127"/>
         <source>Altitude (feet)</source>
         <translation>標高 (ft)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="128"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
         <source>Torque (N)</source>
         <translation>扭距 (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="129"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="130"/>
         <source>Elapsed Time (secs)</source>
         <translation>累計經過時間 (s)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="132"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="133"/>
         <source>Elapsed Distance (km)</source>
         <translation>累計距離 (km)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="134"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="135"/>
         <source>Elapsed Distance (mi)</source>
         <translation>累計距離 (mi)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="136"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
         <source>Interval Number</source>
         <translation>區段數</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="137"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
         <source>Latitude (degree offset)</source>
         <translation>緯度(位移)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="138"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
         <source>Longitude (degree offset)</source>
         <translation>經度(位移)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="139"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
         <source>Circumferential Pedal Velocity (m/s)</source>
         <translation>圓週踏板速率 (m/s)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="140"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="141"/>
         <source>Average Effective Pedal Force (N)</source>
         <translation>平均有效踏板施力 (N)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="144"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
         <source>Time at X/Y (%)</source>
         <translation>時間為X/Y (%)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="145"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
         <source>Power Zone</source>
         <translation>功率區間</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="146"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
         <source>Headwind (kph)</source>
         <translation>逆風 (kph)</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="147"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
         <source>Slope (gradient)</source>
         <translation>坡度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="148"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
         <source>Temperature (C)</source>
         <translation>溫度 (ºC):</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="149"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
         <source>L/R Balance</source>
         <translation>左/右平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="150"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
         <source>Torque Efficiency</source>
         <translation>扭矩效率</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="151"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
         <source>Pedal Smoothness</source>
         <translation>踏板平滑度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="152"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
         <source>Running Vertical Oscillation</source>
         <translation>跑步垂直振幅</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="153"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
         <source>Running Ground Contact Time</source>
         <translation>跑步觸地時間</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="154"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
         <source>Running Cadence</source>
         <translation>跑動步頻</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="155"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
         <source>Gear Ratio</source>
         <translation>齒輪比</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="156"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
         <source>Muscle Oxygen</source>
         <translation>肌肉組織氧含量</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="157"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
         <source>Haemoglobin Mass</source>
         <translation>血紅素總量</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="158"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
         <source>Deoxygenated Haemoglobin</source>
         <translation>不帶氧血紅素</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="159"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="160"/>
         <source>Oxygenated Haemoglobin</source>
         <translation>帶氧血紅素</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="161"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="162"/>
         <source>Unknown</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="165"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
         <source>Power</source>
         <translation>輸出功率</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="166"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
         <source>Cadence</source>
         <translation>迴轉數</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="167"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
         <source>Heartrate</source>
         <translation>心率</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="168"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
         <source>Speed</source>
         <translation>速度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="169"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
         <source>Altitude</source>
         <translation>標高</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="170"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
         <source>Pedal Force</source>
         <translation>踏板施力</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="171"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
         <source>Time</source>
         <translation>時間</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="172"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
         <source>Distance</source>
         <translation>距離</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="173"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
         <source>Interval</source>
         <translation>區段</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="174"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
         <source>Latitude</source>
         <translation>緯度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="175"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
         <source>Longitude</source>
         <translation>經度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="176"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
         <source>Time at X/Y</source>
         <translation>時間為X/Y</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="177"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
         <source>Zone</source>
         <translation>區間</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="178"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
         <source>CPV</source>
         <translation>CPV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="179"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
         <source>AEPF</source>
         <translation>AEPF</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="180"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
         <source>Headwind</source>
         <translation>逆風</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="181"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
         <source>Slope</source>
         <translation>坡度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="182"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
         <source>Temp</source>
         <translation>溫度</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="183"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
         <source>Balance</source>
         <translation>平衡</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="184"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
         <source>TE</source>
         <translation>TE</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="185"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
         <source>PS</source>
         <translation>PS</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="186"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
         <source>RV</source>
         <translation>RV</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="187"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
         <source>GCT</source>
         <translation>GCT</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="188"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
         <source>Run Cad</source>
         <translation>跑動步頻</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="189"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
         <source>Gear</source>
         <translation>檔位</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="190"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
         <source>SmO2</source>
         <translation>SmO2</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="191"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
         <source>tHb</source>
         <translation>tHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="192"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
         <source>O2Hb</source>
         <translation>O2Hb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="193"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="194"/>
         <source>HHb</source>
         <translation>HHb</translation>
     </message>
     <message>
-        <location filename="../../Charts/ScatterPlot.cpp" line="195"/>
+        <location filename="../../Charts/ScatterPlot.cpp" line="196"/>
         <source>None</source>
         <translation>無</translation>
     </message>
@@ -29832,42 +29805,38 @@ native format. Should we do so?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1012"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1013"/>
         <source>Delete</source>
-        <translation>刪除</translation>
+        <translation type="vanished">刪除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1006"/>
         <source>+</source>
-        <translation>+</translation>
+        <translation type="vanished">+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1007"/>
         <source>-</source>
-        <translation>-</translation>
+        <translation type="vanished">-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1023"/>
+        <location filename="../../Gui/AthletePages.cpp" line="982"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="988"/>
         <source>Short</source>
         <translation>簡稱</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1030"/>
+        <location filename="../../Gui/AthletePages.cpp" line="989"/>
         <source>Long</source>
         <translation>全名</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1031"/>
+        <location filename="../../Gui/AthletePages.cpp" line="990"/>
         <source>Percent of CP</source>
         <translation>CP百分比</translation>
     </message>
@@ -29876,14 +29845,14 @@ native format. Should we do so?
         <translation type="vanished">僅允許設定10個區間。</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1069"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1076"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1027"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1034"/>
         <source>New</source>
         <translation>新建</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="1071"/>
-        <location filename="../../Gui/AthletePages.cpp" line="1078"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1029"/>
+        <location filename="../../Gui/AthletePages.cpp" line="1036"/>
         <source>New (%1)</source>
         <translation>新建 (%1)</translation>
     </message>
@@ -30056,64 +30025,64 @@ native format. Should we do so?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3821"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3569"/>
         <source>Add</source>
         <translation>新增</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3822"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3570"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3823"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3571"/>
         <source>Up</source>
         <translation>上</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3824"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3572"/>
         <source>Down</source>
         <translation>下</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3870"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3872"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3963"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3965"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3618"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3620"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3711"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3713"/>
         <source>ddd MMM d, yyyy</source>
         <translation>yyyy年M月d日ddd</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3809"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3557"/>
         <source>+</source>
         <translation>+</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3810"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3558"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3804"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3835"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3552"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3583"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3805"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3836"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3553"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3584"/>
         <source>Type</source>
         <translation>種類</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3806"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3837"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3554"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3585"/>
         <source>From</source>
         <translation>從</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="3807"/>
-        <location filename="../../Gui/AthletePages.cpp" line="3838"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3555"/>
+        <location filename="../../Gui/AthletePages.cpp" line="3586"/>
         <source>To</source>
         <translation>至</translation>
     </message>
@@ -32414,25 +32383,25 @@ tab.</source>
 <context>
     <name>TrainSidebar</name>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="253"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="257"/>
         <source>Save workout data</source>
         <translation>儲存訓練課表數據</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="259"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="263"/>
         <source>Devices</source>
         <translation>裝置</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="262"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="267"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="311"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="321"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="271"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="315"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="325"/>
         <source>Menu</source>
         <translation>選單</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="266"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="270"/>
         <source>Workouts</source>
         <translation>訓練課表</translation>
     </message>
@@ -32441,143 +32410,143 @@ tab.</source>
         <translation type="obsolete">過濾...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="303"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="307"/>
         <source>Workout Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="310"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="314"/>
         <source>Media</source>
         <translation>多媒體</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="320"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="324"/>
         <source>VideoSync</source>
         <translation>影片同步檔</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="506"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
         <source>Import Workout from File</source>
         <translation>匯入訓練課程</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="507"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="511"/>
         <source>Get Workouts from TrainerDay</source>
         <translation>從TrainerDay下載訓練課表</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="509"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="513"/>
         <source>Create Workout via Wizard</source>
         <translation>新增訓練課表精靈</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="510"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="514"/>
         <source>Scan for Workouts</source>
         <translation>搜尋訓練課表</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="534"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="538"/>
         <source>Delete selected Workout</source>
         <translation>刪除選中的課表</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="541"/>
         <source>Delete %1 selected Workouts</source>
         <translation>刪除選中的%1課表</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Train mode active</source>
         <translation>訓練模式啓用中</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="565"/>
         <source>Please stop the train mode before closing the window or application.</source>
         <translation>請於關閉程式前，先停止訓練模式。</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="635"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="639"/>
         <source>Remove reference to selected video</source>
         <translation>移除與影片之關聯</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="650"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="654"/>
         <source>Import VideoSync from File</source>
         <translation>從檔案匯入影片同步檔</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="651"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="655"/>
         <source>Scan for VideoSyncs</source>
         <translation>掃瞄影片同步檔</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="668"/>
         <source>Delete selected VideoSync</source>
         <translation>刪除選中的影片同步檔</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1064"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1068"/>
         <source>Are you sure you want to remove the reference to this video?</source>
         <translation>是否真的刪除此影片之關聯？</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1066"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1128"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1204"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1070"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1132"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1208"/>
         <source>Remove</source>
         <translation>移除</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1099"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1103"/>
         <source>Are you sure you want to delete this VideoSync?</source>
         <translation>是否真的刪除此影片同步檔？</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1126"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1130"/>
         <source>The VideoSync file is either not valid or not existing and will be removed from the library.</source>
         <translation>此影片關聯檔不可用或不存在，將從資料庫移除。</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1160"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1164"/>
         <source>Are you sure you want to delete this Workout?</source>
         <translation>是否真的刪除此訓練課表？</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1163"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1167"/>
         <source>Are you sure you want to delete this %1 workouts?</source>
         <translation>是否真的刪除訓練課表%1？</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1202"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1206"/>
         <source>The Workout file is either not valid or not existing and will be removed from the library.</source>
         <translation>此訓練課表檔不可用或不存在，將從資料庫移除。</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1347"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1351"/>
         <source>Starting in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2225"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2237"/>
         <source>Recalibrating steering..</source>
         <translation>重新較正移軸..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2521"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2525"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2594"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2645"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2649"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2533"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2537"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2606"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2657"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2661"/>
         <source>Requesting calibration..</source>
         <translation>請求進行校正..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2532"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2544"/>
         <source>Calibrating...</source>
         <translation>校正中...</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2536"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2548"/>
         <source>Calibrating...
 Current speed %1 kph
 Increase speed to %2 kph</source>
@@ -32586,14 +32555,14 @@ Increase speed to %2 kph</source>
 請加速至%2kph</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2540"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2552"/>
         <source>Calibrating...
 Stop pedalling until speed drops to 0</source>
         <translation>校正中...
 停止踩踏直至速度歸零</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2545"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2557"/>
         <source>Calibration completed successfully!
 Spindown %1 ms
 Zero Offset %2</source>
@@ -32602,30 +32571,30 @@ Zero Offset %2</source>
 零值偏移%2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2553"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2620"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2672"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2565"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2632"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2684"/>
         <source>Calibration failed!</source>
         <translation>校正失敗!</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2561"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2573"/>
         <source>Calibration Failed: Loosen Roller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2569"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2581"/>
         <source>Calibration Failed: Tighten Roller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2588"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="2639"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2600"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2651"/>
         <source>Unclip or stop pedalling to begin calibration..</source>
         <translation>脫卡扣或停止踩踏，以開始進行校正..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2607"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2619"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Torque %1</source>
@@ -32634,7 +32603,7 @@ Torque %1</source>
 扭矩值%1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2612"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2624"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Torque %2</source>
@@ -32643,7 +32612,7 @@ Torque %2</source>
 扭矩%2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2659"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2671"/>
         <source>Calibrating...
 Unclip or stop pedalling until process is completed..
 Zero Offset %1</source>
@@ -32652,7 +32621,7 @@ Zero Offset %1</source>
 零值偏移%1</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2664"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2676"/>
         <source>Calibration completed successfully!
 Zero Offset %1
 Slope %2</source>
@@ -32661,169 +32630,169 @@ Slope %2</source>
 斜率%2</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2693"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2705"/>
         <source>Give the pedal a kick to start calibration...
 The motor will run until calibration is complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2695"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
         <source>Allow wheel speed to settle, DO NOT PEDAL...
 The motor will run until calibration is complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2700"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2712"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Gathering enough samples to calculate average: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2707"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2719"/>
         <source>Calibrating... DO NOT PEDAL, remain seated...
 Waiting for value to stabilize (max %1s): %2 (%3W @ %4kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2722"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
         <source>Calibration completed successfully!
 Final calibration value %1 (%2W @ %3kph)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2734"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2746"/>
         <source>Calibration failed! Do not pedal while calibration is taking place.
 Allow wheel to run freely.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2780"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2792"/>
         <source>Fast forward..</source>
         <translation>快進..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2813"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2825"/>
         <source>Rewind..</source>
         <translation>後退..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2843"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2855"/>
         <source>Next Lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2876"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2888"/>
         <source>Back Lap..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2902"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2914"/>
         <source>Increasing intensity..</source>
         <translation>強度增加中..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2928"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2940"/>
         <source>Decreasing intensity..</source>
         <translation>強度降低中..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="621"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="625"/>
         <source>Import Video from File</source>
         <translation>從檔案匯入影片</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="508"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="512"/>
         <source>Get Workouts from Strava Routes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="622"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="626"/>
         <source>Scan for Videos</source>
         <translation>掃描影片</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1101"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="1173"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3183"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1105"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1177"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3195"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1309"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1313"/>
         <source>Resuming..</source>
         <translation>回復中..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1336"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1340"/>
         <source>Paused..</source>
         <translation>暫停..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1465"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1469"/>
         <source>Starting..</source>
         <translation>啓動中..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1673"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1677"/>
         <source>Stopped..</source>
         <translation>已停止..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1763"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1769"/>
         <source>Connected..</source>
         <translation>已連線..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="1787"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="1793"/>
         <source>Disconnected..</source>
         <translation>已斷線..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2198"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2210"/>
         <source>New lap..</source>
         <translation>進入下一圈..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>No Devices Configured</source>
         <translation>未設定裝置</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2232"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2244"/>
         <source>Please configure a device in Preferences.</source>
         <translation>請先設定裝置。</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2483"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2495"/>
         <source>Exiting calibration..</source>
         <translation>離開校正..</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2498"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2510"/>
         <source>Calibration not supported for this device.</source>
         <translation>此裝置未支援校正功能。</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="2505"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="2517"/>
         <source>Calibrating...
 Press F3 on Controller when done.</source>
         <translation>校正中...
 完成後按控制器之F3鍵。</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3135"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3153"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3147"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3165"/>
         <source>Add Device</source>
         <translation>新增裝置</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3140"/>
-        <location filename="../../Train/TrainSidebar.cpp" line="3158"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3152"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3170"/>
         <source>Delete Device</source>
         <translation>刪除裝置</translation>
     </message>
     <message>
-        <location filename="../../Train/TrainSidebar.cpp" line="3181"/>
+        <location filename="../../Train/TrainSidebar.cpp" line="3193"/>
         <source>Are you sure you want to delete this device?</source>
         <translation>是否真的刪除此裝置？</translation>
     </message>
@@ -33140,7 +33109,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>UniqueLabelEditDelegate</name>
     <message>
-        <location filename="../../Gui/StyledItemDelegates.cpp" line="77"/>
+        <location filename="../../Gui/StyledItemDelegates.cpp" line="108"/>
         <source>The given value &quot;%1&quot; is not unique</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33156,171 +33125,167 @@ Press F3 on Controller when done.</source>
 <context>
     <name>UserChartSettings</name>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="772"/>
+        <location filename="../../Charts/UserChart.cpp" line="773"/>
         <source>Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="782"/>
+        <location filename="../../Charts/UserChart.cpp" line="783"/>
         <source>Sub-title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="785"/>
+        <location filename="../../Charts/UserChart.cpp" line="786"/>
         <source>Description</source>
         <translation type="unfinished">説明</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="791"/>
+        <location filename="../../Charts/UserChart.cpp" line="792"/>
         <source>Line Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="792"/>
+        <location filename="../../Charts/UserChart.cpp" line="793"/>
         <source>Scatter Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="793"/>
+        <location filename="../../Charts/UserChart.cpp" line="794"/>
         <source>Bar Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="794"/>
+        <location filename="../../Charts/UserChart.cpp" line="795"/>
         <source>Stacked Bar Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="795"/>
+        <location filename="../../Charts/UserChart.cpp" line="796"/>
         <source>Stacked Percent Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="796"/>
+        <location filename="../../Charts/UserChart.cpp" line="797"/>
         <source>Pie Chart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="800"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="801"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Type</source>
         <translation type="unfinished">種類</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="804"/>
+        <location filename="../../Charts/UserChart.cpp" line="805"/>
         <source>Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="805"/>
+        <location filename="../../Charts/UserChart.cpp" line="806"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="808"/>
+        <location filename="../../Charts/UserChart.cpp" line="809"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="812"/>
+        <location filename="../../Charts/UserChart.cpp" line="813"/>
         <source>None</source>
         <translation type="unfinished">無</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="813"/>
+        <location filename="../../Charts/UserChart.cpp" line="814"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="814"/>
+        <location filename="../../Charts/UserChart.cpp" line="815"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="815"/>
+        <location filename="../../Charts/UserChart.cpp" line="816"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="816"/>
+        <location filename="../../Charts/UserChart.cpp" line="817"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="820"/>
+        <location filename="../../Charts/UserChart.cpp" line="821"/>
         <source>Legend</source>
         <translation type="unfinished">圖例</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="829"/>
+        <location filename="../../Charts/UserChart.cpp" line="830"/>
         <source>Font scaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="831"/>
-        <location filename="../../Charts/UserChart.cpp" line="833"/>
+        <location filename="../../Charts/UserChart.cpp" line="832"/>
+        <location filename="../../Charts/UserChart.cpp" line="834"/>
         <source>Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="836"/>
+        <location filename="../../Charts/UserChart.cpp" line="837"/>
         <source>Animate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="838"/>
+        <location filename="../../Charts/UserChart.cpp" line="839"/>
         <source>Single series per plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="841"/>
+        <location filename="../../Charts/UserChart.cpp" line="842"/>
         <source>Refresh for intervals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="848"/>
+        <location filename="../../Charts/UserChart.cpp" line="849"/>
         <source>Series</source>
         <translation type="unfinished">序列</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="926"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
-        <location filename="../../Charts/UserChart.cpp" line="1357"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="900"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
+        <location filename="../../Charts/UserChart.cpp" line="1315"/>
         <source>Name</source>
         <translation type="unfinished">名稱</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="864"/>
-        <location filename="../../Charts/UserChart.cpp" line="1199"/>
+        <location filename="../../Charts/UserChart.cpp" line="865"/>
+        <location filename="../../Charts/UserChart.cpp" line="1157"/>
         <source>Y Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="870"/>
-        <location filename="../../Charts/UserChart.cpp" line="932"/>
         <source>Edit</source>
-        <translation type="unfinished">編輯</translation>
+        <translation type="obsolete">編輯</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="889"/>
         <source>Up</source>
-        <translation type="unfinished">上</translation>
+        <translation type="obsolete">上</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="890"/>
         <source>Down</source>
-        <translation type="unfinished">下</translation>
+        <translation type="obsolete">下</translation>
     </message>
     <message>
-        <location filename="../../Charts/UserChart.cpp" line="911"/>
+        <location filename="../../Charts/UserChart.cpp" line="885"/>
         <source>Axes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -33986,72 +33951,72 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VideoWindow</name>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> kph</source>
         <translation> kph</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="119"/>
+        <location filename="../../Train/VideoWindow.cpp" line="144"/>
         <source>Meters layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="127"/>
+        <location filename="../../Train/VideoWindow.cpp" line="152"/>
         <source>Reset Meters layout to default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="533"/>
+        <location filename="../../Train/VideoWindow.cpp" line="589"/>
         <source> mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> m</source>
         <translation type="unfinished"> m</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="612"/>
+        <location filename="../../Train/VideoWindow.cpp" line="668"/>
         <source> feet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="625"/>
+        <location filename="../../Train/VideoWindow.cpp" line="681"/>
         <source>w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="629"/>
+        <location filename="../../Train/VideoWindow.cpp" line="685"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> km</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="636"/>
+        <location filename="../../Train/VideoWindow.cpp" line="692"/>
         <source> mi</source>
         <translation type="unfinished"> mi</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="673"/>
+        <location filename="../../Train/VideoWindow.cpp" line="729"/>
         <source>Calibration required</source>
         <translation>需要校正</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="678"/>
+        <location filename="../../Train/VideoWindow.cpp" line="734"/>
         <source>Configuration required</source>
         <translation>需要設定</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="683"/>
+        <location filename="../../Train/VideoWindow.cpp" line="739"/>
         <source>brake fault</source>
         <translation>煞車異常</translation>
     </message>
     <message>
-        <location filename="../../Train/VideoWindow.cpp" line="688"/>
+        <location filename="../../Train/VideoWindow.cpp" line="744"/>
         <source>Ready</source>
         <translation>準備完成</translation>
     </message>
@@ -34486,27 +34451,27 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WheelSizeCalculator</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="202"/>
+        <location filename="../../Gui/AthletePages.cpp" line="187"/>
         <source>Wheel Size Calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="221"/>
+        <location filename="../../Gui/AthletePages.cpp" line="206"/>
         <source>Rim Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="222"/>
+        <location filename="../../Gui/AthletePages.cpp" line="207"/>
         <source>Tire Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="223"/>
+        <location filename="../../Gui/AthletePages.cpp" line="208"/>
         <source>Wheel Size</source>
         <translation type="unfinished">輪徑</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="242"/>
+        <location filename="../../Gui/AthletePages.cpp" line="227"/>
         <source>mm</source>
         <translation type="unfinished">mm</translation>
     </message>
@@ -34618,12 +34583,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutFilterBox</name>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="34"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="44"/>
         <source>Filter...</source>
         <translation type="unfinished">過濾...</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutFilterBox.cpp" line="64"/>
+        <location filename="../../Train/WorkoutFilterBox.cpp" line="95"/>
         <source>ERROR: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34631,12 +34596,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutImportDialog</name>
     <message>
-        <location filename="../../Train/Library.cpp" line="820"/>
+        <location filename="../../Train/Library.cpp" line="809"/>
         <source>Import to Library</source>
         <translation>匯入至資料庫</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="854"/>
+        <location filename="../../Train/Library.cpp" line="843"/>
         <source>Please note, that when importing or drag and dropping videos into the library we DO NOT copy the file into the GoldenCheetah library, instead we add a REFERENCE to it. We DO copy workout and videoSync files, since they are smaller.
 
 You can remove references when managing the library via the context menu options</source>
@@ -34645,24 +34610,107 @@ You can remove references when managing the library via the context menu options
 在管理訓練課表庫時，可通過菜單選項移除此引用</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="868"/>
+        <location filename="../../Train/Library.cpp" line="857"/>
         <source>Files</source>
         <translation>檔案</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="878"/>
+        <location filename="../../Train/Library.cpp" line="867"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="880"/>
+        <location filename="../../Train/Library.cpp" line="869"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../Train/Library.cpp" line="884"/>
+        <location filename="../../Train/Library.cpp" line="873"/>
         <source>Overwite existing files</source>
         <translation>覆寫現有檔案</translation>
+    </message>
+</context>
+<context>
+    <name>WorkoutMenuProvider</name>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="271"/>
+        <source>Select Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="274"/>
+        <source>Manage Filters</source>
+        <translation type="unfinished">過濾器管理</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="275"/>
+        <source>Add Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="289"/>
+        <source>Add Tag to Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="292"/>
+        <source>Filter Tags...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="310"/>
+        <source>Match all selected tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="353"/>
+        <source>Manage Workout Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="360"/>
+        <source>Name</source>
+        <translation type="unfinished">名稱</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="361"/>
+        <source>Filter</source>
+        <translation type="unfinished">過濾器</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="362"/>
+        <source>_index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="370"/>
+        <source>Execute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="371"/>
+        <source>Update</source>
+        <translation type="unfinished">更新</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="423"/>
+        <source>Add Workout Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="426"/>
+        <source>Name of the Filter...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="467"/>
+        <source>New</source>
+        <translation type="unfinished">新建</translation>
+    </message>
+    <message>
+        <location filename="../../Train/WorkoutMenuProvider.cpp" line="469"/>
+        <source>New (%1)</source>
+        <translation type="unfinished">新建 (%1)</translation>
     </message>
 </context>
 <context>
@@ -34677,41 +34725,41 @@ You can remove references when managing the library via the context menu options
     <name>WorkoutPlotWindow</name>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="40"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="104"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
         <source>Ergmode specific settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="46"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="105"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
         <source>Color power zones</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="48"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="56"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="106"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="49"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="107"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="50"/>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="57"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="108"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="112"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="109"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="113"/>
         <source>When stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Train/WorkoutPlotWindow.cpp" line="54"/>
-        <location filename="../../Train/WorkoutPlotWindow.cpp" line="110"/>
+        <location filename="../../Train/WorkoutPlotWindow.cpp" line="111"/>
         <source>Show tooltip</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34801,12 +34849,12 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>WorkoutWidget</name>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="1531"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="1532"/>
         <source>File save failed.</source>
         <translation>存檔失敗。</translation>
     </message>
     <message>
-        <location filename="../../Train/WorkoutWidget.cpp" line="2367"/>
+        <location filename="../../Train/WorkoutWidget.cpp" line="2368"/>
         <source>Intensity</source>
         <translation>強度</translation>
     </message>
@@ -34960,26 +35008,22 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="44"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="45"/>
         <source>xData</source>
         <translation>XData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="58"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="59"/>
         <source>Data Series</source>
         <translation>資料序列</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="78"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="80"/>
         <source>Add</source>
-        <translation>新增</translation>
+        <translation type="vanished">新增</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="79"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="81"/>
         <source>Delete</source>
-        <translation>刪除</translation>
+        <translation type="vanished">刪除</translation>
     </message>
 </context>
 <context>
@@ -35056,32 +35100,32 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataSeriesSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="333"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="315"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="338"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="320"/>
         <source>Units</source>
         <translation>單位</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="346"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="328"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="347"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="329"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Error</source>
         <translation>錯誤</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="362"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="344"/>
         <source>Name is blank</source>
         <translation>未輸入名稱</translation>
     </message>
@@ -35089,48 +35133,48 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>XDataSettingsDialog</name>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="262"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="244"/>
         <source>xData</source>
         <translation>XData</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="269"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="251"/>
         <source>Data Series</source>
         <translation>資料序列</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="270"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="252"/>
         <source>Units</source>
         <translation>單位</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="274"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="256"/>
         <source>Series %1</source>
         <translation>序列 %1</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="281"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="263"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="282"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="264"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Error</source>
         <translation>錯誤</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="297"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="279"/>
         <source>XData name is blank</source>
         <translation>未輸入XData名稱</translation>
     </message>
     <message>
-        <location filename="../../FileIO/XDataDialog.cpp" line="313"/>
+        <location filename="../../FileIO/XDataDialog.cpp" line="295"/>
         <source>Must have at least one data series.</source>
         <translation>必須定義至少一個資料序列。</translation>
     </message>
@@ -35451,17 +35495,17 @@ You can remove references when managing the library via the context menu options
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="915"/>
+        <location filename="../../Gui/AthletePages.cpp" line="886"/>
         <source>Sport</source>
         <translation>運動種類</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="962"/>
+        <location filename="../../Gui/AthletePages.cpp" line="933"/>
         <source>Critical Power</source>
         <translation>臨界功率</translation>
     </message>
     <message>
-        <location filename="../../Gui/AthletePages.cpp" line="963"/>
+        <location filename="../../Gui/AthletePages.cpp" line="934"/>
         <source>Default</source>
         <translation>預設</translation>
     </message>

--- a/src/Train/LiveMapWebPageWindow.cpp
+++ b/src/Train/LiveMapWebPageWindow.cpp
@@ -231,6 +231,9 @@ void LiveMapWebPageWindow::configChanged(qint32)
 // Update position on the map when telemetry changes.
 void LiveMapWebPageWindow::telemetryUpdate(RealtimeData rtd)
 {
+    if (!isVisible())
+        return;
+
     QString code = "";
     geolocation geoloc(rtd.getLatitude(), rtd.getLongitude(), rtd.getAltitude());
     if (geoloc.IsReasonableGeoLocation()) {

--- a/src/Train/MeterWidget.cpp
+++ b/src/Train/MeterWidget.cpp
@@ -808,6 +808,10 @@ void ElevationZoomedMeterWidget::updateRidePointsQ(int tDist) {
 
 void ElevationZoomedMeterWidget::scalePointsToPlot() {
 
+    // In the weird situation where a video is selected but workout is not GPS based
+    if (plotQ.empty())
+        return;
+
     double pixelX = -1;
     double pixelY = -1;
     m_zoomedElevationPolygon.clear();

--- a/src/Train/RealtimePlotWindow.cpp
+++ b/src/Train/RealtimePlotWindow.cpp
@@ -259,7 +259,8 @@ RealtimePlotWindow::telemetryUpdate(RealtimeData rtData)
         rtPlot->o2hbData->addData(rtData.value(RealtimeData::O2Hb));
         rtPlot->hhbData->addData(rtData.value(RealtimeData::HHb));
     }
-    rtPlot->replot();                // redraw
+    if (isVisible())
+        rtPlot->replot();                // redraw
 }
 
 void

--- a/src/Train/SpinScanPlotWindow.cpp
+++ b/src/Train/SpinScanPlotWindow.cpp
@@ -149,6 +149,8 @@ SpinScanPlotWindow::telemetryUpdate(RealtimeData rtData)
     memcpy(history[current++], rtData.spinScan, 24);
     if (current==16) current=0;
 
-    plPlot->replot();                // redraw
-    rtPlot->replot();                // redraw
+    if (isVisible()) {
+        plPlot->replot();                // redraw
+        rtPlot->replot();                // redraw
+    }
 }

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -303,7 +303,8 @@ void VideoWindow::showMeters()
         p_meterWidget->AdjustSizePos();
         p_meterWidget->update();
         p_meterWidget->raise();
-        p_meterWidget->show();
+        if (isVisible())
+            p_meterWidget->show();
         p_meterWidget->startPlayback(context);
     }
     prevPosition = mapToGlobal(pos());
@@ -318,6 +319,24 @@ void VideoWindow::resizeEvent(QResizeEvent * )
     foreach(MeterWidget* p_meterWidget , m_metersWidget)
         p_meterWidget->AdjustSizePos();
     prevPosition = mapToGlobal(pos());
+}
+
+void VideoWindow::showEvent(QShowEvent *event)
+{
+    GcChartWindow::showEvent(event);
+    if (init  && (state == PlaybackState::Playing || state == PlaybackState::Paused)) {
+        foreach(MeterWidget* p_meterWidget , m_metersWidget)
+            p_meterWidget->show();
+    }
+}
+
+void VideoWindow::hideEvent(QHideEvent *event)
+{
+    GcChartWindow::hideEvent(event);
+    if (init) {
+        foreach(MeterWidget* p_meterWidget , m_metersWidget)
+            p_meterWidget->hide();
+    }
 }
 
 VideoSyncFilePoint VideoWindow::VideoSyncPointAdjust(const VideoSyncFilePoint& vsfp) const
@@ -546,6 +565,9 @@ void VideoWindow::resumePlayback()
 
 void VideoWindow::telemetryUpdate(RealtimeData rtd)
 {
+    if (!isVisible())
+        return;
+
     Lock lock(stateLock);
     if (!hasActiveVideo())
         return;

--- a/src/Train/VideoWindow.h
+++ b/src/Train/VideoWindow.h
@@ -270,6 +270,9 @@ class VideoWindow : public GcChartWindow
 
     protected:
 
+        void showEvent(QShowEvent *event) override;
+        void hideEvent(QHideEvent *event) override;
+
         void resizeEvent(QResizeEvent *);
 
         // media data

--- a/src/Train/WebPageWindow.cpp
+++ b/src/Train/WebPageWindow.cpp
@@ -171,6 +171,8 @@ WebPageWindow::WebPageWindow(Context *context) : GcChartWindow(context), context
     connect(view->page()->profile(), SIGNAL(downloadRequested(QWebEngineDownloadRequest*)), this, SLOT(downloadRequested(QWebEngineDownloadRequest*)));
 #endif
     connect(view->page(), SIGNAL(linkHovered(QString)), this, SLOT(linkHovered(QString)));
+
+    forceReplot();
 }
 
 WebPageWindow::~WebPageWindow()

--- a/src/Train/WorkoutPlotWindow.cpp
+++ b/src/Train/WorkoutPlotWindow.cpp
@@ -93,7 +93,8 @@ WorkoutPlotWindow::ergFileSelected(ErgFile *f)
 void
 WorkoutPlotWindow::setNow(long now)
 {
-    ergPlot->setNow(now);
+    if (isVisible())
+        ergPlot->setNow(now);
 }
 
 void

--- a/src/Train/WorkoutWidget.cpp
+++ b/src/Train/WorkoutWidget.cpp
@@ -188,7 +188,8 @@ WorkoutWidget::stop()
 void
 WorkoutWidget::setNow(long x)
 {
-    ensureVisible(x/1000);
+    if (isVisible())
+        ensureVisible(x/1000);
 }
 
 void


### PR DESCRIPTION
When importing a GPX file, prefer embedded speed data (if present) over GPS coordinates for calculating speed and distance.

The GPX file format supports providing the measured speed at each trackpoint as a TrackPointExtension. Some programs use this to report readings from dedicated speed sensors.

If no speed data is embedded or if data is missing from any trackpoints, Golden Cheetah calculates speed from the GPS coordinates. When using GPS, weak signal or low-quality receivers can result in irregular speed measurements due to location jitter, whereas dedicated speed sensors should be consistent in any environment.

Distance is additionally calculated from speed and time if available, falling back to GPS otherwise.